### PR TITLE
docs: list new chart types and Stat in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 
 Turn an AI agent's implementation and design plans into polished, visual web pages instead of
 walls of text. A plan is written as MDX and compiled to a single self-contained HTML page:
-architecture diagrams, charts, file-change trees, option comparisons, callouts, math, and a
-numbered phase timeline.
+architecture diagrams, charts, metric cards, file-change trees, option comparisons, callouts,
+math, and a numbered phase timeline.
 
 **Documentation and live examples: [visualplan.dev](https://visualplan.dev)**
 
@@ -75,7 +75,8 @@ flowchart LR
  - ` ```math ` (LaTeX, typeset as MathML)
  - `Phase` (timeline/execution/planning steps)
  - `FileTree` (file-change maps)
- - `Chart` (bar/line/pie graphs)
+ - `Chart` (bar, line, area, scatter, radar, gauge, funnel, treemap, and pie graphs, with optional stacking)
+ - `Stat` (headline metric cards)
  - `Compare` (option tradeoffs)
  - `Matrix` (scorecards)
  - `Callout` (note/tip/risk/decision/warning)


### PR DESCRIPTION
## What

Update the README to list the chart types and the `Stat` component added in 0.9.0.

## How

The "All components" list now shows the full nine `Chart` types (bar, line, area, scatter, radar, gauge, funnel, treemap, pie) with optional stacking, adds a `Stat` (headline metric cards) entry, and mentions metric cards in the intro summary.

## Verification

Docs-only change (README); verified by inspection that the listed types and `Stat` match the shipped 0.9.0 vocabulary. No source changed, so the code checks below were not re-run for this PR (CI runs them regardless).

## Notes

Follows the 0.9.0 release that introduced these.
