### PR TITLE
ci: PR check workflow, CODEOWNERS, and issue/PR templates

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @brandonburrus

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,51 @@
+name: Bug report
+description: Report something in vplan that is broken or behaves unexpectedly
+labels: ["bug"]
+body:
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened
+      description: What did you do, and what went wrong?
+      placeholder: I ran `vplan plan.mdx` and ...
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: What you expected
+      description: What should have happened instead?
+    validations:
+      required: true
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+      description: The exact command(s), and a minimal plan (.mdx) if relevant.
+      placeholder: |
+        1. `vplan check example.mdx`
+        2. ...
+      render: shell
+    validations:
+      required: true
+  - type: input
+    id: vplan-version
+    attributes:
+      label: vplan version
+      description: Output of `vplan --version` (shown in the page footer too).
+    validations:
+      required: true
+  - type: input
+    id: node-version
+    attributes:
+      label: Node version
+      description: Output of `node --version`. vplan requires Node >= 20.
+    validations:
+      required: true
+  - type: input
+    id: os
+    attributes:
+      label: OS
+      placeholder: macOS 15.3, Ubuntu 24.04, Windows 11, ...
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,6 @@
+# Require issues to use one of the forms above; send open-ended questions to Discussions.
+blank_issues_enabled: false
+contact_links:
+  - name: Question or discussion
+    url: https://github.com/brandonburrus/visualplan/discussions
+    about: Ask a question or discuss an idea before filing an issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,25 @@
+name: Feature request
+description: Suggest a capability or improvement for vplan
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What are you trying to do that vplan does not let you do today?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: What would you like vplan to do? Be concrete.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Other approaches you weighed, and why they fall short.
+    validations:
+      required: false

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,21 @@
+## What
+
+<!-- What does this PR change, and why? One or two sentences. -->
+
+## How
+
+<!-- Notable implementation details or decisions a reviewer should know. -->
+
+## Verification
+
+<!-- How you confirmed this works. Paste the commands you ran and what you observed. -->
+
+- [ ] `pnpm lint` passes
+- [ ] `pnpm format` reports no changes (`biome format .`)
+- [ ] `pnpm typecheck` passes
+- [ ] `pnpm build` succeeds
+- [ ] `pnpm test` passes
+
+## Notes
+
+<!-- Breaking changes, follow-ups, screenshots, or anything else. Delete if empty. -->

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -23,15 +23,15 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         # Full history + tags so build-info can resolve the released version from `git describe`
         # on a branch deploy (workflow_dispatch); a release build reads it from GITHUB_REF_NAME.
         with:
           fetch-depth: 0
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
 
@@ -44,9 +44,9 @@ jobs:
       - name: Build the docs site
         run: pnpm --filter @visualplan/app build
 
-      - uses: actions/configure-pages@v5
+      - uses: actions/configure-pages@v6
 
-      - uses: actions/upload-pages-artifact@v3
+      - uses: actions/upload-pages-artifact@v5
         with:
           path: packages/app/dist
 
@@ -58,4 +58,4 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -1,0 +1,46 @@
+name: PR Check
+
+# Run lint, format, typecheck, build, and tests on every PR into main. The steps
+# share a single checkout + install and run in order; a failing step stops the rest.
+on:
+  pull_request:
+    branches: [main]
+
+# Cancel an in-flight run when a new commit is pushed to the same PR or branch.
+concurrency:
+  group: pr-check-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: pnpm/action-setup@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      # biome lint/format without --write: report problems, never mutate the tree.
+      - name: Lint
+        run: pnpm exec biome lint .
+
+      - name: Format
+        run: pnpm exec biome format .
+
+      - name: Typecheck
+        run: pnpm typecheck
+
+      - name: Build
+        run: pnpm build
+
+      - name: Test
+        run: pnpm test

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,11 +16,11 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
           registry-url: https://registry.npmjs.org


### PR DESCRIPTION
## What

Adds repo governance + CI:

- **`.github/workflows/pr-check.yml`** runs lint, format, typecheck, build, and tests on every PR into `main` (single job, ordered steps, one install).
- **`CODEOWNERS`** (`* @brandonburrus`).
- **PR template** and **bug/feature issue forms** (`config.yml` disables blank issues, links Discussions).
- Bumps existing workflows (`docs.yml`, `publish.yml`) to the latest action majors.

## How

- Lint/format use `biome lint .` / `biome format .` without `--write` so CI verifies rather than mutates. Verified `biome format` exits non-zero on an unformatted file.
- Actions pinned to current majors: checkout v7, pnpm/action-setup v6, setup-node v6, and Pages actions configure v6 / upload-pages-artifact v5 / deploy-pages v5.

## Verification

Ran the pr-check commands locally on this branch, all pass:

- `pnpm exec biome lint .`
- `pnpm exec biome format .`
- `pnpm typecheck`
- `pnpm build`
- `pnpm test`

This PR exists to confirm the workflow runs green in CI.