### PR TITLE
feat: file-type icons and inline comments for FileTree

### DIFF
--- a/packages/app/AGENTS.md
+++ b/packages/app/AGENTS.md
@@ -59,7 +59,14 @@ looks like a locally-built one. Untrusted source from a URL is the core risk, ha
   `rehype-expressive-code`. Heavy, so it is imported lazily (a code-split chunk behind a spinner).
   It sets shiki's `engine: 'javascript'` (no WebAssembly in the browser); this is set ONLY here, not
   in the shared `baseExpressiveCodeOptions`, so the CLI keeps oniguruma and its output stays
-  byte-stable. File-type icons are omitted in the browser (the plugin is disk-based and Node-only).
+  byte-stable. Code-block file-type icons are omitted in the browser (that EC plugin is disk-based
+  and Node-only). FileTree file icons, however, ARE shown: `compile-browser.ts` appends
+  `remark-filetree-icons-browser.ts` after the shared `remarkPlugins`. That plugin lazily
+  `import()`s `file-icons-browser.ts` ONLY when a plan contains a `<FileTree>`, so the 324 KB icon
+  manifest is a code-split chunk no other page pays for. The SVGs are loaded PER ICON via a non-eager
+  `import.meta.glob` over `material-icon-theme/icons/*.svg` (one tiny chunk each), so a plan fetches
+  only the icon types it uses, not the 5 MB set. Resolution is single-sourced through
+  `@visualplan/compile/icon-resolution`, so `/view` and the CLI pick identical icons.
 - `src/lib/render-plan.tsx` wraps the compiled component in the runtime shell (`MDXProvider` +
   `Layout` + `components` + `theme.css`), identical to the CLI's `mount`. The runtime `ShareButton`
   self-hides here (no `__VP_SHARE__`).

--- a/packages/app/AGENTS.md
+++ b/packages/app/AGENTS.md
@@ -62,11 +62,16 @@ looks like a locally-built one. Untrusted source from a URL is the core risk, ha
   byte-stable. Code-block file-type icons are omitted in the browser (that EC plugin is disk-based
   and Node-only). FileTree file icons, however, ARE shown: `compile-browser.ts` appends
   `remark-filetree-icons-browser.ts` after the shared `remarkPlugins`. That plugin lazily
-  `import()`s `file-icons-browser.ts` ONLY when a plan contains a `<FileTree>`, so the 324 KB icon
-  manifest is a code-split chunk no other page pays for. The SVGs are loaded PER ICON via a non-eager
+  `import()`s `file-icons-browser.ts` ONLY when a plan contains a `<FileTree>`, so the icon resolver
+  is a code-split chunk no other page pays for. The SVGs are loaded PER ICON via a non-eager
   `import.meta.glob` over `material-icon-theme/icons/*.svg` (one tiny chunk each), so a plan fetches
   only the icon types it uses, not the 5 MB set. Resolution is single-sourced through
   `@visualplan/compile/icon-resolution`, so `/view` and the CLI pick identical icons.
+  **Do not reintroduce a reference to the manifest's `iconDefinitions` in `file-icons-browser.ts`:**
+  it is 71 KB and Vite tree-shakes it only while it stays unreferenced. The SVG basename is derived
+  as `<iconName>.svg`, with the build-time `virtual:material-icon-clones` map (emitted by
+  `materialIconClones` in `astro.config.mjs`) covering the ~72 `.clone.svg` icons. That keeps the
+  code-split icon chunk ~256 KB instead of ~324 KB.
 - `src/lib/render-plan.tsx` wraps the compiled component in the runtime shell (`MDXProvider` +
   `Layout` + `components` + `theme.css`), identical to the CLI's `mount`. The runtime `ShareButton`
   self-hides here (no `__VP_SHARE__`).

--- a/packages/app/astro.config.mjs
+++ b/packages/app/astro.config.mjs
@@ -1,6 +1,38 @@
+import { readFileSync } from 'node:fs'
+import { createRequire } from 'node:module'
 import mdx from '@astrojs/mdx'
 import react from '@astrojs/react'
 import { defineConfig } from 'astro/config'
+
+/**
+ * Emit a virtual module with the Material icon "clones": the ~72 icons whose SVG file name is NOT
+ * `<iconName>.svg` (they end in `.clone.svg`). The `/view` icon loader derives every other basename
+ * as `<iconName>.svg`, so importing this tiny map (~2 KB) lets it avoid pulling the manifest's 71 KB
+ * `iconDefinitions` table into the code-split icon chunk, cutting it by ~22%. The map is computed
+ * from the installed manifest at build time, so it never drifts from the package version.
+ */
+function materialIconClones() {
+  const VIRTUAL_ID = 'virtual:material-icon-clones'
+  const RESOLVED_ID = `\0${VIRTUAL_ID}`
+  const require = createRequire(import.meta.url)
+  return {
+    name: 'visualplan:material-icon-clones',
+    resolveId(id) {
+      return id === VIRTUAL_ID ? RESOLVED_ID : null
+    },
+    load(id) {
+      if (id !== RESOLVED_ID) return null
+      const manifestPath = require.resolve('material-icon-theme/dist/material-icons.json')
+      const manifest = JSON.parse(readFileSync(manifestPath, 'utf8'))
+      const clones = {}
+      for (const [name, definition] of Object.entries(manifest.iconDefinitions)) {
+        const basename = definition.iconPath.split('/').pop()
+        if (basename !== `${name}.svg`) clones[name] = basename
+      }
+      return `export default ${JSON.stringify(clones)}`
+    },
+  }
+}
 
 // visualplan.dev is a custom apex domain served by GitHub Pages, so the site
 // roots at `/` (no `base`). `site` is the canonical origin used for absolute
