### PR TITLE
feat: programmatic API for the vplan package

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,8 @@ polished, self-contained HTML page, so an AI agent can present plans as scannabl
 - `vplan check <file.mdx>` validates a plan without rendering (the self-correction
   loop): MDX compile errors plus static component checks, printed as `file:line:col`.
 - `vplan components` prints the component vocabulary cheat-sheet.
+- A programmatic API (`import { render, check } from 'vplan'`) renders/validates a plan from an
+  in-memory MDX string, with a named export per catalog entry. See `packages/cli/src/api.ts`.
 
 Plans use a fixed, tiny component vocabulary (`Phase`, `FileTree`, `Chart`, `Compare`, `Matrix`,
 `Callout`, `Questions`, `Checklist`, and ` ```mermaid ` / ` ```math ` fences) with no imports — the
@@ -26,9 +28,10 @@ a multi-series `Chart`), not inline object-array props; only scalar settings (`t
 
 `pnpm-workspace.yaml` globs `packages/*`. Five packages, one published:
 
-- `packages/cli` — **the only published package** (`vplan`). The Node CLI (commander
-  dispatch + Vite/MDX build), built with tsup to `dist/index.js` (the `bin`). Holds
-  `templates/example.mdx` (used by the integration tests) and `scripts/vendor.mjs`.
+- `packages/cli` — **the only published package** (`vplan`). Two entries built by tsup: the Node CLI
+  (commander dispatch + Vite/MDX build) at `dist/index.js` (the `bin`), and the programmatic API at
+  `dist/api.js` (the `import` entry, `src/api.ts`). Holds `templates/example.mdx` (used by the
+  integration tests) and `scripts/vendor.mjs`.
 - `packages/runtime` — `@visualplan/runtime` (private). The browser/React code, shipped as
   **source** and compiled at render time by Vite. Components, `Layout.tsx`, `main.tsx`,
   `index.tsx` (MDX scope + `mount`), `theme.css`, `fullscreen.ts`.

--- a/packages/app/AGENTS.md
+++ b/packages/app/AGENTS.md
@@ -18,8 +18,8 @@ package that is a web app rather than part of the CLI's render pipeline.
   `Footer.astro`.
 - `src/nav.ts` — `docLinks`, the single source of truth for the docs sidebar order.
 - `src/pages/index.astro` — the landing page (custom hero + feature grid, uses `Base` directly).
-- `src/pages/docs/*` — the docs content: `index.md`, `install.md`, `cli.md`, and `authoring.mdx`
-  (MDX, because it embeds live component demos).
+- `src/pages/docs/*` — the docs content: `index.md`, `install.md`, `cli.md`, `programmatic.md` (the
+  `vplan` Node API), and `authoring.mdx` (MDX, because it embeds live component demos).
 - `src/components/Demo.astro` — wraps a live runtime component as a "Renders to" stage (see below).
 - `src/nav.ts` — `docLinks` (the Guide sidebar group) and `exampleLinks` (the Examples group, which
   links straight to the rendered example HTML in a new tab).

--- a/packages/app/src/nav.ts
+++ b/packages/app/src/nav.ts
@@ -9,6 +9,7 @@ export const docLinks: DocLink[] = [
   { href: '/docs/install/', label: 'Installation' },
   { href: '/docs/authoring/', label: 'Authoring plans' },
   { href: '/docs/cli/', label: 'CLI reference' },
+  { href: '/docs/programmatic/', label: 'Programmatic interface' },
 ]
 
 /**

--- a/packages/app/src/pages/docs/programmatic.md
+++ b/packages/app/src/pages/docs/programmatic.md
@@ -1,0 +1,98 @@
+---
+layout: ../../layouts/Docs.astro
+title: Programmatic interface
+description: Render and validate plans from Node with the vplan API.
+---
+
+# Programmatic interface
+
+Besides the [CLI](/docs/cli/), `vplan` exposes a small Node API so a server, a build step, or an
+agent harness can render and validate plans in memory instead of shelling out. Install it as a
+dependency:
+
+```bash
+npm install vplan
+```
+
+Everything works on an in-memory MDX **string**, nothing touches the filesystem unless you ask it
+to:
+
+```ts
+import { render, check } from 'vplan'
+
+const source = `# Add rate limiting
+
+<Phase title="Build the limiter" status="active">
+  1. Sliding window in Redis
+</Phase>
+`
+
+const html = await render(source) // a self-contained HTML string
+```
+
+## render
+
+```ts
+render(source: string, options?: { out?: string }): Promise<string>
+```
+
+Compiles a plan's MDX source to a self-contained HTML page and returns it as a string. Pass `out`
+to also write the HTML to a file:
+
+```ts
+const html = await render(source)              // string in, string out
+await render(source, { out: 'plan.html' })     // also write a file
+```
+
+`render` validates the plan first and **throws `InvalidPlanError` if it is invalid**, so a
+programmatic caller gets the same self-correction guarantee the CLI has. The error carries the
+structured issues:
+
+```ts
+import { render, InvalidPlanError } from 'vplan'
+
+try {
+  await render('# Bad\n\n<Phase status="nope">x</Phase>\n')
+} catch (error) {
+  if (error instanceof InvalidPlanError) {
+    for (const issue of error.issues) {
+      console.error(`${issue.line}:${issue.column}  ${issue.message}`)
+    }
+  }
+}
+```
+
+## check
+
+```ts
+check(source: string): Promise<CheckIssue[]>
+```
+
+Validates a plan's MDX source without rendering it, returning the issues (an empty array when the
+plan is valid). Each issue has a `line`, `column`, and `message`, the same checks the CLI's
+`vplan check` runs:
+
+```ts
+const issues = await check(source)
+if (issues.length === 0) {
+  // safe to render
+}
+```
+
+## Component catalog
+
+The component vocabulary is exported as one named descriptor per component, so you can introspect a
+single component's props and valid enum values without rendering anything:
+
+```ts
+import { chart, phase } from 'vplan'
+
+chart.name // 'Chart'
+chart.staticEnums.type // ['bar', 'line', 'area', 'scatter', ...]
+phase.staticEnums.status // ['planned', 'active', 'done']
+```
+
+The named exports are `phase`, `fileTree`, `chart`, `compare`, `matrix`, `callout`, `questions`,
+`checklist`, `stat`, `mermaid`, and `math`. Each is a `CatalogEntry` with a `name`, a `summary`, its
+statically-checkable `staticEnums`, and an authoring `example`. See [Authoring
+plans](/docs/authoring/) for the full vocabulary.

--- a/packages/cli/AGENTS.md
+++ b/packages/cli/AGENTS.md
@@ -22,9 +22,12 @@ programmatic Node API at `dist/api.js` (the package's `import` entry, `exports["
   returns the module whose default export is the MDX component, matching `runtime/virtual-plan.d.ts`.
   This single plugin replaced the old `virtual:plan` path alias AND `@mdx-js/rollup` (the plan is the
   only `.mdx`), so the one-shot build and `--watch` share ONE compile path and cannot drift. For
-  `--watch`, `startDevServer(path)` passes `{ path }`; the plugin re-reads the file in `load` and
-  calls `this.addWatchFile(path)` so an edit invalidates the module and Vite recompiles + reloads
-  (that registration, not @mdx-js/rollup's old watcher, is now what drives HMR). `planSharePlugin` encodes the plan's MDX
+  `--watch`, `startDevServer(path)` passes `{ path }`; the plugin re-reads the file in `load`.
+  **HMR gotcha:** the plan is now a virtual module backed by a file, not a real module Vite tracks by
+  path, so `addWatchFile` alone does NOT invalidate it on a save (verified: it only adds the file to
+  the watcher). The plugin's `handleHotUpdate` is what drives `--watch`: on a change to the plan it
+  invalidates the virtual module and sends a `full-reload`. Do not drop it, or editing a watched plan
+  silently stops reloading. `planSharePlugin` encodes the plan's MDX
   (`@visualplan/core/share` `encodePlan`) and injects it onto `globalThis.__VP_SHARE__` for the
   runtime share button; on the dev server it also serves `/__vp_share`, which re-encodes the file on
   each request so a watched plan shares its current state. Imports the shared remark plugins and

--- a/packages/cli/AGENTS.md
+++ b/packages/cli/AGENTS.md
@@ -1,14 +1,30 @@
 # packages/cli (vplan)
 
-The published package: the `vplan` Node CLI (commander dispatch + the Vite/MDX build that
-renders a plan to a self-contained HTML page). Built with tsup to `dist/index.js` (the `bin`).
+The published package. It ships two entrypoints: the `vplan` CLI (commander dispatch + the Vite/MDX
+build that renders a plan to a self-contained HTML page) at `dist/index.js` (the `bin`), and a
+programmatic Node API at `dist/api.js` (the package's `import` entry, `exports["."]`).
 
 ## Structure
 
-- `src/index.ts` — commander dispatch. `src/commands/` — one file per command (render, check,
-  components).
-- `src/build/compile.ts` — Vite orchestration for `render` (single-file build via
-  `vite-plugin-singlefile`) and `--watch` (dev server). `planSharePlugin` encodes the plan's MDX
+- `src/index.ts` — commander dispatch (the `bin`). `src/commands/` — one file per command (render,
+  check, components).
+- `src/api.ts` — the programmatic API (the library entry): `render(source, { out? })` (returns the
+  HTML string, throws `InvalidPlanError` on an invalid plan, optional file write), `check(source)`,
+  and one named re-export per catalog entry from `@visualplan/core` (`phase`, `chart`, ...). It is
+  source-string based on purpose: rendering a file is `render(await readFile(path, 'utf8'))`, which
+  avoids a path-vs-source overload. It wraps the same `buildHtml`/`checkSource` the CLI uses.
+- `src/build/compile.ts` — Vite orchestration. `buildHtml(source)` is the shared core: it compiles
+  a plan from an in-memory MDX **string** and returns the self-contained HTML (single-file build via
+  `vite-plugin-singlefile`). `renderToFile(path, out)` reads the file once and delegates; the API's
+  `render` passes its source straight through, so nothing is written to disk except the optional
+  output. The plan is served as the `virtual:plan` module by `virtualPlanPlugin`, which compiles the
+  source with `@mdx-js/mdx` `compile()` (the shared remark/rehype config in `mdxCompileOptions`) and
+  returns the module whose default export is the MDX component, matching `runtime/virtual-plan.d.ts`.
+  This single plugin replaced the old `virtual:plan` path alias AND `@mdx-js/rollup` (the plan is the
+  only `.mdx`), so the one-shot build and `--watch` share ONE compile path and cannot drift. For
+  `--watch`, `startDevServer(path)` passes `{ path }`; the plugin re-reads the file in `load` and
+  calls `this.addWatchFile(path)` so an edit invalidates the module and Vite recompiles + reloads
+  (that registration, not @mdx-js/rollup's old watcher, is now what drives HMR). `planSharePlugin` encodes the plan's MDX
   (`@visualplan/core/share` `encodePlan`) and injects it onto `globalThis.__VP_SHARE__` for the
   runtime share button; on the dev server it also serves `/__vp_share`, which re-encodes the file on
   each request so a watched plan shares its current state. Imports the shared remark plugins and
@@ -55,11 +71,11 @@ user's plan via `virtual:plan`. `server.fs.strict` is off because the runtime, c
 span sibling dirs in the monorepo.
 
 The build also aliases `react/jsx-runtime`, `react/jsx-dev-runtime`, and `@mdx-js/react` to the
-CLI's own copies (via `require.resolve`). The plan `.mdx` is an external absolute path, so
-@mdx-js/rollup's emitted imports would otherwise resolve relative to the plan's own directory,
-which usually has no `node_modules` (e.g. a global install rendering `~/plan.mdx`). Without these
-aliases, rendering a plan outside a node project fails with "failed to resolve react/jsx-runtime".
-Do not remove them.
+CLI's own copies (via `require.resolve`). The compiled `virtual:plan` module imports those, but it
+is a virtual module with no directory of its own (and a file plan often lives outside any node
+project, e.g. a global install rendering `~/plan.mdx`), so without these aliases they resolve
+relative to nothing and rendering fails with "failed to resolve react/jsx-runtime". Do not remove
+them. The `tests/compile.test.ts` "renders a plan outside any node project" case guards this.
 
 ## Constraints
 
@@ -73,6 +89,18 @@ Do not remove them.
   workspace source, so a stale copy silently shadows your runtime/core edits at render time. After
   changing the runtime or core, re-vendor (`pnpm --filter vplan vendor`) or remove `cli/runtime` +
   `cli/core` so renders pick up the workspace source again.
+- **`tsup.config.ts` is two configs, not one.** The CLI bin (`src/index.ts`) needs the
+  `#!/usr/bin/env node` shebang banner; the library entry (`src/api.ts`) must NOT carry it (it would
+  be a stray line atop an imported module) and needs `.d.ts` types the bin does not. They cannot
+  share one pass, so the bin config has the banner + `clean: true` and the library config has
+  `dts: { resolve: [/^@visualplan\//] }` + `clean: false`. The `dts.resolve` is load-bearing:
+  without it tsup leaves the catalog re-exports as `from '@visualplan/core'` (a private package a
+  consumer lacks), breaking the published types; `resolve` inlines the `@visualplan` types while
+  leaving third-party ones (zod) as ordinary imports. The library config must not clean, or it wipes
+  the bin tsup built first.
+- The package has an `exports` map (`"."` -> the library `dist/api.js` + `dist/api.d.ts`) alongside
+  the `bin`. Keep `"./package.json": "./package.json"` in it: an `exports` map blocks every unlisted
+  subpath, and dropping it would break tooling that resolves the package's `package.json`.
 - `tsup` `noExternal` is the regex `/^@visualplan\/(core|compile)/` (not a bare string) so it also
   bundles the `@visualplan/core/share` and `@visualplan/compile/file-icons` subpaths that
   `compile.ts` imports. The compile package's own third-party deps (rehype-expressive-code,

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -32,6 +32,15 @@
   "bin": {
     "vplan": "dist/index.js"
   },
+  "main": "dist/api.js",
+  "types": "dist/api.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/api.d.ts",
+      "import": "./dist/api.js"
+    },
+    "./package.json": "./package.json"
+  },
   "files": [
     "dist",
     "runtime",

--- a/packages/cli/src/api.ts
+++ b/packages/cli/src/api.ts
@@ -1,0 +1,62 @@
+/**
+ * The programmatic interface for `vplan`: render and validate a plan from an in-memory MDX string,
+ * and introspect the component vocabulary. This is the package's import entry (`import { render }
+ * from 'vplan'`); the CLI bin is a separate entry. Nothing here touches the filesystem unless you
+ * pass `render`'s `out` option.
+ */
+import { writeFile } from 'node:fs/promises'
+import { resolve } from 'node:path'
+import { buildHtml } from './build/compile.js'
+import { type CheckIssue, checkSource } from './build/check.js'
+
+export interface RenderOptions {
+  /** Also write the rendered HTML to this path. The HTML string is returned regardless. */
+  out?: string
+}
+
+/** Thrown by `render` when the plan fails validation, carrying the structured issues. */
+export class InvalidPlanError extends Error {
+  readonly issues: CheckIssue[]
+  constructor(issues: CheckIssue[]) {
+    const detail = issues.map(issue => `  ${issue.line}:${issue.column}  ${issue.message}`).join('\n')
+    super(`Plan has ${issues.length} issue(s):\n${detail}`)
+    this.name = 'InvalidPlanError'
+    this.issues = issues
+  }
+}
+
+/**
+ * Compile a plan's MDX source to a self-contained HTML page, returned as a string. Validates the
+ * plan first and throws `InvalidPlanError` if it has any issues, so a programmatic caller gets the
+ * same self-correction guarantee the CLI has. Pass `out` to also write the HTML to a file.
+ */
+export async function render(source: string, options: RenderOptions = {}): Promise<string> {
+  const issues = await checkSource(source)
+  if (issues.length > 0) throw new InvalidPlanError(issues)
+  const html = await buildHtml(source)
+  if (options.out) await writeFile(resolve(options.out), html)
+  return html
+}
+
+/** Validate a plan's MDX source, returning the issues (an empty array when the plan is valid). */
+export async function check(source: string): Promise<CheckIssue[]> {
+  return checkSource(source)
+}
+
+export type { CheckIssue } from './build/check.js'
+export type { CatalogEntry } from '@visualplan/core'
+// The component vocabulary, one named descriptor per component, so a consumer can introspect a
+// single component's props and enums (`import { chart } from 'vplan'`).
+export {
+  callout,
+  chart,
+  checklist,
+  compare,
+  fileTree,
+  math,
+  matrix,
+  mermaid,
+  phase,
+  questions,
+  stat,
+} from '@visualplan/core'

--- a/packages/cli/src/api.ts
+++ b/packages/cli/src/api.ts
@@ -18,7 +18,9 @@ export interface RenderOptions {
 export class InvalidPlanError extends Error {
   readonly issues: CheckIssue[]
   constructor(issues: CheckIssue[]) {
-    const detail = issues.map(issue => `  ${issue.line}:${issue.column}  ${issue.message}`).join('\n')
+    const detail = issues
+      .map(issue => `  ${issue.line}:${issue.column}  ${issue.message}`)
+      .join('\n')
     super(`Plan has ${issues.length} issue(s):\n${detail}`)
     this.name = 'InvalidPlanError'
     this.issues = issues

--- a/packages/cli/src/build/check.ts
+++ b/packages/cli/src/build/check.ts
@@ -39,9 +39,13 @@ const ENUMS_BY_COMPONENT = new Map(CATALOG.map(entry => [entry.name, entry.stati
 
 const BLOCK_COMPONENTS: readonly string[] = CHILD_BLOCK_COMPONENTS
 
-/** Validate a plan's MDX: real compile errors plus static enum / unknown-component checks. */
+/** Validate a plan's MDX file: real compile errors plus static enum / unknown-component checks. */
 export async function checkPlan(mdxPath: string): Promise<CheckIssue[]> {
-  const source = await readFile(mdxPath, 'utf8')
+  return checkSource(await readFile(mdxPath, 'utf8'))
+}
+
+/** Validate a plan's MDX source string (the in-memory form `checkPlan` and the API both use). */
+export async function checkSource(source: string): Promise<CheckIssue[]> {
   const issues: CheckIssue[] = []
 
   try {

--- a/packages/cli/src/build/compile.ts
+++ b/packages/cli/src/build/compile.ts
@@ -1,10 +1,10 @@
-import { cp, mkdtemp, rm } from 'node:fs/promises'
 import { existsSync, readFileSync } from 'node:fs'
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
 import { createRequire } from 'node:module'
 import { tmpdir } from 'node:os'
 import { dirname, join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
-import mdx from '@mdx-js/rollup'
+import { compile, type CompileOptions } from '@mdx-js/mdx'
 import { baseExpressiveCodeOptions, remarkPlugins } from '@visualplan/compile'
 import { pluginFileIcons } from '@visualplan/compile/file-icons'
 import { remarkFileTreeIcons } from '@visualplan/compile/filetree-icons'
@@ -25,7 +25,29 @@ const expressiveCodeOptions: RehypeExpressiveCodeOptions = {
   ],
 }
 
+// The one place MDX is compiled for the render path. The same remark/rehype config drives both the
+// one-shot build and the --watch dev server (both go through virtualPlanPlugin), so they cannot
+// drift. remarkFileTreeIcons is appended CLI-only: it inlines Material file icons (Node-only, reads
+// SVGs from disk) after plan-blocks serializes the FileTree data, so the browser /view path never
+// pulls in material-icon-theme and falls back to a generic icon.
+const mdxCompileOptions: CompileOptions = {
+  providerImportSource: '@mdx-js/react',
+  remarkPlugins: [...remarkPlugins, remarkFileTreeIcons],
+  rehypePlugins: [[rehypeExpressiveCode, expressiveCodeOptions]],
+}
+
 const require = createRequire(import.meta.url)
+
+/** A plan to render: either MDX source in memory (the programmatic API) or a file to read. */
+type PlanInput = string | { path: string }
+
+/** Read the plan's current source, BOM-stripped; for a `{ path }` input it re-reads each call so a
+ * watched plan reflects its latest saved state. */
+function sourceReader(input: PlanInput): () => string {
+  if (typeof input === 'string') return () => input
+  const { path } = input
+  return () => readFileSync(path, 'utf8').replace(/^\ufeff/, '')
+}
 
 interface RuntimePaths {
   /** Directory Vite roots at: holds index.html plus the runtime source. */
@@ -59,28 +81,44 @@ function findRuntimePaths(): RuntimePaths {
   return { runtimeDir, coreEntry: join(coreDir, 'src', 'index.ts') }
 }
 
-function mdxPlugin(): Plugin {
+const VIRTUAL_PLAN_ID = 'virtual:plan'
+const RESOLVED_VIRTUAL_PLAN_ID = '\0virtual:plan'
+
+/**
+ * Serve the plan as the `virtual:plan` module the runtime imports. The source is compiled with
+ * `@mdx-js/mdx` here (not via @mdx-js/rollup) so the plan can be an in-memory string with no file
+ * on disk. The compiled module's default export is the MDX component, matching virtual-plan.d.ts.
+ * For a `{ path }` input (the --watch dev server) the file is re-read and registered with
+ * `addWatchFile`, so an edit invalidates this module and Vite recompiles + reloads.
+ */
+function virtualPlanPlugin(input: PlanInput): Plugin {
+  const readSource = sourceReader(input)
+  const watchPath = typeof input === 'string' ? null : input.path
   return {
+    name: 'visualplan:virtual-plan',
     enforce: 'pre',
-    ...mdx({
-      providerImportSource: '@mdx-js/react',
-      // The ordered list (frontmatter, gfm, plan-blocks, mermaid, math) is shared with the
-      // /view browser compiler via @visualplan/compile so both render plans identically.
-      // remarkFileTreeIcons is appended CLI-only: it inlines Material file icons (Node-only,
-      // reads SVGs from disk) after plan-blocks serializes the FileTree data, so the browser
-      // bundle never pulls in material-icon-theme and /view falls back to a generic icon.
-      remarkPlugins: [...remarkPlugins, remarkFileTreeIcons],
-      rehypePlugins: [[rehypeExpressiveCode, expressiveCodeOptions]],
-    }),
+    resolveId(id) {
+      if (id === VIRTUAL_PLAN_ID) return RESOLVED_VIRTUAL_PLAN_ID
+    },
+    async load(id) {
+      if (id !== RESOLVED_VIRTUAL_PLAN_ID) return null
+      if (watchPath) this.addWatchFile(watchPath)
+      const compiled = await compile(readSource(), mdxCompileOptions)
+      return String(compiled)
+    },
   }
 }
 
 /** The plan's title is its first `# ` heading (plans have no frontmatter). */
+function planTitleFromSource(source: string): string {
+  // Strip a leading UTF-8 BOM first, or a BOM-prefixed "# Title" first line never matches `^# `.
+  return source.replace(/^\ufeff/, '').match(/^# (.+?)\s*$/m)?.[1] ?? 'Plan'
+}
+
+/** The plan's title from a file path; falls back to "Plan" if the file is unreadable. */
 export function planTitle(mdxPath: string): string {
   try {
-    // Strip a leading UTF-8 BOM first, or a BOM-prefixed "# Title" first line never matches `^# `.
-    const source = readFileSync(mdxPath, 'utf8').replace(/^\ufeff/, '')
-    return source.match(/^# (.+?)\s*$/m)?.[1] ?? 'Plan'
+    return planTitleFromSource(readFileSync(mdxPath, 'utf8'))
   } catch {
     return 'Plan'
   }
@@ -95,11 +133,14 @@ function escapeHtml(text: string): string {
 }
 
 /** Set the page `<title>` to the plan's title so the browser tab is named, not "Plan". */
-function htmlTitlePlugin(mdxPath: string): Plugin {
-  const title = escapeHtml(planTitle(mdxPath))
+function htmlTitlePlugin(readSource: () => string): Plugin {
   return {
     name: 'visualplan:html-title',
-    transformIndexHtml: html => html.replace(/<title>[\s\S]*?<\/title>/, `<title>${title}</title>`),
+    transformIndexHtml: html =>
+      html.replace(
+        /<title>[\s\S]*?<\/title>/,
+        `<title>${escapeHtml(planTitleFromSource(readSource()))}</title>`,
+      ),
   }
 }
 
@@ -114,12 +155,12 @@ interface PlanShare {
 /**
  * Embed the plan's encoded MDX source so the runtime share button can build a
  * stateless `visualplan.dev/view?data=...` link. The source is read fresh on
- * every call (BOM-stripped to match `planTitle`), so the `--watch` dev server
- * always reflects the current file: `transformIndexHtml` seeds the initial value,
- * and a `/__vp_share` dev endpoint re-encodes on demand when the button is clicked.
+ * every call, so the `--watch` dev server always reflects the current file:
+ * `transformIndexHtml` seeds the initial value, and a `/__vp_share` dev endpoint
+ * re-encodes on demand when the button is clicked.
  */
-function planSharePlugin(mdxPath: string): Plugin {
-  const encode = () => encodePlan(readFileSync(mdxPath, 'utf8').replace(/^\ufeff/, ''))
+function planSharePlugin(readSource: () => string): Plugin {
+  const encode = () => encodePlan(readSource())
   return {
     name: 'visualplan:share',
     configureServer(server) {
@@ -151,41 +192,39 @@ function planSharePlugin(mdxPath: string): Plugin {
   }
 }
 
-function baseConfig(paths: RuntimePaths, mdxPath: string): InlineConfig {
+function baseConfig(paths: RuntimePaths, input: PlanInput): InlineConfig {
+  const readSource = sourceReader(input)
   return {
     root: paths.runtimeDir,
     configFile: false,
     logLevel: 'silent',
     resolve: {
       alias: {
-        'virtual:plan': mdxPath,
         '@visualplan/core': paths.coreEntry,
-        // The plan .mdx lives anywhere on disk, often outside any node project, but
-        // @mdx-js/rollup makes it import react/jsx-runtime and @mdx-js/react. Those
-        // are attributed to the plan's own directory, which usually has no
-        // node_modules, so resolve them from the CLI's install instead. Without this
-        // a plan in a bare directory fails with "failed to resolve react/jsx-runtime".
+        // The compiled plan imports react/jsx-runtime and @mdx-js/react, but it is a virtual
+        // module with no directory of its own (and a file plan often lives outside any node
+        // project), so resolve those from the CLI's own install. Without this a plan in a bare
+        // directory fails with "failed to resolve react/jsx-runtime".
         'react/jsx-runtime': require.resolve('react/jsx-runtime'),
         'react/jsx-dev-runtime': require.resolve('react/jsx-dev-runtime'),
         '@mdx-js/react': require.resolve('@mdx-js/react'),
       },
     },
     esbuild: { jsx: 'automatic', jsxImportSource: 'react' },
-    plugins: [mdxPlugin(), htmlTitlePlugin(mdxPath), planSharePlugin(mdxPath)],
-    // The runtime, core, and the user's plan span sibling dirs (and a hoisted
-    // node_modules) in the monorepo, so the dev server cannot use a single allow
-    // root. This is a local tool rendering the user's own file, so fs is unrestricted.
+    plugins: [virtualPlanPlugin(input), htmlTitlePlugin(readSource), planSharePlugin(readSource)],
+    // The runtime, core, and (for a file input) the user's plan span sibling dirs (and a hoisted
+    // node_modules) in the monorepo, so the dev server cannot use a single allow root. This is a
+    // local tool rendering the user's own plan, so fs is unrestricted.
     server: { fs: { strict: false }, open: false },
   }
 }
 
-/** Compile an MDX plan to a single self-contained HTML file at `outPath`. */
-export async function renderToFile(mdxPath: string, outPath: string): Promise<void> {
+/** Compile a plan's MDX source to a single self-contained HTML page, returned as a string. */
+export async function buildHtml(source: string): Promise<string> {
   const paths = findRuntimePaths()
-  const absMdx = resolve(mdxPath)
   const outDir = await mkdtemp(join(tmpdir(), 'visualplan-build-'))
   try {
-    const config = baseConfig(paths, absMdx)
+    const config = baseConfig(paths, source)
     await build({
       ...config,
       plugins: [...(config.plugins ?? []), viteSingleFile()],
@@ -195,10 +234,16 @@ export async function renderToFile(mdxPath: string, outPath: string): Promise<vo
         rollupOptions: { input: join(paths.runtimeDir, 'index.html') },
       },
     })
-    await cp(join(outDir, 'index.html'), resolve(outPath))
+    return await readFile(join(outDir, 'index.html'), 'utf8')
   } finally {
     await rm(outDir, { recursive: true, force: true })
   }
+}
+
+/** Compile an MDX plan file to a single self-contained HTML file at `outPath`. */
+export async function renderToFile(mdxPath: string, outPath: string): Promise<void> {
+  const source = readFileSync(resolve(mdxPath), 'utf8').replace(/^\ufeff/, '')
+  await writeFile(resolve(outPath), await buildHtml(source))
 }
 
 export interface DevServer {
@@ -206,11 +251,10 @@ export interface DevServer {
   close: () => Promise<void>
 }
 
-/** Start a hot-reloading dev server for an MDX plan and return its local URL. */
+/** Start a hot-reloading dev server for an MDX plan file and return its local URL. */
 export async function startDevServer(mdxPath: string): Promise<DevServer> {
   const paths = findRuntimePaths()
-  const absMdx = resolve(mdxPath)
-  const server = await createServer(baseConfig(paths, absMdx))
+  const server = await createServer(baseConfig(paths, { path: resolve(mdxPath) }))
   await server.listen()
   const url =
     server.resolvedUrls?.local[0] ?? `http://localhost:${server.config.server.port ?? 5173}`

--- a/packages/cli/src/build/compile.ts
+++ b/packages/cli/src/build/compile.ts
@@ -88,12 +88,12 @@ const RESOLVED_VIRTUAL_PLAN_ID = '\0virtual:plan'
  * Serve the plan as the `virtual:plan` module the runtime imports. The source is compiled with
  * `@mdx-js/mdx` here (not via @mdx-js/rollup) so the plan can be an in-memory string with no file
  * on disk. The compiled module's default export is the MDX component, matching virtual-plan.d.ts.
- * For a `{ path }` input (the --watch dev server) the file is re-read and registered with
- * `addWatchFile`, so an edit invalidates this module and Vite recompiles + reloads.
+ * For a `{ path }` input (the --watch dev server) the file is re-read on each load and a save
+ * triggers a recompile + full reload via handleHotUpdate.
  */
 function virtualPlanPlugin(input: PlanInput): Plugin {
   const readSource = sourceReader(input)
-  const watchPath = typeof input === 'string' ? null : input.path
+  const watchPath = typeof input === 'string' ? null : resolve(input.path)
   return {
     name: 'visualplan:virtual-plan',
     enforce: 'pre',
@@ -105,6 +105,21 @@ function virtualPlanPlugin(input: PlanInput): Plugin {
       if (watchPath) this.addWatchFile(watchPath)
       const compiled = await compile(readSource(), mdxCompileOptions)
       return String(compiled)
+    },
+    // The plan is a virtual module backed by a file, not a module Vite tracks by path, so a save
+    // does NOT invalidate it on its own (addWatchFile adds the file to the watcher but does not
+    // trigger invalidation, verified). On a change to the watched plan, invalidate the virtual
+    // module and trigger a full reload so --watch reflects the edit. MDX has no HMR boundary, so a
+    // full reload is the right granularity.
+    handleHotUpdate(ctx) {
+      if (!watchPath || resolve(ctx.file) !== watchPath) return
+      const mod = ctx.server.moduleGraph.getModuleById(RESOLVED_VIRTUAL_PLAN_ID)
+      // Invalidate the compiled module if it has been loaded, then always reload: the reload must
+      // fire even before the browser has loaded virtual:plan (e.g. the very first edit), so it is
+      // unconditional, not gated on the module being in the graph.
+      if (mod) ctx.server.moduleGraph.invalidateModule(mod)
+      ctx.server.ws.send({ type: 'full-reload' })
+      return []
     },
   }
 }

--- a/packages/cli/tests/api.test.ts
+++ b/packages/cli/tests/api.test.ts
@@ -1,0 +1,96 @@
+// @vitest-environment node
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { CATALOG } from '@visualplan/core'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import * as api from '../src/api.js'
+import { InvalidPlanError, check, render } from '../src/api.js'
+import { checkPlan } from '../src/build/check.js'
+
+const VALID_PLAN = '# A plan\n\n<Phase title="Build">\n  1. Do the thing\n</Phase>\n'
+const INVALID_PLAN = '# Bad\n\n<Phase status="nope">x</Phase>\n'
+
+let workDir: string
+
+beforeAll(async () => {
+  workDir = await mkdtemp(join(tmpdir(), 'visualplan-api-test-'))
+})
+
+afterAll(async () => {
+  await rm(workDir, { recursive: true, force: true })
+})
+
+describe('render', () => {
+  let html: string
+  let written: string
+
+  beforeAll(async () => {
+    const out = join(workDir, 'plan.html')
+    html = await render(VALID_PLAN, { out })
+    written = await readFile(out, 'utf8')
+  }, 60_000)
+
+  it('returns a self-contained HTML string with the mount root (golden)', () => {
+    expect(html).toContain('<!doctype html>')
+    expect(html).toContain('id="root"')
+    // singlefile inlines the JS and CSS; assert the positive (a text scan for external
+    // tags false-positives on JS string literals in the bundle).
+    expect(html).toMatch(/<script type="module"[^>]*>\s*\S/)
+    expect(html).toMatch(/<style[^>]*>\s*\S/)
+  })
+
+  it('writes the same HTML to the out path when given one (golden)', () => {
+    expect(written).toBe(html)
+  })
+
+  it('throws InvalidPlanError carrying the issues for an invalid plan (error)', async () => {
+    await expect(render(INVALID_PLAN)).rejects.toBeInstanceOf(InvalidPlanError)
+    const error = await render(INVALID_PLAN).catch((caught: unknown) => caught)
+    expect(error).toBeInstanceOf(InvalidPlanError)
+    expect((error as InvalidPlanError).issues).toHaveLength(1)
+    expect((error as InvalidPlanError).issues[0].message).toContain('status="nope"')
+  })
+
+  it('renders an effectively empty plan without throwing (edge)', async () => {
+    const empty = await render('   \n')
+    expect(empty).toContain('<!doctype html>')
+    expect(empty).toContain('id="root"')
+  }, 60_000)
+})
+
+describe('check', () => {
+  it('returns no issues for a valid plan (golden)', async () => {
+    expect(await check(VALID_PLAN)).toEqual([])
+  })
+
+  it('returns issues with a line and column for an invalid plan (error)', async () => {
+    const issues = await check(INVALID_PLAN)
+    expect(issues).toHaveLength(1)
+    expect(issues[0].line).toBeGreaterThan(0)
+    expect(issues[0].column).toBeGreaterThan(0)
+    expect(issues[0].message).toContain('status="nope"')
+  })
+
+  it('matches the file-based checkPlan on the same source (edge)', async () => {
+    const path = join(workDir, 'parity.mdx')
+    await writeFile(path, INVALID_PLAN)
+    expect(await check(INVALID_PLAN)).toEqual(await checkPlan(path))
+  })
+})
+
+describe('catalog entry exports', () => {
+  it('exposes a component descriptor with its static enums (golden)', () => {
+    expect(api.chart.name).toBe('Chart')
+    expect(api.chart.staticEnums.type).toContain('bar')
+    expect(api.phase.staticEnums.status).toContain('planned')
+  })
+
+  it('exports every CATALOG entry under a named export (regression)', () => {
+    // CATALOG is composed from the named consts, so each entry must be reachable as an export.
+    const exported = new Set(Object.values(api as Record<string, unknown>))
+    for (const entry of CATALOG) {
+      expect(exported.has(entry)).toBe(true)
+    }
+  })
+})

--- a/packages/cli/tests/watch.test.ts
+++ b/packages/cli/tests/watch.test.ts
@@ -1,0 +1,63 @@
+// @vitest-environment node
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { type DevServer, startDevServer } from '../src/build/compile.js'
+
+let workDir: string
+let planPath: string
+let server: DevServer
+
+beforeAll(async () => {
+  workDir = await mkdtemp(join(tmpdir(), 'visualplan-watch-test-'))
+  planPath = join(workDir, 'plan.mdx')
+  await writeFile(planPath, '# First\n\ntext\n')
+  server = await startDevServer(planPath)
+}, 60_000)
+
+afterAll(async () => {
+  await server?.close()
+  await rm(workDir, { recursive: true, force: true })
+})
+
+describe('startDevServer (--watch)', () => {
+  it('serves the plan over a local URL (golden)', async () => {
+    const html = await (await fetch(server.url)).text()
+    expect(html).toContain('id="root"')
+  })
+
+  it('pushes a full-reload over HMR when the watched plan is edited (regression)', async () => {
+    // The plan is a virtual module backed by a file, so addWatchFile alone does not invalidate it
+    // on save; the plugin's handleHotUpdate must. Assert the browser-facing signal: a full-reload
+    // arrives on the HMR socket when the file changes. Without the hook this times out.
+    // Load the entry module so it imports virtual:plan into the graph; this exercises the
+    // invalidate-the-loaded-module path, not just the unconditional reload.
+    await (await fetch(new URL('/main.tsx', server.url))).text()
+    const ws = new WebSocket(server.url.replace('http', 'ws'), 'vite-hmr')
+    try {
+      const reload = new Promise<string>((resolve, reject) => {
+        ws.addEventListener('message', event => {
+          const message = JSON.parse(String(event.data))
+          if (message.type === 'full-reload') resolve(message.type)
+        })
+        ws.addEventListener('error', () => reject(new Error('HMR socket error')))
+      })
+      await new Promise(resolve => ws.addEventListener('open', resolve))
+      // Re-touch the file on an interval: under parallel test load the fork can be starved and a
+      // single chokidar event may be delayed or coalesced, so keep producing changes until the
+      // reload arrives. Resolves immediately on an idle machine.
+      let tick = 0
+      const retouch = setInterval(() => {
+        void writeFile(planPath, `# Edit ${++tick}\n\nbody ${tick}\n`)
+      }, 2_000)
+      try {
+        await expect(reload).resolves.toBe('full-reload')
+      } finally {
+        clearInterval(retouch)
+      }
+    } finally {
+      ws.close()
+    }
+  }, 60_000)
+})

--- a/packages/cli/tsup.config.ts
+++ b/packages/cli/tsup.config.ts
@@ -1,18 +1,38 @@
-import { defineConfig } from 'tsup'
+import { defineConfig, type Options } from 'tsup'
 
-export default defineConfig({
-  entry: ['src/index.ts'],
+// @visualplan/core and @visualplan/compile are private workspace packages (devDependencies), so
+// bundle them into dist for the Node check/render/API path (including core's `/share` subpath and
+// compile's `/file-icons` subpath). The regex covers the subpaths, which a bare string would miss.
+// Their third-party deps (rehype-expressive-code, material-icon-theme, remark-*, ...) stay external
+// and ship as the CLI's own dependencies. Vite resolves core separately at render time via the
+// vendored alias in compile.ts.
+const shared: Options = {
   format: ['esm'],
-  dts: false,
   sourcemap: true,
-  clean: true,
   outDir: 'dist',
-  banner: { js: '#!/usr/bin/env node' },
-  // @visualplan/core and @visualplan/compile are private workspace packages
-  // (devDependencies), so bundle them into dist for the Node check/render path (including
-  // core's `/share` subpath and compile's `/file-icons` subpath). The regex covers the
-  // subpaths, which a bare string would miss. Their third-party deps (rehype-expressive-code,
-  // material-icon-theme, remark-*, ...) stay external and ship as the CLI's own dependencies.
-  // Vite resolves core separately at render time via the vendored alias in compile.ts.
   noExternal: [/^@visualplan\/(core|compile)/],
-})
+}
+
+// Two entries cannot share one pass: the CLI bin needs the `#!/usr/bin/env node` shebang, which
+// would be a stray line at the top of the importable library, and the library needs `.d.ts` types
+// the bin does not. The CLI config cleans dist first; the library config must not (it would wipe
+// the bin). tsup builds array configs in order, so the clean happens before the library is written.
+export default defineConfig([
+  {
+    ...shared,
+    entry: ['src/index.ts'],
+    dts: false,
+    clean: true,
+    banner: { js: '#!/usr/bin/env node' },
+  },
+  {
+    ...shared,
+    entry: ['src/api.ts'],
+    // Inline the @visualplan/core types into the declaration. Without `resolve`, tsup leaves the
+    // catalog re-exports as `from '@visualplan/core'`, a private workspace package a consumer's
+    // node_modules will not have, so the types would fail to resolve. Scope it to @visualplan so
+    // third-party types (zod, etc.) stay as ordinary external imports.
+    dts: { resolve: [/^@visualplan\//] },
+    clean: false,
+  },
+])

--- a/packages/core/AGENTS.md
+++ b/packages/core/AGENTS.md
@@ -36,8 +36,12 @@ CLI's `check` and `components` commands. One file: `src/index.ts`.
 is a data component with `statSchema` and `STAT_INTENT_VALUES` (`note`, `good`, `warn`, `risk`);
 its item `value` is a free-text string (so "5 min", "99.9%" validate), unlike `Chart`'s numbers.
 
-A new component needs a schema, its enum constants, and a `CATALOG` entry (with `staticEnums`
-and an `example`) here, plus a component in `@visualplan/runtime`. `staticEnums` is what
+Each `CATALOG` entry is its own named const (`phase`, `chart`, `fileTree`, ...) and `CATALOG` is
+composed from them, so the `vplan` programmatic API can re-export one descriptor per component. The
+const name is the export identifier; the entry's `name` field is the human label (`mermaid`/`math`
+keep their "(code fence)" labels). A new component needs a schema, its enum constants, and a named
+`CATALOG` entry (with `staticEnums` and an `example`) added to the `CATALOG` array here, plus a
+component in `@visualplan/runtime`. `staticEnums` is what
 the CLI's AST checker validates statically; everything else is validated at render time by zod.
 The schemas describe the **decoded** shape; for the data components the `example` shows the
 markdown-children authoring (a bullet/task list, `Compare` headings, or a GFM table for `Matrix`

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -137,87 +137,113 @@ export interface CatalogEntry {
   example: string
 }
 
+// Each entry is its own named export so a consumer of the programmatic API can import a single
+// component's descriptor (`import { chart } from 'vplan'`). The const name is the export
+// identifier; the `name` field stays the human label used by `check` and the components printer
+// (so `mermaid`/`math` keep their "(code fence)" labels). CATALOG is composed from them below.
+export const phase: CatalogEntry = {
+  name: 'Phase',
+  summary: 'A numbered vertical-timeline step with a status badge. Wraps markdown.',
+  staticEnums: { status: STATUS_VALUES },
+  example: '<Phase title="Build the API" status="active">\n  1. Define routes\n</Phase>',
+}
+
+export const fileTree: CatalogEntry = {
+  name: 'FileTree',
+  summary:
+    'A nested directory tree of file changes. Write a markdown list, one "- <change> <path>" per file; change is add/modify/delete/move. Append " -- <note>" for an inline comment.',
+  staticEnums: {},
+  example:
+    '<FileTree>\n- add src/api/routes.ts -- new sliding-window limiter\n- modify src/api/db.ts\n- delete src/legacy.ts\n</FileTree>',
+}
+
+export const chart: CatalogEntry = {
+  name: 'Chart',
+  summary:
+    'A bar/line/area/scatter/radar/gauge/funnel/treemap/pie chart for estimates or metrics. Single series (bar/line/area/gauge/funnel/treemap/pie): a markdown list of "- <label>: <value>". Multiple series (bar/line/area/radar): a markdown table with a "category | series1 | series2" header. Scatter needs a table with exactly two value columns (x, y). Add the "stacked" attribute to a multi-series bar/area to stack the series.',
+  staticEnums: { type: CHART_TYPE_VALUES },
+  example:
+    '<Chart type="bar" title="Effort (days)">\n- API: 3\n- UI: 2\n</Chart>\n\n<Chart type="line" title="Latency by stage (ms)">\n| Stage | p50 | p95 |\n|-------|-----|-----|\n| Auth  | 12  | 30  |\n| DB    | 40  | 120 |\n</Chart>\n\n<Chart type="bar" stacked title="Effort by area (days)">\n| Phase | API | UI |\n|-------|-----|----|\n| Build | 3   | 2  |\n| Test  | 1   | 1  |\n</Chart>',
+}
+
+export const compare: CatalogEntry = {
+  name: 'Compare',
+  summary:
+    'Side-by-side option cards for weighing approaches. Each option is a "## Name" heading (add "(pick)" to recommend one) with as many "- pro:" / "- con:" bullets as you need.',
+  staticEnums: {},
+  example:
+    '<Compare>\n## Postgres (pick)\n- pro: ACID\n- pro: mature tooling\n- con: vertical scaling\n\n## SQLite\n- pro: simple\n- con: single-writer\n</Compare>',
+}
+
+export const matrix: CatalogEntry = {
+  name: 'Matrix',
+  summary:
+    'A comparison grid (options x dimensions) for weighing several choices across several criteria. Write a markdown table; the first column is the row labels, append "(pick)" to one column header to highlight it. Use Compare for pros/cons, Matrix for a scorecard.',
+  staticEnums: {},
+  example:
+    '<Matrix>\n| Dimension | Postgres (pick) | ClickHouse | DynamoDB |\n|-----------|-----------------|------------|----------|\n| Writes    | medium          | high       | high     |\n| Querying  | high            | medium     | low      |\n| Ops cost  | low             | medium     | low      |\n</Matrix>',
+}
+
+export const callout: CatalogEntry = {
+  name: 'Callout',
+  summary: 'A highlighted note/tip/risk/decision/warning block. Wraps markdown.',
+  staticEnums: { type: CALLOUT_TYPE_VALUES },
+  example: '<Callout type="tip">\n  Use ins=/regex/ to mark code as inserted.\n</Callout>',
+}
+
+export const questions: CatalogEntry = {
+  name: 'Questions',
+  summary:
+    'Open questions you want the reader to weigh in on before building, as a highlighted panel. Write a markdown list. Title defaults to "Open questions"; override with title.',
+  staticEnums: {},
+  example:
+    '<Questions>\n- Should refresh tokens rotate on every use?\n- Is a 15-minute access-token TTL acceptable?\n</Questions>',
+}
+
+export const checklist: CatalogEntry = {
+  name: 'Checklist',
+  summary:
+    'Acceptance criteria / definition of done. Write a markdown task list ("- [x]" done, "- [ ]" todo).',
+  staticEnums: {},
+  example:
+    '<Checklist title="Done when">\n- [x] Returns 429 over the limit\n- [ ] Dashboards live\n</Checklist>',
+}
+
+export const stat: CatalogEntry = {
+  name: 'Stat',
+  summary:
+    'Headline plan metrics as a grid of cards. Write a markdown list, one "- <label>: <value> (<intent>) -- <caption>" per stat; value is free text, intent (good/warn/risk/note) and the "-- caption" are optional.',
+  staticEnums: {},
+  example:
+    '<Stat>\n- Files changed: 12\n- Est. uptime: 99.9% (good)\n- RPO: 5 min (risk) -- worst-case data loss\n</Stat>',
+}
+
+export const mermaid: CatalogEntry = {
+  name: 'mermaid (code fence)',
+  summary:
+    'A flowchart, sequence, state, class, ER, or XY-chart diagram. Write a ```mermaid fenced block. (gantt/pie are not supported by the renderer.)',
+  staticEnums: {},
+  example: '```mermaid\nflowchart LR\n  A[Client] --> B[API] --> C[(DB)]\n```',
+}
+
+export const math: CatalogEntry = {
+  name: 'math (code fence)',
+  summary:
+    'A display math formula. Write a ```math fenced block containing LaTeX; it is typeset as MathML.',
+  staticEnums: {},
+  example: '```math\n\\sum_{i=1}^{n} i = \\frac{n(n+1)}{2}\n```',
+}
+
 export const CATALOG: readonly CatalogEntry[] = [
-  {
-    name: 'Phase',
-    summary: 'A numbered vertical-timeline step with a status badge. Wraps markdown.',
-    staticEnums: { status: STATUS_VALUES },
-    example: '<Phase title="Build the API" status="active">\n  1. Define routes\n</Phase>',
-  },
-  {
-    name: 'FileTree',
-    summary:
-      'A nested directory tree of file changes. Write a markdown list, one "- <change> <path>" per file; change is add/modify/delete/move. Append " -- <note>" for an inline comment.',
-    staticEnums: {},
-    example:
-      '<FileTree>\n- add src/api/routes.ts -- new sliding-window limiter\n- modify src/api/db.ts\n- delete src/legacy.ts\n</FileTree>',
-  },
-  {
-    name: 'Chart',
-    summary:
-      'A bar/line/area/scatter/radar/gauge/funnel/treemap/pie chart for estimates or metrics. Single series (bar/line/area/gauge/funnel/treemap/pie): a markdown list of "- <label>: <value>". Multiple series (bar/line/area/radar): a markdown table with a "category | series1 | series2" header. Scatter needs a table with exactly two value columns (x, y). Add the "stacked" attribute to a multi-series bar/area to stack the series.',
-    staticEnums: { type: CHART_TYPE_VALUES },
-    example:
-      '<Chart type="bar" title="Effort (days)">\n- API: 3\n- UI: 2\n</Chart>\n\n<Chart type="line" title="Latency by stage (ms)">\n| Stage | p50 | p95 |\n|-------|-----|-----|\n| Auth  | 12  | 30  |\n| DB    | 40  | 120 |\n</Chart>\n\n<Chart type="bar" stacked title="Effort by area (days)">\n| Phase | API | UI |\n|-------|-----|----|\n| Build | 3   | 2  |\n| Test  | 1   | 1  |\n</Chart>',
-  },
-  {
-    name: 'Compare',
-    summary:
-      'Side-by-side option cards for weighing approaches. Each option is a "## Name" heading (add "(pick)" to recommend one) with as many "- pro:" / "- con:" bullets as you need.',
-    staticEnums: {},
-    example:
-      '<Compare>\n## Postgres (pick)\n- pro: ACID\n- pro: mature tooling\n- con: vertical scaling\n\n## SQLite\n- pro: simple\n- con: single-writer\n</Compare>',
-  },
-  {
-    name: 'Matrix',
-    summary:
-      'A comparison grid (options x dimensions) for weighing several choices across several criteria. Write a markdown table; the first column is the row labels, append "(pick)" to one column header to highlight it. Use Compare for pros/cons, Matrix for a scorecard.',
-    staticEnums: {},
-    example:
-      '<Matrix>\n| Dimension | Postgres (pick) | ClickHouse | DynamoDB |\n|-----------|-----------------|------------|----------|\n| Writes    | medium          | high       | high     |\n| Querying  | high            | medium     | low      |\n| Ops cost  | low             | medium     | low      |\n</Matrix>',
-  },
-  {
-    name: 'Callout',
-    summary: 'A highlighted note/tip/risk/decision/warning block. Wraps markdown.',
-    staticEnums: { type: CALLOUT_TYPE_VALUES },
-    example: '<Callout type="tip">\n  Use ins=/regex/ to mark code as inserted.\n</Callout>',
-  },
-  {
-    name: 'Questions',
-    summary:
-      'Open questions you want the reader to weigh in on before building, as a highlighted panel. Write a markdown list. Title defaults to "Open questions"; override with title.',
-    staticEnums: {},
-    example:
-      '<Questions>\n- Should refresh tokens rotate on every use?\n- Is a 15-minute access-token TTL acceptable?\n</Questions>',
-  },
-  {
-    name: 'Checklist',
-    summary:
-      'Acceptance criteria / definition of done. Write a markdown task list ("- [x]" done, "- [ ]" todo).',
-    staticEnums: {},
-    example:
-      '<Checklist title="Done when">\n- [x] Returns 429 over the limit\n- [ ] Dashboards live\n</Checklist>',
-  },
-  {
-    name: 'Stat',
-    summary:
-      'Headline plan metrics as a grid of cards. Write a markdown list, one "- <label>: <value> (<intent>) -- <caption>" per stat; value is free text, intent (good/warn/risk/note) and the "-- caption" are optional.',
-    staticEnums: {},
-    example:
-      '<Stat>\n- Files changed: 12\n- Est. uptime: 99.9% (good)\n- RPO: 5 min (risk) -- worst-case data loss\n</Stat>',
-  },
-  {
-    name: 'mermaid (code fence)',
-    summary:
-      'A flowchart, sequence, state, class, ER, or XY-chart diagram. Write a ```mermaid fenced block. (gantt/pie are not supported by the renderer.)',
-    staticEnums: {},
-    example: '```mermaid\nflowchart LR\n  A[Client] --> B[API] --> C[(DB)]\n```',
-  },
-  {
-    name: 'math (code fence)',
-    summary:
-      'A display math formula. Write a ```math fenced block containing LaTeX; it is typeset as MathML.',
-    staticEnums: {},
-    example: '```math\n\\sum_{i=1}^{n} i = \\frac{n(n+1)}{2}\n```',
-  },
+  phase,
+  fileTree,
+  chart,
+  compare,
+  matrix,
+  callout,
+  questions,
+  checklist,
+  stat,
+  mermaid,
+  math,
 ]


### PR DESCRIPTION
## What

Adds a programmatic Node API to `vplan` so a server, build step, or agent harness can render and validate plans in memory instead of shelling out to the CLI. The package now ships two entries: the existing `vplan` bin and a new `import` entry.

```ts
import { render, check, chart } from 'vplan'

const html = await render(source)            // string in, self-contained HTML string out
await render(source, { out: 'plan.html' })   // also write a file
const issues = await check(source)           // structured issues, [] when valid
chart.staticEnums.type                        // introspect a single component
```

## Surface

- `render(source, { out? })` -> HTML string. Validates first and throws `InvalidPlanError` (carrying `.issues`) on an invalid plan, so callers get the same self-correction guarantee the CLI has.
- `check(source)` -> `CheckIssue[]`.
- One named export per catalog entry (`phase`, `chart`, `fileTree`, ...), each a `CatalogEntry`.

## Notable changes

- **In-memory compile, no temp file.** `virtual:plan` is now a virtual module compiled with `@mdx-js/mdx` rather than a path alias + `@mdx-js/rollup`. The one-shot build and `--watch` share one compile path.
- **`@visualplan/core`** refactored so each `CATALOG` entry is its own named const (composed into `CATALOG`), enabling the per-component re-exports.
- **Packaging:** `exports` map + `main`/`types` alongside the `bin`; `tsup` split into two configs (shebang bin vs. dts library; `dts.resolve` inlines the private `@visualplan` types so consumers' types resolve).
- **`--watch` HMR fix:** a plan is now a virtual module backed by a file, so `addWatchFile` does not invalidate it on save; a `handleHotUpdate` hook invalidates the module and pushes a full-reload. Guarded by a regression test over the HMR socket.
- **Docs:** new `/docs/programmatic` page (in the sidebar) plus AGENTS.md updates across root/cli/core/app.

## Verification

- `pnpm build` (both entries + `.d.ts`), `pnpm test` (195 passing, +11 new), `pnpm typecheck` (0 errors), biome clean on all touched files.
- Built `dist/api.js` exercised as a consumer (render/check/throw/catalog); built CLI bin still works unchanged.