### PR TITLE
feat: add six chart types, stacked bars, and a Stat component

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -88,6 +88,10 @@ A release is cut by creating a GitHub release; the tag is the published version 
   runs `tsc` in every package. `pnpm test` runs one vitest config with a project per package.
   `pnpm check` runs biome. `pnpm build` builds the CLI.
 - No emojis or em/en dashes in code, output, or docs.
+- When a change adds or alters the component vocabulary (a new component, a chart type, or an
+  authoring syntax), update `skills/visual-plan/SKILL.md` to match: it is the agent-facing source
+  of truth for how a plan is written. Do this only when the change genuinely adds author-facing
+  substance; skip purely internal refactors that do not change how a plan is authored.
 
 ## Critical Constraints
 

--- a/packages/app/src/pages/docs/authoring.mdx
+++ b/packages/app/src/pages/docs/authoring.mdx
@@ -11,6 +11,7 @@ import { FileTree } from '@visualplan/runtime/components/FileTree'
 import { Chart } from '@visualplan/runtime/components/Chart'
 import { Compare } from '@visualplan/runtime/components/Compare'
 import { Matrix } from '@visualplan/runtime/components/Matrix'
+import { Stat } from '@visualplan/runtime/components/Stat'
 import { Questions } from '@visualplan/runtime/components/Questions'
 import { Checklist } from '@visualplan/runtime/components/Checklist'
 import { Mermaid } from '@visualplan/runtime/components/Mermaid'
@@ -90,7 +91,8 @@ single line.
 ## Charts: the numbers
 
 When a plan involves quantities, effort, latency, traffic, rows, a small chart shows the shape of
-the data better than a list of figures. Plans render real bar, line, and pie charts.
+the data better than a list of figures. Plans render nine chart types, bar, line, area, scatter,
+radar, gauge, funnel, treemap, and pie, with multi-series bar and area able to stack.
 
 <Demo>
   <Chart client:only="react" type="bar" title="Effort (days)" data={{ series: ['value'], data: [{ label: 'Limiter', values: [2] }, { label: 'Dashboards', values: [1] }, { label: 'Tests', values: [1.5] }] }} />
@@ -102,6 +104,23 @@ the data better than a list of figures. Plans render real bar, line, and pie cha
 
 <Demo>
   <Chart client:only="react" type="pie" title="Traffic by client" data={{ series: ['value'], data: [{ label: 'Web', values: [62] }, { label: 'Mobile', values: [28] }, { label: 'API', values: [10] }] }} />
+</Demo>
+
+<Demo>
+  <Chart client:only="react" type="gauge" title="Error budget remaining (%)" data={{ series: ['value'], data: [{ label: 'Remaining', values: [78] }] }} />
+</Demo>
+
+## Headline metrics
+
+When the most important facts are a handful of numbers, files changed, expected uptime, the rollout
+plan, a stat grid puts them up front as cards, each optionally colored by how good or risky it is.
+
+<Demo>
+  <Stat items={[
+    { label: 'Files changed', value: '4' },
+    { label: 'Added latency', value: '~1 ms', intent: 'good' },
+    { label: 'Rollout', value: '1% to 100%', intent: 'warn', caption: 'ramp while watching reject rates' },
+  ]} />
 </Demo>
 
 ## Comparing options

--- a/packages/cli/templates/example.mdx
+++ b/packages/cli/templates/example.mdx
@@ -9,6 +9,12 @@ the edge, observable, and safe to roll out behind a flag.
   starve the fleet by spreading requests across endpoints.
 </Callout>
 
