### PR TITLE
fix: render the README banner on npm + point homepage at visualplan.dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="assets/banner.jpg" alt="Visual Plan: render an AI agent's plans as scannable visual pages instead of walls of text" width="100%">
+  <img src="https://raw.githubusercontent.com/brandonburrus/visualplan/main/assets/banner.jpg" alt="Visual Plan: render an AI agent's plans as scannable visual pages instead of walls of text" width="100%">
 </p>
 
 Turn an AI agent's implementation and design plans into polished, visual web pages instead of

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -23,7 +23,7 @@
     "url": "git+https://github.com/brandonburrus/visualplan.git",
     "directory": "packages/cli"
   },
-  "homepage": "https://github.com/brandonburrus/visualplan#readme",
+  "homepage": "https://visualplan.dev",
   "bugs": "https://github.com/brandonburrus/visualplan/issues",
   "type": "module",
   "engines": {


### PR DESCRIPTION
## Why

On the npm page for `vplan` the banner image doesn't render. Root cause: the published README is the **root `README.md`**, vendored into `packages/cli` at `prepack` by `scripts/vendor.mjs`. Its banner used a **relative** `src="assets/banner.jpg"`, which npm can't resolve (and the image isn't in the tarball). Confirmed against the live package with `npm view vplan readme`.

## Changes

- **`README.md`**: banner `src` -> `https://raw.githubusercontent.com/brandonburrus/visualplan/main/assets/banner.jpg` (absolute). Renders on both npm and GitHub. Verified the URL returns `200 image/jpeg` (297966 bytes, matches `assets/banner.jpg`).
- **`packages/cli/package.json`**: `homepage` -> `https://visualplan.dev` (the docs site is the canonical home now). `repository` and `bugs` stay on GitHub.

## Note

The npm README is baked at publish time, so npm won't show the fixed banner until the next release. This PR only changes the README/metadata; cut a patch release after merge to update the npm page.