@@ -11,6 +43,7 @@ export default defineConfig({
   // react() renders the @visualplan/runtime plan components (Chart hydrates as an island);
   // mdx() lets the authoring page mix prose, code samples, and live component demos.
   integrations: [react(), mdx()],
+  vite: { plugins: [materialIconClones()] },
   markdown: {
     // Dual-theme Shiki to match the rendered-plan highlighting (github light/dark).
     // `defaultColor: false` emits only `--shiki-light` / `--shiki-dark` CSS vars

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -23,6 +23,7 @@
     "@visualplan/runtime": "workspace:*",
     "astro": "^5.16.2",
     "beautiful-mermaid": "^1.1.3",
+    "material-icon-theme": "^5.35.0",
     "react": "^19.2.7",
     "react-dom": "^19.2.7",
     "recharts": "^3.8.1",

--- a/packages/app/src/lib/compile-browser.ts
+++ b/packages/app/src/lib/compile-browser.ts
@@ -4,6 +4,7 @@ import { assertPlanIsSafe, baseExpressiveCodeOptions, remarkPlugins } from '@vis
 import type { ComponentType } from 'react'
 import * as runtime from 'react/jsx-runtime'
 import rehypeExpressiveCode from 'rehype-expressive-code'
+import { remarkFileTreeIconsBrowser } from './remark-filetree-icons-browser'
 
 /**
  * Compile a plan's MDX source to a React component IN THE BROWSER, mirroring the CLI's Node render
@@ -26,7 +27,10 @@ export async function compilePlan(source: string): Promise<ComponentType> {
   const mdxModule = await evaluate(source, {
     ...runtime,
     useMDXComponents,
-    remarkPlugins,
+    // remarkFileTreeIconsBrowser is appended AFTER the shared list (so it sees the serialized
+    // FileTree `files` prop) and lazily code-splits the Material icon set, fetched only when a plan
+    // contains a FileTree. Mirrors the CLI's remarkFileTreeIcons but per-icon lazy in the browser.
+    remarkPlugins: [...remarkPlugins, remarkFileTreeIconsBrowser],
     rehypePlugins: [
       [rehypeExpressiveCode, { ...baseExpressiveCodeOptions, shiki: { engine: 'javascript' } }],
     ],

--- a/packages/app/src/lib/file-icons-browser.ts
+++ b/packages/app/src/lib/file-icons-browser.ts
@@ -1,4 +1,5 @@
 import { type IconManifest, resolveIconName } from '@visualplan/compile/icon-resolution'
+import clones from 'virtual:material-icon-clones'
 import manifest from 'material-icon-theme/dist/material-icons.json'
 
 /**
@@ -11,6 +12,10 @@ import manifest from 'material-icon-theme/dist/material-icons.json'
  * tiny chunk per `.svg`, so a rendered plan fetches only the handful of icon types it uses, not the
  * full 5 MB set. Resolution order is single-sourced through `@visualplan/compile`'s isomorphic
  * `resolveIconName`, so `/view` and the CLI pick identical icons.
+ *
+ * An icon's SVG file is `<iconName>.svg` except for the ~72 `.clone.svg` icons, which the
+ * build-time `virtual:material-icon-clones` map covers. Deriving the basename this way keeps the
+ * manifest's 71 KB `iconDefinitions` table out of this code-split chunk (Vite tree-shakes it).
  */
 const typedManifest = manifest as unknown as IconManifest
 
@@ -34,8 +39,8 @@ export async function fileIconSvg(fileName: string): Promise<string | null> {
   const iconName = resolveIconName(typedManifest, fileName)
   const cached = svgCache.get(iconName)
   if (cached !== undefined) return cached
-  const basename = typedManifest.iconDefinitions[iconName]?.iconPath.split('/').pop()
-  const loader = basename ? loaderByBasename.get(basename) : undefined
+  const basename = clones[iconName] ?? `${iconName}.svg`
+  const loader = loaderByBasename.get(basename)
   const svg = loader ? await loader() : null
   svgCache.set(iconName, svg)
   return svg

--- a/packages/app/src/lib/file-icons-browser.ts
+++ b/packages/app/src/lib/file-icons-browser.ts
@@ -1,0 +1,42 @@
+import { type IconManifest, resolveIconName } from '@visualplan/compile/icon-resolution'
+import manifest from 'material-icon-theme/dist/material-icons.json'
+
+/**
+ * The browser counterpart of the CLI's `fileIconSvg`: resolves a file name to its Material Icon
+ * Theme SVG markup for the `/view` shared-plan renderer. This module is imported lazily (only when
+ * a plan actually contains a `<FileTree>`), so the 449 KB manifest below is a code-split chunk that
+ * never weighs on the main bundle.
+ *
+ * The icon SVGs themselves are loaded PER ICON: `import.meta.glob` (non-eager) makes Vite emit one
+ * tiny chunk per `.svg`, so a rendered plan fetches only the handful of icon types it uses, not the
+ * full 5 MB set. Resolution order is single-sourced through `@visualplan/compile`'s isomorphic
+ * `resolveIconName`, so `/view` and the CLI pick identical icons.
+ */
+const typedManifest = manifest as unknown as IconManifest
+
+const iconLoaders = import.meta.glob('../../node_modules/material-icon-theme/icons/*.svg', {
+  query: '?raw',
+  import: 'default',
+}) as Record<string, () => Promise<string>>
+
+/** The per-icon loaders are keyed by their full glob path; index them by SVG basename instead. */
+const loaderByBasename = new Map<string, () => Promise<string>>()
+for (const [path, loader] of Object.entries(iconLoaders)) {
+  const basename = path.split('/').pop()
+  if (basename) loaderByBasename.set(basename, loader)
+}
+
+/** Resolved icon markup, keyed by icon name (`null` marks a name with no loadable SVG). */
+const svgCache = new Map<string, string | null>()
+
+/** Resolve a basename to its Material icon SVG markup, fetching only that icon's chunk. */
+export async function fileIconSvg(fileName: string): Promise<string | null> {
+  const iconName = resolveIconName(typedManifest, fileName)
+  const cached = svgCache.get(iconName)
+  if (cached !== undefined) return cached
+  const basename = typedManifest.iconDefinitions[iconName]?.iconPath.split('/').pop()
+  const loader = basename ? loaderByBasename.get(basename) : undefined
+  const svg = loader ? await loader() : null
+  svgCache.set(iconName, svg)
+  return svg
+}

--- a/packages/app/src/lib/remark-filetree-icons-browser.ts
+++ b/packages/app/src/lib/remark-filetree-icons-browser.ts
@@ -1,0 +1,64 @@
+interface MdNode {
+  type?: string
+  name?: string | null
+  attributes?: Array<{ type?: string; name?: string; value?: unknown }>
+  children?: MdNode[]
+}
+
+interface FileEntry {
+  path: string
+  change: string
+  from?: string
+  comment?: string
+  icon?: string
+}
+
+/** Collect every `<FileTree>` JSX node in the tree (manual walk, so this stays dependency-free). */
+function collectFileTrees(node: MdNode, found: MdNode[]): void {
+  if (node.type === 'mdxJsxFlowElement' && node.name === 'FileTree') found.push(node)
+  for (const child of node.children ?? []) collectFileTrees(child, found)
+}
+
+/**
+ * The `/view` counterpart of the CLI's `remarkFileTreeIcons`: it inlines a Material file-type icon
+ * into each `<FileTree>` entry so a shared plan shows the same colored icons a local render does.
+ *
+ * It runs AFTER `remarkPlanBlocks` (which serializes the entries onto the `files` attribute) and is
+ * appended only in the browser compiler. Crucially, the heavy icon module is imported LAZILY and
+ * only when a plan actually contains a `<FileTree>`, so a plan without one never downloads the icon
+ * manifest or any SVG chunk. A directory entry (a path ending in `/`) keeps its folder icon.
+ */
+export function remarkFileTreeIconsBrowser() {
+  return async (tree: MdNode) => {
+    const fileTrees: MdNode[] = []
+    collectFileTrees(tree, fileTrees)
+    const targets: Array<{ attribute: { value?: unknown }; entries: FileEntry[] }> = []
+    for (const node of fileTrees) {
+      const attribute = (node.attributes ?? []).find(
+        candidate => candidate.type === 'mdxJsxAttribute' && candidate.name === 'files',
+      )
+      if (!attribute || typeof attribute.value !== 'string') continue
+      try {
+        const entries = JSON.parse(attribute.value)
+        if (Array.isArray(entries)) targets.push({ attribute, entries })
+      } catch {
+        // A non-JSON files attribute is left untouched; the component surfaces the error at render.
+      }
+    }
+    if (!targets.length) return
+
+    // Code-split: the manifest + per-icon loaders load only now, when a FileTree is present.
+    const { fileIconSvg } = await import('./file-icons-browser')
+    for (const { attribute, entries } of targets) {
+      await Promise.all(
+        entries.map(async entry => {
+          if (!entry || typeof entry.path !== 'string' || entry.path.endsWith('/')) return
+          const basename = entry.path.split('/').filter(Boolean).pop() ?? entry.path
+          const icon = await fileIconSvg(basename)
+          if (icon) entry.icon = icon
+        }),
+      )
+      attribute.value = JSON.stringify(entries)
+    }
+  }
+}

--- a/packages/app/src/virtual-material-icons.d.ts
+++ b/packages/app/src/virtual-material-icons.d.ts
@@ -1,0 +1,9 @@
+/**
+ * The build-time clones map emitted by the `materialIconClones` Vite plugin (astro.config.mjs):
+ * Material icon names whose SVG file is `<name>.clone.svg` rather than `<name>.svg`, mapped to that
+ * actual basename. The `/view` icon loader reads it to avoid bundling the manifest's iconDefinitions.
+ */
+declare module 'virtual:material-icon-clones' {
+  const clones: Record<string, string>
+  export default clones
+}

--- a/packages/cli/AGENTS.md
+++ b/packages/cli/AGENTS.md
@@ -15,7 +15,9 @@ renders a plan to a self-contained HTML page). Built with tsup to `dist/index.js
   `baseExpressiveCodeOptions` from `@visualplan/compile` (so the CLI and `/view` highlight
   identically), and appends the Node-only `@visualplan/compile/file-icons` plugin (a Material Icon
   Theme file-type icon in a titled block's header, `iconClass: 'vp-file-icon'` so `theme.css` can
-  size it). Color chips and file icons both inline their output at build time, so the single-file
+  size it). It also appends the Node-only `remarkFileTreeIcons` (`@visualplan/compile/filetree-icons`)
+  to the remark chain, which inlines a Material file-type icon per `<FileTree>` entry; both are
+  CLI-only so the browser bundle never loads `material-icon-theme`. Color chips and file icons both inline their output at build time, so the single-file
   invariant holds. `src/build/check.ts` — the static AST
   validator. It also runs each ` ```math ` block through Temml and each ` ```mermaid ` block through
   `beautiful-mermaid`'s `renderMermaidSVG` (the same renderer the runtime `Mermaid` component calls)

--- a/packages/cli/src/build/compile.ts
+++ b/packages/cli/src/build/compile.ts
@@ -7,6 +7,7 @@ import { fileURLToPath } from 'node:url'
 import mdx from '@mdx-js/rollup'
 import { baseExpressiveCodeOptions, remarkPlugins } from '@visualplan/compile'
 import { pluginFileIcons } from '@visualplan/compile/file-icons'
+import { remarkFileTreeIcons } from '@visualplan/compile/filetree-icons'
 import { encodePlan } from '@visualplan/core/share'
 import rehypeExpressiveCode, { type RehypeExpressiveCodeOptions } from 'rehype-expressive-code'
 import { build, createServer, type InlineConfig, type Plugin } from 'vite'
@@ -65,7 +66,10 @@ function mdxPlugin(): Plugin {
       providerImportSource: '@mdx-js/react',
       // The ordered list (frontmatter, gfm, plan-blocks, mermaid, math) is shared with the
       // /view browser compiler via @visualplan/compile so both render plans identically.
-      remarkPlugins,
+      // remarkFileTreeIcons is appended CLI-only: it inlines Material file icons (Node-only,
+      // reads SVGs from disk) after plan-blocks serializes the FileTree data, so the browser
+      // bundle never pulls in material-icon-theme and /view falls back to a generic icon.
+      remarkPlugins: [...remarkPlugins, remarkFileTreeIcons],
       rehypePlugins: [[rehypeExpressiveCode, expressiveCodeOptions]],
     }),
   }

--- a/packages/cli/templates/example.mdx
+++ b/packages/cli/templates/example.mdx
@@ -60,8 +60,8 @@ flowchart LR
   2. Return `429` with a `Retry-After` header when the window is exceeded.
 
   <FileTree>
-  - add src/gateway/rate-limiter.ts
-  - modify src/gateway/middleware.ts
+  - add src/gateway/rate-limiter.ts -- sliding-window check against Redis
+  - modify src/gateway/middleware.ts -- mount the limiter behind the flag
   - move src/gateway/throttle.ts -> src/gateway/rate-limiter-legacy.ts
   - delete src/gateway/legacy/
   </FileTree>

--- a/packages/compile/AGENTS.md
+++ b/packages/compile/AGENTS.md
@@ -50,9 +50,14 @@ through the workspace.
   plugins. `remark-math` converts LaTeX to MathML with `temml` at build time (isomorphic).
 - `src/expressive-code.ts` — `baseExpressiveCodeOptions` (themes, frames, ink styling, color
   chips). NO file-icons plugin (Node-only).
+- `src/icon-resolution.ts` — the **isomorphic** Material-icon resolution core
+  (`@visualplan/compile/icon-resolution` subpath): a pure `resolveIconName(manifest, ...)` over a
+  passed-in manifest, no fs. Single-sources the resolution order for the Node `file-icons.ts` AND
+  the app's browser `/view` icon chunk, so both pick identical icons.
 - `src/file-icons.ts` — the Node-only Material file-icons EC plugin (`@visualplan/compile/file-icons`
-  subpath). Reads `material-icon-theme`'s manifest + SVGs from disk; `iconNameForFile` (resolution)
-  and `fileIconSvg` (resolution + raw SVG markup, cached) are exported. CLI-only.
+  subpath). Loads `material-icon-theme`'s manifest from disk and delegates to `resolveIconName`;
+  `iconNameForFile` (resolution) and `fileIconSvg` (resolution + raw SVG markup, cached) are
+  exported. CLI-only.
 - `src/remark-filetree-icons.ts` — the Node-only `remarkFileTreeIcons` plugin
   (`@visualplan/compile/filetree-icons` subpath). Runs AFTER `remark-plan-blocks` and inlines a
   `fileIconSvg(basename)` per FileTree entry onto the serialized `files` prop (skipping `/`

--- a/packages/compile/AGENTS.md
+++ b/packages/compile/AGENTS.md
@@ -43,12 +43,20 @@ through the workspace.
   `(intent)` is validated against `STAT_INTENT_VALUES`). `parseChart` adds shape guards:
   `SINGLE_SERIES_CHARTS` (`pie`, `gauge`, `funnel`, `treemap`) reject a multi-series table, and
   `scatter` requires a table with exactly two value columns (the list form is rejected).
+  `parseFileTree` splits a trailing `' -- <note>'` (or a dangling `' --'`) into an optional
+  `comment` BEFORE the change/path/move parse, so a comment containing `->` is never read as a move
+  arrow; icons are NOT resolved here (that is the CLI-only `remark-filetree-icons` pass).
 - `src/remark-plan-blocks.ts` / `remark-mermaid.ts` / `remark-math.ts` — the three custom remark
   plugins. `remark-math` converts LaTeX to MathML with `temml` at build time (isomorphic).
 - `src/expressive-code.ts` — `baseExpressiveCodeOptions` (themes, frames, ink styling, color
   chips). NO file-icons plugin (Node-only).
 - `src/file-icons.ts` — the Node-only Material file-icons EC plugin (`@visualplan/compile/file-icons`
-  subpath). Reads `material-icon-theme`'s manifest + SVGs from disk; `iconNameForFile` is exported
-  for tests. CLI-only.
+  subpath). Reads `material-icon-theme`'s manifest + SVGs from disk; `iconNameForFile` (resolution)
+  and `fileIconSvg` (resolution + raw SVG markup, cached) are exported. CLI-only.
+- `src/remark-filetree-icons.ts` — the Node-only `remarkFileTreeIcons` plugin
+  (`@visualplan/compile/filetree-icons` subpath). Runs AFTER `remark-plan-blocks` and inlines a
+  `fileIconSvg(basename)` per FileTree entry onto the serialized `files` prop (skipping `/`
+  directories). Appended only by the CLI's remark chain, never in the isomorphic `remarkPlugins`,
+  so the browser bundle never pulls in `material-icon-theme`.
 - `src/safety-gate.ts` — `assertPlanIsSafe(source)`; throws `UnsafePlanError` (carries line/column).
 - `tests/` — `plan-blocks`, `file-icons`, and `safety-gate` (node environment).

--- a/packages/compile/package.json
+++ b/packages/compile/package.json
@@ -11,6 +11,7 @@
     ".": "./src/index.ts",
     "./file-icons": "./src/file-icons.ts",
     "./filetree-icons": "./src/remark-filetree-icons.ts",
+    "./icon-resolution": "./src/icon-resolution.ts",
     "./package.json": "./package.json"
   },
   "scripts": {

--- a/packages/compile/package.json
+++ b/packages/compile/package.json
@@ -10,6 +10,7 @@
   "exports": {
     ".": "./src/index.ts",
     "./file-icons": "./src/file-icons.ts",
+    "./filetree-icons": "./src/remark-filetree-icons.ts",
     "./package.json": "./package.json"
   },
   "scripts": {

--- a/packages/compile/src/file-icons.ts
+++ b/packages/compile/src/file-icons.ts
@@ -5,6 +5,7 @@ import type { ExpressiveCodePlugin } from '@expressive-code/core'
 import { addClassName, getClassNames, select, setProperty } from '@expressive-code/core/hast'
 import type { Element, ElementContent } from 'hast'
 import { fromHtml } from 'hast-util-from-html'
+import { type IconManifest, resolveIconName } from './icon-resolution.js'
 
 /**
  * An Expressive Code plugin that prepends a Material Icon Theme file-type icon to a code block's
@@ -19,15 +20,6 @@ import { fromHtml } from 'hast-util-from-html'
 const require = createRequire(import.meta.url)
 const packageRoot = dirname(require.resolve('material-icon-theme/package.json'))
 
-interface IconManifest {
-  iconDefinitions: Record<string, { iconPath: string }>
-  fileNames: Record<string, string>
-  fileExtensions: Record<string, string>
-  languageIds: Record<string, string>
-  /** The icon name used for any file that matches nothing more specific. */
-  file: string
-}
-
 const manifest: IconManifest = JSON.parse(
   readFileSync(join(packageRoot, 'dist', 'material-icons.json'), 'utf8'),
 )
@@ -36,26 +28,15 @@ const manifest: IconManifest = JSON.parse(
 const iconCache = new Map<string, Element | null>()
 
 /**
- * Resolve a title's filename (with an optional Expressive Code language id and explicit override)
- * to a Material icon name: an exact filename wins, then the longest matching extension, then the
- * language, then the default file icon.
+ * Resolve a title's filename to a Material icon name through this package's disk-loaded manifest,
+ * delegating the resolution order to the isomorphic `resolveIconName`.
  */
 export function iconNameForFile(
   fileName: string,
   language?: string,
   iconOverride?: string,
 ): string {
-  if (iconOverride && manifest.iconDefinitions[iconOverride]) return iconOverride
-  const name = fileName.toLowerCase()
-  if (manifest.fileNames[name]) return manifest.fileNames[name]
-  // Try compound extensions before simple ones, e.g. "d.ts" before "ts", "test.tsx" before "tsx".
-  const segments = name.split('.')
-  for (let i = 1; i < segments.length; i++) {
-    const extension = segments.slice(i).join('.')
-    if (manifest.fileExtensions[extension]) return manifest.fileExtensions[extension]
-  }
-  if (language && manifest.languageIds[language]) return manifest.languageIds[language]
-  return manifest.file
+  return resolveIconName(manifest, fileName, language, iconOverride)
 }
 
 /** Resolved raw icon SVG markup, keyed by icon name (`null` marks a name with no usable icon). */

--- a/packages/compile/src/file-icons.ts
+++ b/packages/compile/src/file-icons.ts
@@ -58,6 +58,27 @@ export function iconNameForFile(
   return manifest.file
 }
 
+/** Resolved raw icon SVG markup, keyed by icon name (`null` marks a name with no usable icon). */
+const svgCache = new Map<string, string | null>()
+
+/**
+ * Resolve a file name to its Material Icon Theme SVG markup, or `null` if none resolves. Used by
+ * the CLI's remark-filetree-icons pass to inline a per-file icon into the FileTree data prop, so
+ * the self-contained page needs no external asset. Pass a basename, not a full path, so an exact
+ * filename match (e.g. `package.json`) wins over its extension.
+ */
+export function fileIconSvg(fileName: string): string | null {
+  const iconName = iconNameForFile(fileName)
+  const cached = svgCache.get(iconName)
+  if (cached !== undefined) return cached
+  const definition = manifest.iconDefinitions[iconName]
+  const svg = definition
+    ? readFileSync(join(packageRoot, 'dist', definition.iconPath), 'utf8')
+    : null
+  svgCache.set(iconName, svg)
+  return svg
+}
+
 /** Read and parse an icon SVG into a hast element once, caching by icon name. */
 function loadIcon(iconName: string): Element | null {
   const cached = iconCache.get(iconName)

--- a/packages/compile/src/icon-resolution.ts
+++ b/packages/compile/src/icon-resolution.ts
@@ -1,0 +1,39 @@
+/**
+ * The isomorphic core of Material Icon Theme resolution: a pure function over the parsed manifest,
+ * with no filesystem or Node access. The Node side (`file-icons.ts`) loads the manifest from disk
+ * and the browser side (the app's `/view` icon chunk) imports it as JSON, but both resolve a file
+ * name to an icon name through this single source so the CLI and `/view` pick identical icons.
+ */
+export interface IconManifest {
+  iconDefinitions: Record<string, { iconPath: string }>
+  fileNames: Record<string, string>
+  fileExtensions: Record<string, string>
+  languageIds: Record<string, string>
+  /** The icon name used for any file that matches nothing more specific. */
+  file: string
+}
+
+/**
+ * Resolve a file name (with an optional language id and explicit override) to a Material icon name:
+ * an exact filename wins, then the longest matching compound extension, then the language, then the
+ * default file icon. Pass a basename, not a full path, so an exact filename match (e.g.
+ * `package.json`) is not shadowed by a leading path segment.
+ */
+export function resolveIconName(
+  manifest: IconManifest,
+  fileName: string,
+  language?: string,
+  iconOverride?: string,
+): string {
+  if (iconOverride && manifest.iconDefinitions[iconOverride]) return iconOverride
+  const name = fileName.toLowerCase()
+  if (manifest.fileNames[name]) return manifest.fileNames[name]
+  // Try compound extensions before simple ones, e.g. "d.ts" before "ts", "test.tsx" before "tsx".
+  const segments = name.split('.')
+  for (let i = 1; i < segments.length; i++) {
+    const extension = segments.slice(i).join('.')
+    if (manifest.fileExtensions[extension]) return manifest.fileExtensions[extension]
+  }
+  if (language && manifest.languageIds[language]) return manifest.languageIds[language]
+  return manifest.file
+}

--- a/packages/compile/src/plan-blocks.ts
+++ b/packages/compile/src/plan-blocks.ts
@@ -94,7 +94,7 @@ function rowCells(row: MdNode): string[] {
 
 function parseFileTree(node: MdNode): BlockResult {
   const issues: BlockIssue[] = []
-  const files: Array<{ path: string; change: string; from?: string }> = []
+  const files: Array<{ path: string; change: string; from?: string; comment?: string }> = []
   const list = firstList(node)
   if (!list) {
     issues.push({
@@ -104,7 +104,19 @@ function parseFileTree(node: MdNode): BlockResult {
     return { value: files, issues }
   }
   for (const item of list.children ?? []) {
-    const text = toText(item).trim()
+    const raw = toText(item).trim()
+    // A " -- <note>" trailer is split off first so the change/path/move parse below never sees it
+    // (and a comment containing "->" cannot be mistaken for a move arrow). A dangling " --" (an
+    // empty note, whose trailing space markdown already trimmed) is stripped so the path stays clean.
+    const dash = raw.indexOf(' -- ')
+    let text = raw
+    let comment: string | undefined
+    if (dash !== -1) {
+      text = raw.slice(0, dash).trim()
+      comment = raw.slice(dash + 4).trim() || undefined
+    } else if (raw.endsWith(' --')) {
+      text = raw.slice(0, -3).trim()
+    }
     const space = text.indexOf(' ')
     const change = space === -1 ? text : text.slice(0, space)
     let path = space === -1 ? '' : text.slice(space + 1).trim()
@@ -132,7 +144,7 @@ function parseFileTree(node: MdNode): BlockResult {
     } else if (!path) {
       issues.push({ ...pos(item), message: `<FileTree> item "${text}" is missing a file path.` })
     }
-    files.push(from ? { path, change, from } : { path, change })
+    files.push({ path, change, ...(from ? { from } : {}), ...(comment ? { comment } : {}) })
   }
   return { value: files, issues }
 }

--- a/packages/compile/src/remark-filetree-icons.ts
+++ b/packages/compile/src/remark-filetree-icons.ts
@@ -1,0 +1,57 @@
+import { visit } from 'unist-util-visit'
+import { fileIconSvg } from './file-icons.js'
+
+interface MdxJsxAttribute {
+  type: string
+  name?: string
+  value?: unknown
+}
+
+interface MdxJsxElement {
+  type: string
+  name?: string | null
+  attributes?: MdxJsxAttribute[]
+}
+
+interface FileEntry {
+  path: string
+  change: string
+  from?: string
+  comment?: string
+  icon?: string
+}
+
+/**
+ * A Node-only remark pass that inlines a Material Icon Theme file-type icon into each `<FileTree>`
+ * entry. It runs AFTER `remarkPlanBlocks` (which serializes the entries onto the `files` attribute)
+ * and is added only in the CLI render path, so the browser bundle and the in-browser `/view`
+ * compiler never load `material-icon-theme`; those plans fall back to the runtime's generic icon.
+ *
+ * A directory entry (a path ending in `/`) keeps the folder icon and is left untouched. The icon
+ * SVG comes from a trusted build-time dependency, so the runtime injects it as-is.
+ */
+export function remarkFileTreeIcons() {
+  return (tree: unknown) => {
+    visit(tree as never, 'mdxJsxFlowElement', (node: MdxJsxElement) => {
+      if (node.name !== 'FileTree') return
+      const attribute = (node.attributes ?? []).find(
+        candidate => candidate.type === 'mdxJsxAttribute' && candidate.name === 'files',
+      )
+      if (!attribute || typeof attribute.value !== 'string') return
+      let entries: FileEntry[]
+      try {
+        entries = JSON.parse(attribute.value)
+      } catch {
+        return
+      }
+      if (!Array.isArray(entries)) return
+      for (const entry of entries) {
+        if (!entry || typeof entry.path !== 'string' || entry.path.endsWith('/')) continue
+        const basename = entry.path.split('/').filter(Boolean).pop() ?? entry.path
+        const icon = fileIconSvg(basename)
+        if (icon) entry.icon = icon
+      }
+      attribute.value = JSON.stringify(entries)
+    })
+  }
+}

--- a/packages/compile/tests/file-icons.test.ts
+++ b/packages/compile/tests/file-icons.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment node
 import { describe, expect, it } from 'vitest'
-import { iconNameForFile } from '../src/file-icons.js'
+import { fileIconSvg, iconNameForFile } from '../src/file-icons.js'
 
 // iconNameForFile resolves a title's filename to a Material Icon Theme icon name through the
 // package's published manifest, so these assertions pin the resolution order against real data.
@@ -31,5 +31,17 @@ describe('iconNameForFile', () => {
   it('falls back to the language id, then the default file icon (error)', () => {
     expect(iconNameForFile('extensionless', 'typescript')).toBe('typescript')
     expect(iconNameForFile('mystery.zzznope')).toBe('file')
+  })
+})
+
+describe('fileIconSvg', () => {
+  it('returns the resolved icon SVG markup for a known type (golden)', () => {
+    const svg = fileIconSvg('routes.ts')
+    expect(svg).toMatch(/^<svg[\s>]/)
+  })
+
+  it('returns the default file icon SVG for an unknown extension (edge)', () => {
+    // iconNameForFile resolves "mystery.zzznope" to the "file" default, which has an SVG.
+    expect(fileIconSvg('mystery.zzznope')).toMatch(/<svg/)
   })
 })

--- a/packages/compile/tests/plan-blocks.test.ts
+++ b/packages/compile/tests/plan-blocks.test.ts
@@ -71,6 +71,35 @@ describe('FileTree block', () => {
     expect(issues).toEqual([])
     expect(value).toEqual([{ path: 'src/legacy/', change: 'delete' }])
   })
+
+  it('splits a " -- " trailer into an inline comment (golden)', () => {
+    const { value, issues } = parseBlock(
+      'FileTree',
+      '<FileTree>\n- modify src/b.ts -- tighten validation\n</FileTree>\n',
+    )
+    expect(issues).toEqual([])
+    expect(value).toEqual([{ path: 'src/b.ts', change: 'modify', comment: 'tighten validation' }])
+  })
+
+  it('keeps a comment on a move and never reads its "->" as the arrow (edge)', () => {
+    const { value, issues } = parseBlock(
+      'FileTree',
+      '<FileTree>\n- move src/old.ts -> src/new.ts -- renamed; old -> new\n</FileTree>\n',
+    )
+    expect(issues).toEqual([])
+    expect(value).toEqual([
+      { path: 'src/new.ts', change: 'move', from: 'src/old.ts', comment: 'renamed; old -> new' },
+    ])
+  })
+
+  it('drops an empty comment after a dangling " -- " (edge)', () => {
+    const { value, issues } = parseBlock(
+      'FileTree',
+      '<FileTree>\n- add src/a.ts -- \n</FileTree>\n',
+    )
+    expect(issues).toEqual([])
+    expect(value).toEqual([{ path: 'src/a.ts', change: 'add' }])
+  })
 })
 
 describe('Chart block', () => {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -38,6 +38,12 @@ export const fileTreeSchema = z.object({
         change: z.enum(CHANGE_VALUES),
         // For a move, the origin path; the entry is placed at `path` (its destination).
         from: z.string().optional(),
+        // An optional inline note, authored after a " -- " trailer, shown muted on the row.
+        comment: z.string().optional(),
+        // The file-type icon SVG, injected at build time by the CLI's remark-filetree-icons pass
+        // (Material Icon Theme), never authored. Absent on the /view path, where the component
+        // falls back to a generic icon.
+        icon: z.string().optional(),
       }),
     )
     .min(1, 'files must list at least one entry'),
@@ -141,10 +147,10 @@ export const CATALOG: readonly CatalogEntry[] = [
   {
     name: 'FileTree',
     summary:
-      'A nested directory tree of file changes. Write a markdown list, one "- <change> <path>" per file; change is add/modify/delete/move.',
+      'A nested directory tree of file changes. Write a markdown list, one "- <change> <path>" per file; change is add/modify/delete/move. Append " -- <note>" for an inline comment.',
     staticEnums: {},
     example:
-      '<FileTree>\n- add src/api/routes.ts\n- modify src/api/db.ts\n- delete src/legacy.ts\n</FileTree>',
+      '<FileTree>\n- add src/api/routes.ts -- new sliding-window limiter\n- modify src/api/db.ts\n- delete src/legacy.ts\n</FileTree>',
   },
   {
     name: 'Chart',

--- a/packages/runtime/AGENTS.md
+++ b/packages/runtime/AGENTS.md
@@ -52,7 +52,13 @@ the root AGENTS.md for why Vite is configured without `@vitejs/plugin-react`.
   path ending in `/` sets `change` on the `DirNode` and renders the marker on the directory row. A
   `move` carries an optional `from` (origin) on the entry; the file renders at its destination with
   a muted `MovedFrom` annotation (`← <from>`) so the rename is visible (the CLI parser requires the
-  `-> <to>` arrow and keeps `from`, rather than discarding the origin).
+  `-> <to>` arrow and keeps `from`, rather than discarding the origin). Each entry also takes an
+  optional `comment` (an inline `- <change> <path> -- <note>` trailer, rendered muted) and an
+  optional `icon` (Material Icon Theme SVG markup). The `icon` is **never authored**: it is injected
+  at build time by the CLI's `remark-filetree-icons` pass and inlined via `dangerouslySetInnerHTML`
+  (trusted build-time dependency, not plan input). When `icon` is absent (the `/view` path, which
+  cannot resolve Material icons), `FileIcon` falls back to a generic Tabler `IconFile`; directories
+  keep their folder icon and are never given a file-type icon.
 
 ## Gotchas
 

--- a/packages/runtime/components/FileTree.tsx
+++ b/packages/runtime/components/FileTree.tsx
@@ -136,7 +136,7 @@ function renderDir(node: DirNode, depth: number): ReactNode[] {
         style={{ paddingLeft: `${depth * 1.15}rem` }}
       >
         {change ? (
-          <span className='vp-filetree__marker' aria-hidden='true'>
+          <span className='vp-filetree__marker' role='img' aria-label={change}>
             {MARKER[change]}
           </span>
         ) : (
@@ -145,7 +145,6 @@ function renderDir(node: DirNode, depth: number): ReactNode[] {
         <span className='vp-filetree__dir'>{collapsed.label}/</span>
         {from ? <MovedFrom from={from} /> : null}
         {comment ? <span className='vp-filetree__comment'>{comment}</span> : null}
-        {change ? <span className='vp-filetree__change'>{change}</span> : null}
       </li>,
     )
     rows.push(...renderDir(collapsed.node, depth + 1))
@@ -158,14 +157,13 @@ function renderDir(node: DirNode, depth: number): ReactNode[] {
         data-change={file.change}
         style={{ paddingLeft: `${depth * 1.15}rem` }}
       >
-        <span className='vp-filetree__marker' aria-hidden='true'>
+        <span className='vp-filetree__marker' role='img' aria-label={file.change}>
           {MARKER[file.change]}
         </span>
         <FileIcon icon={file.icon} />
         <span className='vp-filetree__name'>{file.name}</span>
         {file.from ? <MovedFrom from={file.from} /> : null}
         {file.comment ? <span className='vp-filetree__comment'>{file.comment}</span> : null}
-        <span className='vp-filetree__change'>{file.change}</span>
       </li>,
     )
   }

--- a/packages/runtime/components/FileTree.tsx
+++ b/packages/runtime/components/FileTree.tsx
@@ -1,6 +1,7 @@
 import {
   IconArrowLeft,
   IconArrowRight,
+  IconFile,
   IconFolder,
   IconMinus,
   IconPencil,
@@ -21,13 +22,24 @@ const MARKER: Record<string, ReactNode> = {
   move: <IconArrowRight size={15} stroke={2} />,
 }
 
+interface FileLeaf {
+  name: string
+  change: string
+  from?: string
+  comment?: string
+  /** Build-time-injected file-type icon SVG markup (Material Icon Theme); absent on /view. */
+  icon?: string
+}
+
 interface DirNode {
   dirs: Map<string, DirNode>
-  files: Array<{ name: string; change: string; from?: string }>
+  files: FileLeaf[]
   /** A change applied to the directory itself, from a path written with a trailing slash. */
   change?: string
   /** For a directory move, the origin path. */
   from?: string
+  /** An inline note authored after a " -- " trailer on a directory row. */
+  comment?: string
 }
 
 /** The muted "moved from <origin>" annotation shown on a move row. */
@@ -40,15 +52,34 @@ function MovedFrom({ from }: { from: string }) {
   )
 }
 
+/** The leading file-type icon: the build-time Material SVG when present, else a generic glyph
+ * (the /view path, which cannot resolve Material icons). The SVG is from a trusted build-time
+ * dependency, never plan input, so injecting it as markup is safe. */
+function FileIcon({ icon }: { icon?: string }) {
+  if (icon) {
+    return (
+      <span
+        className='vp-filetree__icon'
+        aria-hidden='true'
+        // biome-ignore lint/security/noDangerouslySetInnerHtml: trusted build-time Material icon SVG
+        dangerouslySetInnerHTML={{ __html: icon }}
+      />
+    )
+  }
+  return <IconFile size={15} stroke={2} className='vp-filetree__icon-fallback' aria-hidden='true' />
+}
+
 function emptyDir(): DirNode {
   return { dirs: new Map(), files: [] }
 }
 
 /** Group flat `{path}` entries into a nested directory tree. A path ending in `/` marks a
  * change on the directory itself rather than adding a file leaf. */
-function buildTree(files: Array<{ path: string; change: string; from?: string }>): DirNode {
+function buildTree(
+  files: Array<{ path: string; change: string; from?: string; comment?: string; icon?: string }>,
+): DirNode {
   const root = emptyDir()
-  for (const { path, change, from } of files) {
+  for (const { path, change, from, comment, icon } of files) {
     const isDir = path.endsWith('/')
     const segments = path.split('/').filter(Boolean)
     // A directory entry consumes every segment; a file entry leaves the last as the file name.
@@ -67,7 +98,9 @@ function buildTree(files: Array<{ path: string; change: string; from?: string }>
     if (isDir) {
       node.change = change
       node.from = from
-    } else node.files.push({ name: segments[segments.length - 1] ?? path, change, from })
+      node.comment = comment
+    } else
+      node.files.push({ name: segments[segments.length - 1] ?? path, change, from, comment, icon })
   }
   return root
 }
@@ -94,6 +127,7 @@ function renderDir(node: DirNode, depth: number): ReactNode[] {
     const collapsed = collapse(name, child)
     const change = collapsed.node.change
     const from = collapsed.node.from
+    const comment = collapsed.node.comment
     rows.push(
       <li
         key={`dir:${depth}:${collapsed.label}`}
@@ -110,6 +144,7 @@ function renderDir(node: DirNode, depth: number): ReactNode[] {
         )}
         <span className='vp-filetree__dir'>{collapsed.label}/</span>
         {from ? <MovedFrom from={from} /> : null}
+        {comment ? <span className='vp-filetree__comment'>{comment}</span> : null}
         {change ? <span className='vp-filetree__change'>{change}</span> : null}
       </li>,
     )
@@ -126,8 +161,10 @@ function renderDir(node: DirNode, depth: number): ReactNode[] {
         <span className='vp-filetree__marker' aria-hidden='true'>
           {MARKER[file.change]}
         </span>
+        <FileIcon icon={file.icon} />
         <span className='vp-filetree__name'>{file.name}</span>
         {file.from ? <MovedFrom from={file.from} /> : null}
+        {file.comment ? <span className='vp-filetree__comment'>{file.comment}</span> : null}
         <span className='vp-filetree__change'>{file.change}</span>
       </li>,
     )

--- a/packages/runtime/tests/components.test.tsx
+++ b/packages/runtime/tests/components.test.tsx
@@ -120,6 +120,29 @@ describe('FileTree', () => {
     expect(html).toContain('src/billing.ts')
     expect(html).toContain('data-change="move"')
   })
+
+  it('renders an inline comment on a file row (golden)', () => {
+    const html = renderToStaticMarkup(
+      <FileTree files={[{ path: 'src/a.ts', change: 'modify', comment: 'add a retry loop' }]} />,
+    )
+    expect(html).toContain('vp-filetree__comment')
+    expect(html).toContain('add a retry loop')
+  })
+
+  it('injects a build-time icon SVG when present (edge)', () => {
+    const html = renderToStaticMarkup(
+      <FileTree files={[{ path: 'src/a.ts', change: 'add', icon: '<svg id="ts-icon"></svg>' }]} />,
+    )
+    expect(html).toContain('vp-filetree__icon')
+    expect(html).toContain('<svg id="ts-icon">')
+    // With an icon present the generic fallback glyph is not rendered.
+    expect(html).not.toContain('vp-filetree__icon-fallback')
+  })
+
+  it('falls back to a generic icon when no icon is resolved (edge)', () => {
+    const html = renderToStaticMarkup(<FileTree files={[{ path: 'src/a.ts', change: 'add' }]} />)
+    expect(html).toContain('vp-filetree__icon-fallback')
+  })
 })
 
 describe('Matrix', () => {

--- a/packages/runtime/theme.css
+++ b/packages/runtime/theme.css
@@ -426,9 +426,10 @@ body {
 
 .vp-filetree__row {
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   gap: 0.65rem;
   padding: 0.22rem 0.45rem;
+  line-height: 1.5;
 }
 
 .vp-filetree__marker {
@@ -483,6 +484,8 @@ body {
 }
 
 .vp-filetree__name {
+  flex: 0 0 auto;
+  white-space: nowrap;
   color: var(--vp-text);
 }
 
@@ -490,28 +493,21 @@ body {
   display: inline-flex;
   align-items: center;
   gap: 0.2rem;
+  min-width: 0;
+  overflow: hidden;
+  white-space: nowrap;
   color: var(--vp-faint);
   font-size: 0.78rem;
 }
 
 .vp-filetree__comment {
+  flex: 1 1 auto;
   min-width: 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+  white-space: normal;
+  overflow-wrap: anywhere;
   color: var(--vp-muted);
   font-family: var(--vp-font);
   font-size: 0.78rem;
-  font-style: italic;
-}
-
-.vp-filetree__change {
-  margin-left: auto;
-  padding-left: 0.6rem;
-  font-size: 0.68rem;
-  color: var(--vp-faint);
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
 }
 
 /* Chart */

--- a/packages/runtime/theme.css
+++ b/packages/runtime/theme.css
@@ -422,6 +422,9 @@ body {
   background: var(--vp-surface);
   font-family: var(--vp-mono);
   font-size: 0.84rem;
+  /* A pathologically long, unbroken path (a non-wrapping file name) scrolls within the card
+     rather than widening the whole page. Wrapping comments still wrap to the card width. */
+  overflow-x: auto;
 }
 
 .vp-filetree__row {

--- a/packages/runtime/theme.css
+++ b/packages/runtime/theme.css
@@ -442,6 +442,24 @@ body {
   flex: 0 0 auto;
 }
 
+.vp-filetree__icon {
+  display: inline-flex;
+  align-items: center;
+  flex: 0 0 auto;
+  margin-left: -0.2rem;
+}
+
+.vp-filetree__icon svg {
+  width: 1rem;
+  height: 1rem;
+}
+
+.vp-filetree__icon-fallback {
+  color: var(--vp-faint);
+  flex: 0 0 auto;
+  margin-left: -0.2rem;
+}
+
 .vp-filetree__row[data-change="add"] .vp-filetree__marker {
   color: var(--vp-done);
 }
@@ -476,8 +494,20 @@ body {
   font-size: 0.78rem;
 }
 
+.vp-filetree__comment {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--vp-muted);
+  font-family: var(--vp-font);
+  font-size: 0.78rem;
+  font-style: italic;
+}
+
 .vp-filetree__change {
   margin-left: auto;
+  padding-left: 0.6rem;
   font-size: 0.68rem;
   color: var(--vp-faint);
   text-transform: uppercase;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -74,6 +74,9 @@ importers:
       beautiful-mermaid:
         specifier: ^1.1.3
         version: 1.1.3
+      material-icon-theme:
+        specifier: ^5.35.0
+        version: 5.35.0
       react:
         specifier: ^19.2.7
         version: 19.2.7

--- a/skills/visual-plan/SKILL.md
+++ b/skills/visual-plan/SKILL.md
@@ -238,6 +238,10 @@ it in paragraphs. Prose is the connective tissue between visuals, never the subs
 - **`<Matrix>` cells do not wrap.** A long sentence in one cell forces a horizontal scrollbar and
   pushes the other columns off-screen. Keep cells to a word or a short score; put rationale in prose
   or a `<Callout>`, not in a cell.
+- **Avoid `-- comments` on `<FileTree>` `move` rows.** A move already shows its origin path (the
+  `← <from>` annotation), which eats most of the row width, so a comment on the same row gets crowded
+  out. Leave move rows uncommented and put any explanation in prose or a `<Callout>`; reserve `--
+  comments` for add/modify/delete rows, which have the space.
 - **Wide mermaid diagrams shrink to illegibility.** Prefer top-down (`flowchart TD`) once a diagram
   has many nodes; a long left-to-right (`LR`) chain shrinks to fit the page and becomes effectively
   unreadable inline. Split a large flow into a few smaller diagrams instead of one sprawling one.

--- a/skills/visual-plan/SKILL.md
+++ b/skills/visual-plan/SKILL.md
@@ -62,12 +62,14 @@ brace errors that break a render.
 - `<FileTree>` — file-change map. One bullet per file, `- <change> <path>`, where `change` is
   `add|modify|delete|move`. A move needs both ends, `- move <from> -> <to>` (the file renders at
   its destination with the origin shown). A path ending in `/` marks a whole directory (e.g.
-  `- delete src/legacy/`).
+  `- delete src/legacy/`). A colored file-type icon is added automatically from the path's
+  extension. Append ` -- <note>` to any line for a short inline comment on that change (what it does
+  or why); keep it to a phrase, since it shares the row with the file name.
 
   ```mdx
   <FileTree>
-  - add src/gateway/rate-limiter.ts
-  - modify src/gateway/middleware.ts
+  - add src/gateway/rate-limiter.ts -- sliding-window check against Redis
+  - modify src/gateway/middleware.ts -- mount the limiter behind the flag
   - delete src/gateway/legacy/
   </FileTree>
   ```


### PR DESCRIPTION
## What

Adds colored file-type icons and optional inline `-- comments` to the `FileTree` component, in both the `vplan` CLI render and the `/view` shared-plan viewer.

## How

- **Icons (CLI):** a Node-only `remarkFileTreeIcons` remark pass inlines a Material Icon Theme SVG per file at build time, kept off the main browser bundle. Icon-name resolution is extracted into an isomorphic `resolveIconName` so the CLI and `/view` always pick the same icon.
- **Icons (`/view`):** a remark pass lazily code-splits the icon set, loading the resolver only when a plan has a `FileTree` and fetching each icon as its own tiny chunk, so a shared plan pulls just the types it uses (not the 5 MB set). The resolver chunk drops `iconDefinitions` (derives basenames + a build-time clones map) to keep it small.
- **Comments + layout:** a ` -- <note>` trailer parses into an inline comment; the redundant change-type word was removed from the right of each row (the colored marker conveys add/modify/delete/move, now with an `aria-label`), long comments wrap, and over-long paths scroll within the card instead of widening the page.

## Verification

Ran locally on this branch:

- `pnpm lint` — clean (pre-existing warnings only)
- `biome format .` — no changes
- `pnpm typecheck` — 0 errors across all packages
- `pnpm build` — success
- `pnpm test` — 184 passed
- Browser-validated both paths with Playwright: the CLI render and the real sandboxed `/view` iframe show correct colored icons (including clone-icons), per-icon chunks load (no 5 MB bundle), comments wrap, and long paths stay contained — in light and dark.

- [x] `pnpm lint` passes
- [x] `pnpm format` reports no changes (`biome format .`)
- [x] `pnpm typecheck` passes
- [x] `pnpm build` succeeds
- [x] `pnpm test` passes

## Notes

- Design tradeoff: file names and paths never wrap (so they stay intact and copy-pasteable, scrolling within the card when pathologically long); only descriptions wrap.
- The `/view` icon resolver is a code-split chunk (~37 KB gzip) fetched only for plans containing a `FileTree`; `fetch()` of static assets is blocked in the opaque-origin `/view` sandbox, so per-icon dynamic-import chunks are required (not a static-asset path).