+<Stat>
+- Files changed: 4
+- Added latency: ~1 ms (good)
+- Rollout: 1% to 100% (warn) -- ramp while watching reject rates
+</Stat>
+
 ## Architecture
 
 ```mermaid
@@ -86,12 +92,16 @@ flowchart LR
   - Dashboards: 1
   </Chart>
 
-  <Chart type='bar' title='Requests/s by ramp step'>
+  <Chart type='area' title='Requests/s by ramp step' stacked>
   | Step | Allowed | Rejected |
   |------|---------|----------|
   | 1%   | 50      | 2        |
   | 10%  | 480     | 15       |
   | 100% | 4800    | 120      |
+  </Chart>
+
+  <Chart type='gauge' title='Error budget remaining (%)'>
+  - Remaining: 78
   </Chart>
 </Phase>
 

--- a/packages/compile/AGENTS.md
+++ b/packages/compile/AGENTS.md
@@ -38,7 +38,11 @@ through the workspace.
   BEFORE the rehype highlighter.
 - `src/plan-blocks.ts` — `parseBlockChildren`: markdown children of the data components ->
   structured props + positioned `issues`. Shared by `remark-plan-blocks.ts` (render, uses `value`)
-  and the CLI's `check.ts` (uses `issues`), so render and check agree.
+  and the CLI's `check.ts` (uses `issues`), so render and check agree. `parseStat` parses the `Stat`
+  block (one `- label: value (intent) -- caption` per item; caption splits on `' -- '`, the trailing
+  `(intent)` is validated against `STAT_INTENT_VALUES`). `parseChart` adds shape guards:
+  `SINGLE_SERIES_CHARTS` (`pie`, `gauge`, `funnel`, `treemap`) reject a multi-series table, and
+  `scatter` requires a table with exactly two value columns (the list form is rejected).
 - `src/remark-plan-blocks.ts` / `remark-mermaid.ts` / `remark-math.ts` — the three custom remark
   plugins. `remark-math` converts LaTeX to MathML with `temml` at build time (isomorphic).
 - `src/expressive-code.ts` — `baseExpressiveCodeOptions` (themes, frames, ink styling, color

--- a/packages/compile/src/plan-blocks.ts
+++ b/packages/compile/src/plan-blocks.ts
@@ -1,4 +1,4 @@
-import { CHANGE_VALUES } from '@visualplan/core'
+import { CHANGE_VALUES, STAT_INTENT_VALUES } from '@visualplan/core'
 
 /**
  * Parses the markdown-list children of the list-shaped plan components into the
@@ -19,6 +19,7 @@ export const CHILD_BLOCK_COMPONENTS = [
   'Chart',
   'Compare',
   'Matrix',
+  'Stat',
 ] as const
 
 /** The prop each block component receives its parsed data on (a JSON string at render). */
@@ -29,6 +30,7 @@ export const BLOCK_DATA_ATTR: Record<string, string> = {
   Chart: 'data',
   Compare: 'options',
   Matrix: 'data',
+  Stat: 'items',
 }
 
 export interface BlockIssue {
@@ -59,6 +61,7 @@ interface MdNode {
 }
 
 const CHANGES: readonly string[] = CHANGE_VALUES
+const STAT_INTENTS: readonly string[] = STAT_INTENT_VALUES
 
 function pos(node: MdNode): { line: number; column: number } {
   return node.position?.start ?? { line: 1, column: 1 }
@@ -318,6 +321,70 @@ function parseCompare(node: MdNode): BlockResult {
   return { value: options, issues }
 }
 
+interface StatItem {
+  label: string
+  value: string
+  intent?: string
+  caption?: string
+}
+
+function parseStat(node: MdNode): BlockResult {
+  const issues: BlockIssue[] = []
+  const items: StatItem[] = []
+  const list = firstList(node)
+  if (!list) {
+    issues.push({
+      ...pos(node),
+      message: '<Stat> needs a markdown list of "- label: value" items.',
+    })
+    return { value: items, issues }
+  }
+  for (const item of list.children ?? []) {
+    const text = toText(item).trim()
+    // A "-- caption" trailer is split off first so the colon split below sees only "label: value".
+    let left = text
+    let caption: string | undefined
+    const dash = text.indexOf(' -- ')
+    if (dash !== -1) {
+      left = text.slice(0, dash)
+      caption = text.slice(dash + 4).trim()
+    }
+    // Split on the FIRST colon: stat values like "5:00" contain colons, labels do not.
+    const colon = left.indexOf(':')
+    if (colon === -1) {
+      issues.push({ ...pos(item), message: `<Stat> item "${text}" must be "label: value".` })
+      items.push({ label: left.trim(), value: '', ...(caption ? { caption } : {}) })
+      continue
+    }
+    const label = left.slice(0, colon).trim()
+    let value = left.slice(colon + 1).trim()
+    let intent: string | undefined
+    const match = value.match(/\s*\(([a-z]+)\)\s*$/i)
+    if (match) {
+      const word = (match[1] ?? '').toLowerCase()
+      if (STAT_INTENTS.includes(word)) {
+        intent = word
+        value = value.slice(0, match.index).trim()
+      } else {
+        issues.push({
+          ...pos(item),
+          message: `<Stat> intent "(${match[1]})" must be one of: note, good, warn, risk.`,
+        })
+      }
+    }
+    if (!label || !value) {
+      issues.push({ ...pos(item), message: `<Stat> item "${text}" must be "label: value".` })
+    }
+    items.push({
+      label,
+      value,
+      ...(intent ? { intent } : {}),
+      ...(caption ? { caption } : {}),
+    })
+  }
+  return { value: items, issues }
+}
+
 const PARSERS: Record<string, (node: MdNode) => BlockResult> = {
   FileTree: parseFileTree,
   Checklist: parseChecklist,
@@ -325,6 +392,7 @@ const PARSERS: Record<string, (node: MdNode) => BlockResult> = {
   Chart: parseChart,
   Compare: parseCompare,
   Matrix: parseMatrix,
+  Stat: parseStat,
 }
 
 /**

--- a/packages/compile/src/plan-blocks.ts
+++ b/packages/compile/src/plan-blocks.ts
@@ -145,9 +145,13 @@ function toNumber(raw: string, label: string, at: MdNode, issues: BlockIssue[]):
   return value
 }
 
+/** Chart types that visualize one value per category; a multi-series table is an authoring error. */
+const SINGLE_SERIES_CHARTS: readonly string[] = ['pie', 'gauge', 'funnel', 'treemap']
+
 function parseChart(node: MdNode): BlockResult {
   const issues: BlockIssue[] = []
   const data: Array<{ label: string; values: unknown[] }> = []
+  const type = attrValue(node, 'type')
 
   // Table form = multiple series: header is "category | series1 | series2 ...".
   const table = firstTable(node)
@@ -160,13 +164,29 @@ function parseChart(node: MdNode): BlockResult {
       const values = series.map((_, i) => toNumber(cells[i + 1] ?? '', label, row, issues))
       data.push({ label, values })
     }
-    if (attrValue(node, 'type') === 'pie' && series.length > 1) {
+    if (type && SINGLE_SERIES_CHARTS.includes(type) && series.length > 1) {
       issues.push({
         ...pos(node),
-        message: '<Chart type="pie"> shows a single series; use a "- label: value" list.',
+        message: `<Chart type="${type}"> shows a single series; use a "- label: value" list.`,
+      })
+    }
+    // Scatter plots x against y, so a table must carry exactly two value columns.
+    if (type === 'scatter' && series.length !== 2) {
+      issues.push({
+        ...pos(node),
+        message: '<Chart type="scatter"> needs exactly two value columns (x, y).',
       })
     }
     return { value: { series, data }, issues }
+  }
+
+  // Scatter has no single-series list form: it always needs an x/y table.
+  if (type === 'scatter') {
+    issues.push({
+      ...pos(node),
+      message: '<Chart type="scatter"> needs a table with x and y columns.',
+    })
+    return { value: { series: ['value'], data }, issues }
   }
 
   // List form = a single series of "- label: value".

--- a/packages/compile/tests/plan-blocks.test.ts
+++ b/packages/compile/tests/plan-blocks.test.ts
@@ -124,6 +124,31 @@ describe('Chart block', () => {
     )
     expect(issues.some(issue => /single series/.test(issue.message))).toBe(true)
   })
+
+  it('rejects a multi-series gauge (error)', () => {
+    const { issues } = parseBlock(
+      'Chart',
+      '<Chart type="gauge">\n| Stage | p50 | p95 |\n|---|---|---|\n| Auth | 12 | 30 |\n</Chart>\n',
+    )
+    expect(issues.some(issue => /single series/.test(issue.message))).toBe(true)
+  })
+
+  it('rejects a scatter list-form (error)', () => {
+    const { issues } = parseBlock('Chart', '<Chart type="scatter">\n- API: 3\n- UI: 2\n</Chart>\n')
+    expect(issues.some(issue => /needs a table with x and y columns/.test(issue.message))).toBe(
+      true,
+    )
+  })
+
+  it('rejects a scatter table without exactly two value columns (error)', () => {
+    const { issues } = parseBlock(
+      'Chart',
+      '<Chart type="scatter">\n| Point | x | y | z |\n|---|---|---|---|\n| A | 1 | 2 | 3 |\n</Chart>\n',
+    )
+    expect(
+      issues.some(issue => /needs exactly two value columns \(x, y\)/.test(issue.message)),
+    ).toBe(true)
+  })
 })
 
 describe('Matrix block', () => {

--- a/packages/compile/tests/plan-blocks.test.ts
+++ b/packages/compile/tests/plan-blocks.test.ts
@@ -212,6 +212,45 @@ describe('Questions block', () => {
   })
 })
 
+describe('Stat block', () => {
+  it('parses "- label: value (intent) -- caption" into a stat item (golden)', () => {
+    const { value, issues } = parseBlock(
+      'Stat',
+      '<Stat>\n- Est. uptime: 99.9% (good) -- rolling avg\n</Stat>\n',
+    )
+    expect(issues).toEqual([])
+    expect(value).toEqual([
+      { label: 'Est. uptime', value: '99.9%', intent: 'good', caption: 'rolling avg' },
+    ])
+  })
+
+  it('flags an unknown intent word (error)', () => {
+    const { issues } = parseBlock('Stat', '<Stat>\n- RPO: 5 min (bogus)\n</Stat>\n')
+    expect(issues.some(issue => /must be one of: note, good, warn, risk/.test(issue.message))).toBe(
+      true,
+    )
+  })
+
+  it('flags a bullet with no colon (error)', () => {
+    const { issues } = parseBlock('Stat', '<Stat>\n- just a label\n</Stat>\n')
+    expect(issues.some(issue => /must be "label: value"/.test(issue.message))).toBe(true)
+  })
+
+  it('splits on the first colon so a value may contain one, with no intent (edge)', () => {
+    const { value, issues } = parseBlock(
+      'Stat',
+      '<Stat>\n- Deploy window: 5:00 -- nightly\n</Stat>\n',
+    )
+    expect(issues).toEqual([])
+    expect(value).toEqual([{ label: 'Deploy window', value: '5:00', caption: 'nightly' }])
+  })
+
+  it('flags a block with no list (edge)', () => {
+    const { issues } = parseBlock('Stat', '<Stat>\nno list here\n</Stat>\n')
+    expect(issues.some(issue => /needs a markdown list/.test(issue.message))).toBe(true)
+  })
+})
+
 describe('Compare block', () => {
   it('parses headings + pro/con bullets and marks the pick (golden)', () => {
     const { value, issues } = parseBlock(

--- a/packages/core/AGENTS.md
+++ b/packages/core/AGENTS.md
@@ -31,6 +31,11 @@ CLI's `check` and `components` commands. One file: `src/index.ts`.
 
 ## Adding to the vocabulary
 
+`CHART_TYPE_VALUES` has nine members (`bar`, `line`, `area`, `scatter`, `radar`, `gauge`,
+`funnel`, `treemap`, `pie`); `chartSchema.stacked` is an optional boolean (bar/area only). `Stat`
+is a data component with `statSchema` and `STAT_INTENT_VALUES` (`note`, `good`, `warn`, `risk`);
+its item `value` is a free-text string (so "5 min", "99.9%" validate), unlike `Chart`'s numbers.
+
 A new component needs a schema, its enum constants, and a `CATALOG` entry (with `staticEnums`
 and an `example`) here, plus a component in `@visualplan/runtime`. `staticEnums` is what
 the CLI's AST checker validates statically; everything else is validated at render time by zod.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -11,7 +11,7 @@ import { z } from 'zod'
 
 export const STATUS_VALUES = ['planned', 'active', 'done'] as const
 export const CHANGE_VALUES = ['add', 'modify', 'delete', 'move'] as const
-export const CHART_TYPE_VALUES = ['bar', 'line', 'pie'] as const
+export const CHART_TYPE_VALUES = ['bar', 'line', 'area', 'pie'] as const
 export const CALLOUT_TYPE_VALUES = ['note', 'tip', 'risk', 'decision', 'warn'] as const
 
 export const phaseSchema = z.object({
@@ -122,7 +122,7 @@ export const CATALOG: readonly CatalogEntry[] = [
   {
     name: 'Chart',
     summary:
-      'A bar/line/pie chart for estimates or metrics. Single series: a markdown list of "- <label>: <value>". Multiple series (bar/line): a markdown table with a "category | series1 | series2" header.',
+      'A bar/line/area/pie chart for estimates or metrics. Single series: a markdown list of "- <label>: <value>". Multiple series (bar/line/area): a markdown table with a "category | series1 | series2" header.',
     staticEnums: { type: CHART_TYPE_VALUES },
     example:
       '<Chart type="bar" title="Effort (days)">\n- API: 3\n- UI: 2\n</Chart>\n\n<Chart type="line" title="Latency by stage (ms)">\n| Stage | p50 | p95 |\n|-------|-----|-----|\n| Auth  | 12  | 30  |\n| DB    | 40  | 120 |\n</Chart>',

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -23,6 +23,7 @@ export const CHART_TYPE_VALUES = [
   'pie',
 ] as const
 export const CALLOUT_TYPE_VALUES = ['note', 'tip', 'risk', 'decision', 'warn'] as const
+export const STAT_INTENT_VALUES = ['note', 'good', 'warn', 'risk'] as const
 
 export const phaseSchema = z.object({
   title: z.string().min(1, 'title is required'),
@@ -107,6 +108,20 @@ export const checklistSchema = z.object({
     .min(1, 'checklist needs at least one item'),
 })
 
+export const statSchema = z.object({
+  title: z.string().optional(),
+  items: z
+    .array(
+      z.object({
+        label: z.string().min(1, 'each stat needs a label'),
+        value: z.string().min(1, 'each stat needs a value'),
+        intent: z.enum(STAT_INTENT_VALUES).optional(),
+        caption: z.string().optional(),
+      }),
+    )
+    .min(1, 'stat needs at least one item'),
+})
+
 /** Describes a component for the `components` printer and the static checker. */
 export interface CatalogEntry {
   name: string
@@ -176,6 +191,14 @@ export const CATALOG: readonly CatalogEntry[] = [
     staticEnums: {},
     example:
       '<Checklist title="Done when">\n- [x] Returns 429 over the limit\n- [ ] Dashboards live\n</Checklist>',
+  },
+  {
+    name: 'Stat',
+    summary:
+      'Headline plan metrics as a grid of cards. Write a markdown list, one "- <label>: <value> (<intent>) -- <caption>" per stat; value is free text, intent (good/warn/risk/note) and the "-- caption" are optional.',
+    staticEnums: {},
+    example:
+      '<Stat>\n- Files changed: 12\n- Est. uptime: 99.9% (good)\n- RPO: 5 min (risk) -- worst-case data loss\n</Stat>',
   },
   {
     name: 'mermaid (code fence)',

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -11,7 +11,17 @@ import { z } from 'zod'
 
 export const STATUS_VALUES = ['planned', 'active', 'done'] as const
 export const CHANGE_VALUES = ['add', 'modify', 'delete', 'move'] as const
-export const CHART_TYPE_VALUES = ['bar', 'line', 'area', 'pie'] as const
+export const CHART_TYPE_VALUES = [
+  'bar',
+  'line',
+  'area',
+  'scatter',
+  'radar',
+  'gauge',
+  'funnel',
+  'treemap',
+  'pie',
+] as const
 export const CALLOUT_TYPE_VALUES = ['note', 'tip', 'risk', 'decision', 'warn'] as const
 
 export const phaseSchema = z.object({
@@ -35,6 +45,8 @@ export const fileTreeSchema = z.object({
 export const chartSchema = z.object({
   type: z.enum(CHART_TYPE_VALUES),
   title: z.string().optional(),
+  // Stacks multi-series bar/area on one axis (recharts stackId); ignored by other types.
+  stacked: z.boolean().optional(),
   // One or more series. A single-series chart (the `- label: value` list form) has one
   // synthetic series; a multi-series chart (the table form) names a series per column.
   series: z.array(z.string().min(1)).min(1, 'chart needs at least one series'),
@@ -122,10 +134,10 @@ export const CATALOG: readonly CatalogEntry[] = [
   {
     name: 'Chart',
     summary:
-      'A bar/line/area/pie chart for estimates or metrics. Single series: a markdown list of "- <label>: <value>". Multiple series (bar/line/area): a markdown table with a "category | series1 | series2" header.',
+      'A bar/line/area/scatter/radar/gauge/funnel/treemap/pie chart for estimates or metrics. Single series (bar/line/area/gauge/funnel/treemap/pie): a markdown list of "- <label>: <value>". Multiple series (bar/line/area/radar): a markdown table with a "category | series1 | series2" header. Scatter needs a table with exactly two value columns (x, y). Add the "stacked" attribute to a multi-series bar/area to stack the series.',
     staticEnums: { type: CHART_TYPE_VALUES },
     example:
-      '<Chart type="bar" title="Effort (days)">\n- API: 3\n- UI: 2\n</Chart>\n\n<Chart type="line" title="Latency by stage (ms)">\n| Stage | p50 | p95 |\n|-------|-----|-----|\n| Auth  | 12  | 30  |\n| DB    | 40  | 120 |\n</Chart>',
+      '<Chart type="bar" title="Effort (days)">\n- API: 3\n- UI: 2\n</Chart>\n\n<Chart type="line" title="Latency by stage (ms)">\n| Stage | p50 | p95 |\n|-------|-----|-----|\n| Auth  | 12  | 30  |\n| DB    | 40  | 120 |\n</Chart>\n\n<Chart type="bar" stacked title="Effort by area (days)">\n| Phase | API | UI |\n|-------|-----|----|\n| Build | 3   | 2  |\n| Test  | 1   | 1  |\n</Chart>',
   },
   {
     name: 'Compare',

--- a/packages/core/tests/catalog.test.ts
+++ b/packages/core/tests/catalog.test.ts
@@ -11,6 +11,15 @@ describe('chartSchema', () => {
     expect(result.success).toBe(true)
   })
 
+  it('accepts a valid area spec (golden)', () => {
+    const result = chartSchema.safeParse({
+      type: 'area',
+      series: ['value'],
+      data: [{ label: 'x', values: [1] }],
+    })
+    expect(result.success).toBe(true)
+  })
+
   it('rejects an unknown chart type (error)', () => {
     const result = chartSchema.safeParse({
       type: 'donut',

--- a/packages/core/tests/catalog.test.ts
+++ b/packages/core/tests/catalog.test.ts
@@ -20,6 +20,28 @@ describe('chartSchema', () => {
     expect(result.success).toBe(true)
   })
 
+  it('accepts each new chart type (golden)', () => {
+    for (const type of ['scatter', 'radar', 'gauge', 'funnel', 'treemap']) {
+      const result = chartSchema.safeParse({
+        type,
+        series: ['value'],
+        data: [{ label: 'x', values: [1] }],
+      })
+      expect(result.success).toBe(true)
+    }
+  })
+
+  it('accepts the stacked attribute and keeps it on the parsed object (golden)', () => {
+    const result = chartSchema.safeParse({
+      type: 'bar',
+      stacked: true,
+      series: ['a', 'b'],
+      data: [{ label: 'x', values: [1, 2] }],
+    })
+    expect(result.success).toBe(true)
+    if (result.success) expect(result.data.stacked).toBe(true)
+  })
+
   it('rejects an unknown chart type (error)', () => {
     const result = chartSchema.safeParse({
       type: 'donut',

--- a/packages/core/tests/catalog.test.ts
+++ b/packages/core/tests/catalog.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { CATALOG, chartSchema, matrixSchema } from '../src/index.js'
+import { CATALOG, chartSchema, matrixSchema, statSchema } from '../src/index.js'
 
 describe('chartSchema', () => {
   it('accepts a valid bar spec (golden)', () => {
@@ -77,6 +77,26 @@ describe('matrixSchema', () => {
 
   it('rejects a grid with no rows (edge)', () => {
     const result = matrixSchema.safeParse({ columns: [{ name: 'A' }, { name: 'B' }], rows: [] })
+    expect(result.success).toBe(false)
+  })
+})
+
+describe('statSchema', () => {
+  it('accepts an item with an intent and caption (golden)', () => {
+    const result = statSchema.safeParse({
+      title: 'Impact',
+      items: [{ label: 'Est. uptime', value: '99.9%', intent: 'good', caption: 'rolling avg' }],
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('rejects empty items (error)', () => {
+    const result = statSchema.safeParse({ items: [] })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects an item missing its value (edge)', () => {
+    const result = statSchema.safeParse({ items: [{ label: 'Files changed' }] })
     expect(result.success).toBe(false)
   })
 })

--- a/packages/runtime/AGENTS.md
+++ b/packages/runtime/AGENTS.md
@@ -26,16 +26,16 @@ the root AGENTS.md for why Vite is configured without `@vitejs/plugin-react`.
   (`counter-reset: vp-phase` on `.vp-main`, `counter-increment` on `.vp-phase`, number drawn by
   `.vp-phase__node::before`), so phases self-number in document order with no index prop. The
   connector line is a `.vp-phase__rail::after` pseudo-element omitted on the last step.
-- `components/` holds the components (Phase, FileTree, Chart, Compare, Matrix, Callout, Questions,
-  Checklist, Mermaid, Math). `Math` (exported as `MathBlock` to avoid shadowing the global `Math`,
+- `components/` holds the components (Phase, FileTree, Chart, Stat, Compare, Matrix, Callout,
+  Questions, Checklist, Mermaid, Math). `Math` (exported as `MathBlock` to avoid shadowing the global `Math`,
   registered under the `Math` scope key) just injects MathML the CLI's `remark-math` produced from
   a ` ```math ` fence at build time; no math library runs in the browser. `FileTree` builds a nested directory tree from flat `{path}` entries
   (collapsing single-child dir chains); `Checklist` renders done/todo acceptance criteria. Each
   validates its props through `validate.ts`
   against the matching zod schema in `@visualplan/core`, throwing a readable, component-named
   error on invalid input (this surfaces in the page and is the render-time half of validation).
-- **The data components (FileTree, Chart, Compare, Matrix, Questions, Checklist) are authored as
-  markdown children, not props.** The CLI's `remark-plan-blocks` plugin parses those children
+- **The data components (FileTree, Chart, Stat, Compare, Matrix, Questions, Checklist) are authored
+  as markdown children, not props.** The CLI's `remark-plan-blocks` plugin parses those children
   into the structured data and passes it as a JSON string on the component's data prop
   (`files`/`data`/`options`/`items`); the component calls `decodeJson` (in `validate.ts`) to
   parse it before `validateProps`. `decodeJson` passes a non-string through unchanged, so the
@@ -44,7 +44,11 @@ the root AGENTS.md for why Vite is configured without `@vitejs/plugin-react`.
   horizontal-scroll wrapper); a column header ending in `(pick)` highlights that column. **Chart**
   is single- or multi-series: its data is `{ series, data: [{ label, values[] }] }`; one
   `<Bar>`/`<Line>` per series, a `<Legend>` only when there is more than one, and the per-point
-  `<Cell>` coloring only for a single series. **FileTree** supports a directory-level change: a
+  `<Cell>` coloring only for a single series. `Chart` dispatches on `type` across nine recharts
+  branches (`bar`, `line`, `area`, `scatter`, `radar`, `gauge`, `funnel`, `treemap`, `pie`);
+  `stacked` applies a shared `stackId` to the `<Bar>`/`<Area>` series. **Stat** renders a responsive
+  grid of metric cards (`.vp-stat__card` with `data-intent`), one per item, value + label + optional
+  caption; the intent tints reuse the `--vp-*-tint` vars. **FileTree** supports a directory-level change: a
   path ending in `/` sets `change` on the `DirNode` and renders the marker on the directory row. A
   `move` carries an optional `from` (origin) on the entry; the file renders at its destination with
   a muted `MovedFrom` annotation (`← <from>`) so the rename is visible (the CLI parser requires the

--- a/packages/runtime/components/Chart.tsx
+++ b/packages/runtime/components/Chart.tsx
@@ -224,7 +224,9 @@ function renderRadar({ rows, keys, multi }: ChartBody) {
     <RadarChart data={rows}>
       <PolarGrid stroke='var(--vp-border)' />
       <PolarAngleAxis dataKey='label' tick={AXIS_TICK} />
-      <PolarRadiusAxis tick={AXIS_TICK} stroke='var(--vp-border)' />
+      {/* Hide the numeric radius scale: recharts renders its ticks rotated along the axis angle,
+          which reads as an illegible vertical strip. A plan radar compares shape, not exact radii. */}
+      <PolarRadiusAxis tick={false} axisLine={false} stroke='var(--vp-border)' />
       {multi ? <Legend wrapperStyle={LEGEND_STYLE} /> : null}
       {keys.map((key, seriesIndex) => (
         <Radar
@@ -249,10 +251,10 @@ function renderGauge({ data }: ChartBody) {
   return (
     <RadialBarChart
       data={points}
-      innerRadius='30%'
-      outerRadius='90%'
-      startAngle={90}
-      endAngle={-270}
+      innerRadius='45%'
+      outerRadius='100%'
+      startAngle={180}
+      endAngle={0}
     >
       <PolarAngleAxis type='number' domain={[0, 100]} tick={false} />
       <RadialBar dataKey='value' background cornerRadius={4} isAnimationActive={false} />

--- a/packages/runtime/components/Chart.tsx
+++ b/packages/runtime/components/Chart.tsx
@@ -5,13 +5,26 @@ import {
   BarChart,
   CartesianGrid,
   Cell,
+  Funnel,
+  FunnelChart,
+  LabelList,
   Legend,
   Line,
   LineChart,
   Pie,
   PieChart,
+  PolarAngleAxis,
+  PolarGrid,
+  PolarRadiusAxis,
+  Radar,
+  RadarChart,
+  RadialBar,
+  RadialBarChart,
   ResponsiveContainer,
+  Scatter,
+  ScatterChart,
   Tooltip,
+  Treemap,
   XAxis,
   YAxis,
 } from 'recharts'
@@ -22,6 +35,8 @@ import { decodeJson, validateProps } from './validate.js'
 interface ChartProps {
   type?: unknown
   title?: unknown
+  // MDX boolean shorthand `<Chart stacked>` yields `true`; `stacked="true"` yields the string.
+  stacked?: unknown
   data: unknown
 }
 
@@ -56,14 +71,22 @@ const TOOLTIP_STYLE = {
 const LEGEND_STYLE = { fontSize: 12, color: 'var(--vp-muted)' }
 const MARGIN = { top: 4, right: 8, bottom: 0, left: -16 }
 
+interface ChartPoint {
+  label: string
+  values: number[]
+}
+
 interface ChartBody {
   rows: Array<Record<string, string | number>>
   keys: string[]
   multi: boolean
+  stacked: boolean
+  series: string[]
+  data: ChartPoint[]
   pieData: Array<{ label: string; value: number }>
 }
 
-function renderBar({ rows, keys, multi }: ChartBody) {
+function renderBar({ rows, keys, multi, stacked }: ChartBody) {
   return (
     <BarChart data={rows} margin={MARGIN}>
       <CartesianGrid strokeDasharray='3 3' stroke='var(--vp-border)' vertical={false} />
@@ -75,6 +98,7 @@ function renderBar({ rows, keys, multi }: ChartBody) {
         <Bar
           key={key}
           dataKey={key}
+          stackId={stacked ? 'a' : undefined}
           radius={[4, 4, 0, 0]}
           maxBarSize={64}
           fill={COLORS[seriesIndex % COLORS.length]}
@@ -114,7 +138,7 @@ function renderLine({ rows, keys, multi }: ChartBody) {
   )
 }
 
-function renderArea({ rows, keys, multi }: ChartBody) {
+function renderArea({ rows, keys, multi, stacked }: ChartBody) {
   return (
     <AreaChart data={rows} margin={MARGIN}>
       <CartesianGrid strokeDasharray='3 3' stroke='var(--vp-border)' vertical={false} />
@@ -127,6 +151,7 @@ function renderArea({ rows, keys, multi }: ChartBody) {
           key={key}
           type='monotone'
           dataKey={key}
+          stackId={stacked ? 'a' : undefined}
           stroke={COLORS[seriesIndex % COLORS.length]}
           fill={COLORS[seriesIndex % COLORS.length]}
           fillOpacity={0.2}
@@ -159,10 +184,158 @@ function renderPie({ pieData }: ChartBody) {
   )
 }
 
+function renderScatter({ data, series }: ChartBody) {
+  const points = data.map(point => ({
+    x: point.values[0] ?? 0,
+    y: point.values[1] ?? 0,
+    label: point.label,
+  }))
+  return (
+    <ScatterChart margin={MARGIN}>
+      <CartesianGrid strokeDasharray='3 3' stroke='var(--vp-border)' />
+      <XAxis
+        type='number'
+        dataKey='x'
+        name={series[0]}
+        tick={AXIS_TICK}
+        stroke='var(--vp-border)'
+        tickFormatter={formatTick}
+      />
+      <YAxis
+        type='number'
+        dataKey='y'
+        name={series[1]}
+        tick={AXIS_TICK}
+        stroke='var(--vp-border)'
+        tickFormatter={formatTick}
+      />
+      <Tooltip cursor={{ strokeDasharray: '3 3' }} contentStyle={TOOLTIP_STYLE} />
+      <Scatter data={points} isAnimationActive={false}>
+        {points.map((point, index) => (
+          <Cell key={point.label} fill={COLORS[index % COLORS.length]} />
+        ))}
+      </Scatter>
+    </ScatterChart>
+  )
+}
+
+function renderRadar({ rows, keys, multi }: ChartBody) {
+  return (
+    <RadarChart data={rows}>
+      <PolarGrid stroke='var(--vp-border)' />
+      <PolarAngleAxis dataKey='label' tick={AXIS_TICK} />
+      <PolarRadiusAxis tick={AXIS_TICK} stroke='var(--vp-border)' />
+      {multi ? <Legend wrapperStyle={LEGEND_STYLE} /> : null}
+      {keys.map((key, seriesIndex) => (
+        <Radar
+          key={key}
+          dataKey={key}
+          stroke={COLORS[seriesIndex % COLORS.length]}
+          fill={COLORS[seriesIndex % COLORS.length]}
+          fillOpacity={0.2}
+          isAnimationActive={false}
+        />
+      ))}
+    </RadarChart>
+  )
+}
+
+function renderGauge({ data }: ChartBody) {
+  const points = data.map((point, index) => ({
+    label: point.label,
+    value: point.values[0] ?? 0,
+    fill: COLORS[index % COLORS.length],
+  }))
+  return (
+    <RadialBarChart
+      data={points}
+      innerRadius='30%'
+      outerRadius='90%'
+      startAngle={90}
+      endAngle={-270}
+    >
+      <PolarAngleAxis type='number' domain={[0, 100]} tick={false} />
+      <RadialBar dataKey='value' background cornerRadius={4} isAnimationActive={false} />
+      <Tooltip contentStyle={TOOLTIP_STYLE} />
+    </RadialBarChart>
+  )
+}
+
+function renderFunnel({ data }: ChartBody) {
+  const points = data.map((point, index) => ({
+    label: point.label,
+    value: point.values[0] ?? 0,
+    fill: COLORS[index % COLORS.length],
+  }))
+  return (
+    <FunnelChart>
+      <Tooltip contentStyle={TOOLTIP_STYLE} />
+      <Funnel dataKey='value' data={points} isAnimationActive={false}>
+        <LabelList dataKey='label' position='right' fill='var(--vp-text)' stroke='none' />
+      </Funnel>
+    </FunnelChart>
+  )
+}
+
+interface TreemapContentProps {
+  x?: number
+  y?: number
+  width?: number
+  height?: number
+  index?: number
+  name?: string
+  fill?: string
+}
+
+/** A treemap tile: a filled rect plus a label when the tile is wide and tall enough to read. */
+function TreemapTile({
+  x = 0,
+  y = 0,
+  width = 0,
+  height = 0,
+  index = 0,
+  name,
+  fill,
+}: TreemapContentProps) {
+  const color = fill ?? COLORS[index % COLORS.length]
+  return (
+    <g>
+      <rect x={x} y={y} width={width} height={height} fill={color} stroke='var(--vp-surface)' />
+      {width > 56 && height > 24 ? (
+        <text x={x + 6} y={y + 18} fill='var(--vp-surface)' fontSize={12}>
+          {name}
+        </text>
+      ) : null}
+    </g>
+  )
+}
+
+function renderTreemap({ data }: ChartBody) {
+  const nodes = data.map((point, index) => ({
+    name: point.label,
+    size: point.values[0] ?? 0,
+    fill: COLORS[index % COLORS.length],
+  }))
+  return (
+    <Treemap
+      data={nodes}
+      dataKey='size'
+      stroke='var(--vp-surface)'
+      isAnimationActive={false}
+      content={<TreemapTile />}
+    />
+  )
+}
+
 const CHART_BODIES = {
   bar: renderBar,
   line: renderLine,
   area: renderArea,
+  scatter: renderScatter,
+  radar: renderRadar,
+  gauge: renderGauge,
+  funnel: renderFunnel,
+  treemap: renderTreemap,
   pie: renderPie,
 }
 
@@ -170,9 +343,11 @@ const CHART_BODIES = {
  * from a `- label: value` list; multiple series from a table with one column per series. */
 export function Chart(props: ChartProps) {
   const decoded = (decodeJson(props.data) ?? {}) as { series?: unknown; data?: unknown }
-  const { type, title, series, data } = validateProps('Chart', chartSchema, {
+  const { type, title, stacked, series, data } = validateProps('Chart', chartSchema, {
     type: props.type,
     title: props.title,
+    // The MDX boolean shorthand `<Chart stacked>` is `true`; `stacked="true"` is the string.
+    stacked: props.stacked === true || props.stacked === 'true',
     series: decoded.series,
     data: decoded.data,
   })
@@ -195,7 +370,7 @@ export function Chart(props: ChartProps) {
       {title ? <figcaption className='vp-chart__title'>{title}</figcaption> : null}
       <div className='vp-chart__canvas' data-type={type}>
         <ResponsiveContainer width='100%' height='100%'>
-          {renderBody({ rows, keys, multi, pieData })}
+          {renderBody({ rows, keys, multi, stacked: stacked === true, series, data, pieData })}
         </ResponsiveContainer>
       </div>
       {type === 'pie' ? (
@@ -211,6 +386,21 @@ export function Chart(props: ChartProps) {
               <span className='vp-chart__legend-value'>
                 {pieTotal > 0 ? `${Math.round((point.value / pieTotal) * 100)}%` : point.value}
               </span>
+            </li>
+          ))}
+        </ul>
+      ) : null}
+      {type === 'gauge' ? (
+        <ul className='vp-chart__legend'>
+          {pieData.map((point, index) => (
+            <li key={point.label} className='vp-chart__legend-item'>
+              <span
+                className='vp-chart__swatch'
+                style={{ background: COLORS[index % COLORS.length] }}
+                aria-hidden='true'
+              />
+              <span className='vp-chart__legend-label'>{point.label}</span>
+              <span className='vp-chart__legend-value'>{point.value}</span>
             </li>
           ))}
         </ul>

--- a/packages/runtime/components/Chart.tsx
+++ b/packages/runtime/components/Chart.tsx
@@ -1,4 +1,6 @@
 import {
+  Area,
+  AreaChart,
   Bar,
   BarChart,
   CartesianGrid,
@@ -54,8 +56,118 @@ const TOOLTIP_STYLE = {
 const LEGEND_STYLE = { fontSize: 12, color: 'var(--vp-muted)' }
 const MARGIN = { top: 4, right: 8, bottom: 0, left: -16 }
 
-/** A bar/line/pie chart for estimates or metrics, backed by recharts. Single series comes from a
- * `- label: value` list; multiple series from a table with one column per series. */
+interface ChartBody {
+  rows: Array<Record<string, string | number>>
+  keys: string[]
+  multi: boolean
+  pieData: Array<{ label: string; value: number }>
+}
+
+function renderBar({ rows, keys, multi }: ChartBody) {
+  return (
+    <BarChart data={rows} margin={MARGIN}>
+      <CartesianGrid strokeDasharray='3 3' stroke='var(--vp-border)' vertical={false} />
+      <XAxis dataKey='label' tick={AXIS_TICK} stroke='var(--vp-border)' />
+      <YAxis allowDecimals tick={AXIS_TICK} stroke='var(--vp-border)' tickFormatter={formatTick} />
+      <Tooltip cursor={{ fill: 'var(--vp-surface-2)' }} contentStyle={TOOLTIP_STYLE} />
+      {multi ? <Legend wrapperStyle={LEGEND_STYLE} /> : null}
+      {keys.map((key, seriesIndex) => (
+        <Bar
+          key={key}
+          dataKey={key}
+          radius={[4, 4, 0, 0]}
+          maxBarSize={64}
+          fill={COLORS[seriesIndex % COLORS.length]}
+          isAnimationActive={false}
+        >
+          {multi
+            ? null
+            : rows.map((row, index) => (
+                <Cell key={String(row.label)} fill={COLORS[index % COLORS.length]} />
+              ))}
+        </Bar>
+      ))}
+    </BarChart>
+  )
+}
+
+function renderLine({ rows, keys, multi }: ChartBody) {
+  return (
+    <LineChart data={rows} margin={MARGIN}>
+      <CartesianGrid strokeDasharray='3 3' stroke='var(--vp-border)' vertical={false} />
+      <XAxis dataKey='label' tick={AXIS_TICK} stroke='var(--vp-border)' />
+      <YAxis allowDecimals tick={AXIS_TICK} stroke='var(--vp-border)' tickFormatter={formatTick} />
+      <Tooltip contentStyle={TOOLTIP_STYLE} />
+      {multi ? <Legend wrapperStyle={LEGEND_STYLE} /> : null}
+      {keys.map((key, seriesIndex) => (
+        <Line
+          key={key}
+          type='monotone'
+          dataKey={key}
+          stroke={COLORS[seriesIndex % COLORS.length]}
+          strokeWidth={2.5}
+          dot={{ fill: COLORS[seriesIndex % COLORS.length], r: 3 }}
+          isAnimationActive={false}
+        />
+      ))}
+    </LineChart>
+  )
+}
+
+function renderArea({ rows, keys, multi }: ChartBody) {
+  return (
+    <AreaChart data={rows} margin={MARGIN}>
+      <CartesianGrid strokeDasharray='3 3' stroke='var(--vp-border)' vertical={false} />
+      <XAxis dataKey='label' tick={AXIS_TICK} stroke='var(--vp-border)' />
+      <YAxis allowDecimals tick={AXIS_TICK} stroke='var(--vp-border)' tickFormatter={formatTick} />
+      <Tooltip contentStyle={TOOLTIP_STYLE} />
+      {multi ? <Legend wrapperStyle={LEGEND_STYLE} /> : null}
+      {keys.map((key, seriesIndex) => (
+        <Area
+          key={key}
+          type='monotone'
+          dataKey={key}
+          stroke={COLORS[seriesIndex % COLORS.length]}
+          fill={COLORS[seriesIndex % COLORS.length]}
+          fillOpacity={0.2}
+          strokeWidth={2.5}
+          dot={{ fill: COLORS[seriesIndex % COLORS.length], r: 3 }}
+          isAnimationActive={false}
+        />
+      ))}
+    </AreaChart>
+  )
+}
+
+function renderPie({ pieData }: ChartBody) {
+  return (
+    <PieChart>
+      <Tooltip contentStyle={TOOLTIP_STYLE} />
+      <Pie
+        data={pieData}
+        dataKey='value'
+        nameKey='label'
+        outerRadius={88}
+        stroke='none'
+        isAnimationActive={false}
+      >
+        {pieData.map((point, index) => (
+          <Cell key={point.label} fill={COLORS[index % COLORS.length]} />
+        ))}
+      </Pie>
+    </PieChart>
+  )
+}
+
+const CHART_BODIES = {
+  bar: renderBar,
+  line: renderLine,
+  area: renderArea,
+  pie: renderPie,
+}
+
+/** A bar/line/area/pie chart for estimates or metrics, backed by recharts. Single series comes
+ * from a `- label: value` list; multiple series from a table with one column per series. */
 export function Chart(props: ChartProps) {
   const decoded = (decodeJson(props.data) ?? {}) as { series?: unknown; data?: unknown }
   const { type, title, series, data } = validateProps('Chart', chartSchema, {
@@ -77,81 +189,13 @@ export function Chart(props: ChartProps) {
   })
   const pieData = data.map(point => ({ label: point.label, value: point.values[0] ?? 0 }))
   const pieTotal = pieData.reduce((sum, point) => sum + point.value, 0)
+  const renderBody = CHART_BODIES[type]
   return (
     <figure className='vp-chart vp-expandable'>
       {title ? <figcaption className='vp-chart__title'>{title}</figcaption> : null}
       <div className='vp-chart__canvas' data-type={type}>
         <ResponsiveContainer width='100%' height='100%'>
-          {type === 'bar' ? (
-            <BarChart data={rows} margin={MARGIN}>
-              <CartesianGrid strokeDasharray='3 3' stroke='var(--vp-border)' vertical={false} />
-              <XAxis dataKey='label' tick={AXIS_TICK} stroke='var(--vp-border)' />
-              <YAxis
-                allowDecimals
-                tick={AXIS_TICK}
-                stroke='var(--vp-border)'
-                tickFormatter={formatTick}
-              />
-              <Tooltip cursor={{ fill: 'var(--vp-surface-2)' }} contentStyle={TOOLTIP_STYLE} />
-              {multi ? <Legend wrapperStyle={LEGEND_STYLE} /> : null}
-              {keys.map((key, seriesIndex) => (
-                <Bar
-                  key={key}
-                  dataKey={key}
-                  radius={[4, 4, 0, 0]}
-                  maxBarSize={64}
-                  fill={COLORS[seriesIndex % COLORS.length]}
-                  isAnimationActive={false}
-                >
-                  {multi
-                    ? null
-                    : rows.map((row, index) => (
-                        <Cell key={String(row.label)} fill={COLORS[index % COLORS.length]} />
-                      ))}
-                </Bar>
-              ))}
-            </BarChart>
-          ) : type === 'line' ? (
-            <LineChart data={rows} margin={MARGIN}>
-              <CartesianGrid strokeDasharray='3 3' stroke='var(--vp-border)' vertical={false} />
-              <XAxis dataKey='label' tick={AXIS_TICK} stroke='var(--vp-border)' />
-              <YAxis
-                allowDecimals
-                tick={AXIS_TICK}
-                stroke='var(--vp-border)'
-                tickFormatter={formatTick}
-              />
-              <Tooltip contentStyle={TOOLTIP_STYLE} />
-              {multi ? <Legend wrapperStyle={LEGEND_STYLE} /> : null}
-              {keys.map((key, seriesIndex) => (
-                <Line
-                  key={key}
-                  type='monotone'
-                  dataKey={key}
-                  stroke={COLORS[seriesIndex % COLORS.length]}
-                  strokeWidth={2.5}
-                  dot={{ fill: COLORS[seriesIndex % COLORS.length], r: 3 }}
-                  isAnimationActive={false}
-                />
-              ))}
-            </LineChart>
-          ) : (
-            <PieChart>
-              <Tooltip contentStyle={TOOLTIP_STYLE} />
-              <Pie
-                data={pieData}
-                dataKey='value'
-                nameKey='label'
-                outerRadius={88}
-                stroke='none'
-                isAnimationActive={false}
-              >
-                {pieData.map((point, index) => (
-                  <Cell key={point.label} fill={COLORS[index % COLORS.length]} />
-                ))}
-              </Pie>
-            </PieChart>
-          )}
+          {renderBody({ rows, keys, multi, pieData })}
         </ResponsiveContainer>
       </div>
       {type === 'pie' ? (

--- a/packages/runtime/components/Stat.tsx
+++ b/packages/runtime/components/Stat.tsx
@@ -1,0 +1,29 @@
+import { statSchema } from '@visualplan/core'
+import { decodeJson, validateProps } from './validate.js'
+
+interface StatProps {
+  title?: unknown
+  items: unknown
+}
+
+/** Headline plan metrics as a responsive grid of cards (value, label, optional caption). */
+export function Stat(props: StatProps) {
+  const { title, items } = validateProps('Stat', statSchema, {
+    ...props,
+    items: decodeJson(props.items),
+  })
+  return (
+    <section className='vp-stat'>
+      {title ? <div className='vp-stat__title'>{title}</div> : null}
+      <div className='vp-stat__grid'>
+        {items.map(item => (
+          <div key={item.label} className='vp-stat__card' data-intent={item.intent}>
+            <div className='vp-stat__value'>{item.value}</div>
+            <div className='vp-stat__label'>{item.label}</div>
+            {item.caption ? <div className='vp-stat__caption'>{item.caption}</div> : null}
+          </div>
+        ))}
+      </div>
+    </section>
+  )
+}

--- a/packages/runtime/index.tsx
+++ b/packages/runtime/index.tsx
@@ -11,6 +11,7 @@ import { Matrix } from './components/Matrix.js'
 import { Mermaid } from './components/Mermaid.js'
 import { Phase } from './components/Phase.js'
 import { Questions } from './components/Questions.js'
+import { Stat } from './components/Stat.js'
 import { Layout } from './Layout.js'
 import './theme.css'
 
@@ -28,6 +29,7 @@ export const components = {
   Callout,
   Questions,
   Checklist,
+  Stat,
   Mermaid,
   Math: MathBlock,
 }

--- a/packages/runtime/tests/components.test.tsx
+++ b/packages/runtime/tests/components.test.tsx
@@ -341,6 +341,79 @@ describe('Chart', () => {
     expect(html).not.toContain('vp-chart__legend')
   })
 
+  it('mounts a scatter chart and emits the vp-chart markup (golden)', () => {
+    const html = renderToStaticMarkup(
+      <Chart type='scatter' data={chartData(['x', 'y'], [{ label: 'A', values: [1, 2] }])} />,
+    )
+    expect(html).toContain('vp-chart')
+    expect(html).toContain('data-type="scatter"')
+  })
+
+  it('mounts a radar chart and emits the vp-chart markup (golden)', () => {
+    const html = renderToStaticMarkup(
+      <Chart
+        type='radar'
+        data={chartData(
+          ['p50', 'p95'],
+          [
+            { label: 'Auth', values: [1, 2] },
+            { label: 'DB', values: [3, 4] },
+          ],
+        )}
+      />,
+    )
+    expect(html).toContain('vp-chart')
+    expect(html).toContain('data-type="radar"')
+  })
+
+  it('mounts a gauge chart and emits its legend list (golden)', () => {
+    const html = renderToStaticMarkup(
+      <Chart type='gauge' data={chartData(['value'], [{ label: 'Done', values: [80] }])} />,
+    )
+    expect(html).toContain('vp-chart')
+    expect(html).toContain('data-type="gauge"')
+    expect(html).toContain('vp-chart__legend')
+  })
+
+  it('mounts a funnel chart and emits the vp-chart markup (golden)', () => {
+    const html = renderToStaticMarkup(
+      <Chart type='funnel' data={chartData(['value'], [{ label: 'Visit', values: [100] }])} />,
+    )
+    expect(html).toContain('vp-chart')
+    expect(html).toContain('data-type="funnel"')
+  })
+
+  it('mounts a treemap chart and emits the vp-chart markup (golden)', () => {
+    const html = renderToStaticMarkup(
+      <Chart type='treemap' data={chartData(['value'], [{ label: 'API', values: [60] }])} />,
+    )
+    expect(html).toContain('vp-chart')
+    expect(html).toContain('data-type="treemap"')
+  })
+
+  it('mounts a stacked multi-series bar chart (golden)', () => {
+    const html = renderToStaticMarkup(
+      <Chart
+        type='bar'
+        stacked
+        data={chartData(['p50', 'p95'], [{ label: 'Auth', values: [12, 30] }])}
+      />,
+    )
+    expect(html).toContain('vp-chart')
+    expect(html).toContain('data-type="bar"')
+  })
+
+  it('accepts the string form of the stacked attribute (edge)', () => {
+    const html = renderToStaticMarkup(
+      <Chart
+        type='area'
+        stacked='true'
+        data={chartData(['a', 'b'], [{ label: 'x', values: [1, 2] }])}
+      />,
+    )
+    expect(html).toContain('data-type="area"')
+  })
+
   it('throws on an unknown chart type (error)', () => {
     expect(() =>
       renderToStaticMarkup(

--- a/packages/runtime/tests/components.test.tsx
+++ b/packages/runtime/tests/components.test.tsx
@@ -10,6 +10,7 @@ import { Matrix } from '../components/Matrix.js'
 import { Phase } from '../components/Phase.js'
 import { Questions } from '../components/Questions.js'
 import { copyText, ShareButton } from '../components/ShareButton.js'
+import { Stat } from '../components/Stat.js'
 
 describe('Phase', () => {
   it('renders the title and a status badge for active/done (golden)', () => {
@@ -420,6 +421,50 @@ describe('Chart', () => {
         <Chart type='donut' data={chartData(['value'], [{ label: 'x', values: [1] }])} />,
       ),
     ).toThrow(/invalid props/)
+  })
+})
+
+describe('Stat', () => {
+  // The Stat receives its parsed items as a JSON string in the `items` prop (the
+  // remark-plan-blocks decode path).
+  const statItems = (items: unknown) => JSON.stringify(items)
+
+  it('renders a grid of stat cards with their values, labels, and captions (golden)', () => {
+    const html = renderToStaticMarkup(
+      <Stat
+        title='Impact'
+        items={statItems([
+          { label: 'Files changed', value: '12' },
+          { label: 'RPO', value: '5 min', intent: 'risk', caption: 'worst-case data loss' },
+        ])}
+      />,
+    )
+    expect(html).toContain('vp-stat')
+    expect(html).toContain('vp-stat__card')
+    expect(html).toContain('Impact')
+    expect(html).toContain('Files changed')
+    expect(html).toContain('12')
+    expect(html).toContain('5 min')
+    expect(html).toContain('worst-case data loss')
+  })
+
+  it('carries the matching data-intent on a card with an intent (edge)', () => {
+    const html = renderToStaticMarkup(
+      <Stat items={statItems([{ label: 'Est. uptime', value: '99.9%', intent: 'good' }])} />,
+    )
+    expect(html).toContain('data-intent="good"')
+  })
+
+  it('mounts a minimal single-item stat without throwing (golden)', () => {
+    const html = renderToStaticMarkup(
+      <Stat items={statItems([{ label: 'Files changed', value: '12' }])} />,
+    )
+    expect(html).toContain('vp-stat')
+    expect(html).toContain('Files changed')
+  })
+
+  it('throws on an empty item list (error)', () => {
+    expect(() => renderToStaticMarkup(<Stat items={statItems([])} />)).toThrow(/at least one item/)
   })
 })
 

--- a/packages/runtime/tests/components.test.tsx
+++ b/packages/runtime/tests/components.test.tsx
@@ -1,6 +1,7 @@
 import { renderToStaticMarkup } from 'react-dom/server'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { Callout } from '../components/Callout.js'
+import { Chart } from '../components/Chart.js'
 import { Checklist } from '../components/Checklist.js'
 import { Compare } from '../components/Compare.js'
 import { FileTree } from '../components/FileTree.js'
@@ -277,6 +278,75 @@ describe('Checklist', () => {
   it('defaults an item to not done (edge)', () => {
     const html = renderToStaticMarkup(<Checklist items={[{ text: 'only' }]} />)
     expect(html).toContain('data-done="false"')
+  })
+})
+
+describe('Chart', () => {
+  // The Chart receives its parsed spec as a JSON string in the `data` prop (the
+  // remark-plan-blocks decode path), with `series` and `data` inside.
+  const chartData = (series: string[], data: Array<{ label: string; values: number[] }>) =>
+    JSON.stringify({ series, data })
+
+  it('renders a single-series bar chart and its title (golden)', () => {
+    const html = renderToStaticMarkup(
+      <Chart
+        type='bar'
+        title='Effort'
+        data={chartData(['value'], [{ label: 'API', values: [3] }])}
+      />,
+    )
+    expect(html).toContain('vp-chart')
+    expect(html).toContain('data-type="bar"')
+    expect(html).toContain('Effort')
+  })
+
+  it('renders a line chart (golden)', () => {
+    const html = renderToStaticMarkup(
+      <Chart type='line' data={chartData(['value'], [{ label: 'Auth', values: [12] }])} />,
+    )
+    expect(html).toContain('vp-chart')
+    expect(html).toContain('data-type="line"')
+  })
+
+  it('renders a pie chart with its percentage legend list (golden)', () => {
+    const html = renderToStaticMarkup(
+      <Chart
+        type='pie'
+        data={chartData(
+          ['value'],
+          [
+            { label: 'A', values: [3] },
+            { label: 'B', values: [1] },
+          ],
+        )}
+      />,
+    )
+    expect(html).toContain('data-type="pie"')
+    expect(html).toContain('vp-chart__legend')
+    expect(html).toContain('75%')
+  })
+
+  it('renders an area chart without throwing and emits the vp-chart markup (golden)', () => {
+    const html = renderToStaticMarkup(
+      <Chart
+        type='area'
+        title='Traffic'
+        data={chartData(['value'], [{ label: 'Jan', values: [10] }])}
+      />,
+    )
+    expect(html).toContain('vp-chart')
+    expect(html).toContain('data-type="area"')
+    expect(html).toContain('Traffic')
+    // area is a cartesian chart, not a pie, so the pie percentage legend must not render.
+    expect(html).not.toContain('vp-chart__legend')
+  })
+
+  it('throws on an unknown chart type (error)', () => {
+    expect(() =>
+      renderToStaticMarkup(
+        <Chart type='donut' data={chartData(['value'], [{ label: 'x', values: [1] }])} />,
+      ),
+    ).toThrow(/invalid props/)
   })
 })
 

--- a/packages/runtime/theme.css
+++ b/packages/runtime/theme.css
@@ -785,6 +785,92 @@ body {
   text-decoration: line-through;
 }
 
+/* Stat */
+.vp-stat {
+  margin: 1.4rem 0;
+}
+
+/* Small uppercase label, identical to the Checklist title. */
+.vp-stat__title {
+  font-size: 0.68rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--vp-muted);
+  margin-bottom: 0.55rem;
+}
+
+.vp-stat__grid {
+  display: grid;
+  /* Cards reflow into as many columns as fit, dropping to one on narrow screens. */
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, 11rem), 1fr));
+  gap: 0.7rem;
+}
+
+.vp-stat__card {
+  border: 1px solid var(--vp-border);
+  border-radius: 10px;
+  padding: 0.9rem 1rem;
+  background: var(--vp-surface);
+}
+
+/* Intent tints reuse the callout color vars: good maps to the green "tip" palette. */
+.vp-stat__card[data-intent="note"] {
+  background: var(--vp-note-tint);
+  border-color: var(--vp-note-border);
+}
+
+.vp-stat__card[data-intent="good"] {
+  background: var(--vp-tip-tint);
+  border-color: var(--vp-tip-border);
+}
+
+.vp-stat__card[data-intent="warn"] {
+  background: var(--vp-warn-tint);
+  border-color: var(--vp-warn-border);
+}
+
+.vp-stat__card[data-intent="risk"] {
+  background: var(--vp-risk-tint);
+  border-color: var(--vp-risk-border);
+}
+
+.vp-stat__value {
+  font-size: 1.5rem;
+  font-weight: 700;
+  line-height: 1.15;
+  color: var(--vp-text);
+  font-variant-numeric: tabular-nums;
+}
+
+.vp-stat__card[data-intent="note"] .vp-stat__value {
+  color: var(--vp-note);
+}
+
+.vp-stat__card[data-intent="good"] .vp-stat__value {
+  color: var(--vp-tip);
+}
+
+.vp-stat__card[data-intent="warn"] .vp-stat__value {
+  color: var(--vp-warn);
+}
+
+.vp-stat__card[data-intent="risk"] .vp-stat__value {
+  color: var(--vp-risk);
+}
+
+.vp-stat__label {
+  margin-top: 0.3rem;
+  font-size: 0.82rem;
+  color: var(--vp-muted);
+}
+
+.vp-stat__caption {
+  margin-top: 0.35rem;
+  font-size: 0.74rem;
+  color: var(--vp-faint);
+}
+
 /* Mermaid */
 .vp-mermaid {
   margin: 1.4rem 0;

--- a/packages/runtime/theme.css
+++ b/packages/runtime/theme.css
@@ -825,6 +825,13 @@ body {
 .vp-chart__canvas[data-type="pie"] {
   height: 230px;
 }
+/* Radial, polar, and area-fill charts read better with a taller, squarer canvas. */
+.vp-chart__canvas[data-type="gauge"],
+.vp-chart__canvas[data-type="radar"],
+.vp-chart__canvas[data-type="treemap"],
+.vp-chart__canvas[data-type="funnel"] {
+  height: 280px;
+}
 
 /* Fullscreen affordance for code blocks, diagrams, and charts */
 .vp-expandable {

--- a/packages/runtime/theme.css
+++ b/packages/runtime/theme.css
@@ -911,12 +911,15 @@ body {
 .vp-chart__canvas[data-type="pie"] {
   height: 230px;
 }
-/* Radial, polar, and area-fill charts read better with a taller, squarer canvas. */
-.vp-chart__canvas[data-type="gauge"],
+/* Polar and treemap charts read better with a taller, squarer canvas. */
 .vp-chart__canvas[data-type="radar"],
 .vp-chart__canvas[data-type="treemap"],
 .vp-chart__canvas[data-type="funnel"] {
   height: 280px;
+}
+/* A gauge is a 180deg half-arc (wide, not tall), so a shorter canvas avoids dead space below it. */
+.vp-chart__canvas[data-type="gauge"] {
+  height: 180px;
 }
 
 /* Fullscreen affordance for code blocks, diagrams, and charts */

--- a/skills/visual-plan/SKILL.md
+++ b/skills/visual-plan/SKILL.md
@@ -156,7 +156,8 @@ brace errors that break a render.
   One card per bullet, `- <label>: <value> (<intent>) -- <caption>`, where intent is one of
   `note|good|warn|risk` and both `(intent)` and `-- caption` are optional. The value is free text
   (`5 min`, `99.9%`), not a number. Use this for static facts, not time series (use `<Chart>` for
-  those).
+  those). Only add a `<Stat>` when the plan genuinely has standout numbers worth surfacing; most
+  plans have none, and an invented or filler metric is worse than omitting the component entirely.
 
   ```mdx
   <Stat>
@@ -197,6 +198,8 @@ it in paragraphs. Prose is the connective tissue between visuals, never the subs
   two-or-three-file change may need only a short `<FileTree>` and a `<Checklist>`. Do not add a
   diagram or phase that carries no information: an empty 2-node flowchart shows nothing and is worse
   than one plain sentence. Show when there is structure to show; otherwise a tight sentence is fine.
+  The same applies to `<Stat>`: reach for it only when the plan has genuinely meaningful headline
+  numbers, not as a default header on every plan.
 
 ## Composing a plan
 

--- a/skills/visual-plan/SKILL.md
+++ b/skills/visual-plan/SKILL.md
@@ -41,8 +41,8 @@ Begin the file with a single `# Heading`; it becomes the plan title. There is no
 
 ## Components
 
-The data components (`FileTree`, `Chart`, `Compare`, `Matrix`, `Questions`, `Checklist`) take
-their data as **markdown children**, not props: write a normal markdown list (or, for `Matrix`
+The data components (`FileTree`, `Chart`, `Stat`, `Compare`, `Matrix`, `Questions`, `Checklist`)
+take their data as **markdown children**, not props: write a normal markdown list (or, for `Matrix`
 and a multi-series `Chart`, a markdown table) between the tags. Only the scalar settings
 (`title`, `type`, `status`) are attributes. This is fewer tokens and avoids the `{[{ ... }]}`
 brace errors that break a render.
@@ -71,11 +71,21 @@ brace errors that break a render.
   - delete src/gateway/legacy/
   </FileTree>
   ```
-- `<Chart type="bar|line|pie" title="...">` — estimates/metrics. For a single series, one bullet
-  per point, `- <label>: <value>` (value is a number). For multiple series (bar/line only), write
-  a table whose header is `category | series1 | series2`; the header cells after the first name the
-  series (they become the legend), and the first column is the category axis. `pie` is always
-  single-series, so use the list form for it (a table is rejected).
+- `<Chart type="bar|line|area|scatter|radar|gauge|funnel|treemap|pie" title="...">` —
+  estimates/metrics. For a single series, one bullet per point, `- <label>: <value>` (value is a
+  number). For multiple series (`bar`/`line`/`area`/`radar`), write a table whose header is
+  `category | series1 | series2`; the header cells after the first name the series (they become the
+  legend), and the first column is the category axis. The new types take these shapes:
+  - `area` — like `line`: a single-series list or a multi-series table.
+  - `scatter` — a table with exactly **two** value columns, read as x and y: `| point | x | y |`.
+  - `radar` — a multi-series options-by-dimensions table, same shape as a multi-series `bar`.
+  - `gauge` — a single-series list of values on a 0-100 scale.
+  - `funnel` — a single-series list of descending stage values.
+  - `treemap` — a single-series list of `- <label>: <value>`.
+
+  `pie`/`gauge`/`funnel`/`treemap` are always single-series, so use the list form (a table is
+  rejected). Add the `stacked` attribute to a multi-series `bar` or `area`
+  (`<Chart type="bar" stacked>`) to stack the series instead of grouping them.
 
   ```mdx
   <Chart type="bar" title="Effort (days)">
@@ -88,6 +98,10 @@ brace errors that break a render.
   |-------|-----|-----|
   | Auth  | 12  | 30  |
   | DB    | 40  | 120 |
+  </Chart>
+
+  <Chart type="gauge" title="Error budget remaining (%)">
+  - Remaining: 78
   </Chart>
   ```
 - `<Compare>` — weigh approaches side by side as pros/cons cards. Each option is a `## Name`
@@ -137,6 +151,19 @@ brace errors that break a render.
   - [x] Returns 429 over the limit
   - [ ] Dashboards live
   </Checklist>
+  ```
+- `<Stat>` — headline plan metrics as a grid of cards (files changed, estimated uptime, rollout).
+  One card per bullet, `- <label>: <value> (<intent>) -- <caption>`, where intent is one of
+  `note|good|warn|risk` and both `(intent)` and `-- caption` are optional. The value is free text
+  (`5 min`, `99.9%`), not a number. Use this for static facts, not time series (use `<Chart>` for
+  those).
+
+  ```mdx
+  <Stat>
+  - Files changed: 12
+  - Est. uptime: 99.9% (good)
+  - RPO: 5 min (risk) -- worst-case data loss
+  </Stat>
   ```
 - Fenced code blocks are syntax-highlighted (Expressive Code): write ` ```ts ` (or js, json, bash,
   python, go, rust, sql, yaml, etc.) to show a key snippet. Add a file name with


### PR DESCRIPTION
## What

Expands the visual-plan component vocabulary: six new `Chart` types (`area`, `scatter`, `radar`, `gauge`, `funnel`, `treemap`), a `stacked` attribute for bar/area, and a new `Stat` component for headline plan metrics (files changed, uptime, RPO, etc.).

## How

- Chart types are driven by the single `CHART_TYPE_VALUES` enum in `@visualplan/core`, which feeds the zod schema, the static `check`, and the catalog at once. `Chart.tsx` was refactored from a nested ternary into a `type`-keyed render dispatch, then each type added as a recharts branch.
- Stacking is a `stacked` boolean attribute (recharts `stackId`), not new enum types, since it is a render mode of existing multi-series data.
- `Stat` follows the data-component pattern (markdown-list children parsed in the compile pipeline). Because `check.ts`, the `/view` safety gate, and `remark-plan-blocks` derive their component set from the catalog/registries, `Stat` was picked up everywhere with no edits to those files.

## Verification

Full suite green, plus a live browser validation of every new visual which caught and fixed two render defects (radar axis labels rendered rotated/illegible; the gauge rendered as a full donut, now a 180deg half-arc).

- [x] `pnpm lint` passes
- [x] `pnpm format` reports no changes (`biome format .`)
- [x] `pnpm typecheck` passes
- [x] `pnpm build` succeeds
- [x] `pnpm test` passes (176)

## Notes

- Per-type chart bodies have jsdom smoke tests only (recharts renders at 0x0 under jsdom); real rendering is covered by the manual/live validation. Good Playwright candidates exist (radar tick absence, gauge arc geometry, Stat intent colors, stacked-bar DOM) as a follow-up.
- The new vocabulary works from the workspace build now; it reaches the global `vplan` command only once a release is cut (published `0.8.4` predates it).
- Root `AGENTS.md` gained a convention to keep `skills/visual-plan/SKILL.md` in sync when the vocabulary changes.
