### PR TITLE
refactor!: rename programmatic API to renderPlan/checkPlan

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,8 +12,8 @@ polished, self-contained HTML page, so an AI agent can present plans as scannabl
 - `vplan check <file.mdx>` validates a plan without rendering (the self-correction
   loop): MDX compile errors plus static component checks, printed as `file:line:col`.
 - `vplan components` prints the component vocabulary cheat-sheet.
-- A programmatic API (`import { render, check } from 'vplan'`) renders/validates a plan from an
-  in-memory MDX string, with a named export per catalog entry. See `packages/cli/src/api.ts`.
+- A programmatic API (`import { renderPlan, checkPlan } from 'vplan'`) renders/validates a plan from
+  an in-memory MDX string, with a named export per catalog entry. See `packages/cli/src/api.ts`.
 
 Plans use a fixed, tiny component vocabulary (`Phase`, `FileTree`, `Chart`, `Compare`, `Matrix`,
 `Callout`, `Questions`, `Checklist`, and ` ```mermaid ` / ` ```math ` fences) with no imports — the

--- a/packages/app/src/pages/docs/programmatic.md
+++ b/packages/app/src/pages/docs/programmatic.md
@@ -18,7 +18,7 @@ Everything works on an in-memory MDX **string**, nothing touches the filesystem 
 to:
 
 ```ts
-import { render, check } from 'vplan'
+import { renderPlan, checkPlan } from 'vplan'
 
 const source = `# Add rate limiting
 
@@ -27,32 +27,32 @@ const source = `# Add rate limiting
 </Phase>
 `
 
-const html = await render(source) // a self-contained HTML string
+const html = await renderPlan(source) // a self-contained HTML string
 ```
 
-## render
+## renderPlan
 
 ```ts
-render(source: string, options?: { out?: string }): Promise<string>
+renderPlan(source: string, options?: { out?: string }): Promise<string>
 ```
 
 Compiles a plan's MDX source to a self-contained HTML page and returns it as a string. Pass `out`
 to also write the HTML to a file:
 
 ```ts
-const html = await render(source)              // string in, string out
-await render(source, { out: 'plan.html' })     // also write a file
+const html = await renderPlan(source)              // string in, string out
+await renderPlan(source, { out: 'plan.html' })     // also write a file
 ```
 
-`render` validates the plan first and **throws `InvalidPlanError` if it is invalid**, so a
+`renderPlan` validates the plan first and **throws `InvalidPlanError` if it is invalid**, so a
 programmatic caller gets the same self-correction guarantee the CLI has. The error carries the
 structured issues:
 
 ```ts
-import { render, InvalidPlanError } from 'vplan'
+import { renderPlan, InvalidPlanError } from 'vplan'
 
 try {
-  await render('# Bad\n\n<Phase status="nope">x</Phase>\n')
+  await renderPlan('# Bad\n\n<Phase status="nope">x</Phase>\n')
 } catch (error) {
   if (error instanceof InvalidPlanError) {
     for (const issue of error.issues) {
@@ -62,10 +62,10 @@ try {
 }
 ```
 
-## check
+## checkPlan
 
 ```ts
-check(source: string): Promise<CheckIssue[]>
+checkPlan(source: string): Promise<CheckIssue[]>
 ```
 
 Validates a plan's MDX source without rendering it, returning the issues (an empty array when the
@@ -73,7 +73,7 @@ plan is valid). Each issue has a `line`, `column`, and `message`, the same check
 `vplan check` runs:
 
 ```ts
-const issues = await check(source)
+const issues = await checkPlan(source)
 if (issues.length === 0) {
   // safe to render
 }

--- a/packages/cli/AGENTS.md
+++ b/packages/cli/AGENTS.md
@@ -8,11 +8,13 @@ programmatic Node API at `dist/api.js` (the package's `import` entry, `exports["
 
 - `src/index.ts` — commander dispatch (the `bin`). `src/commands/` — one file per command (render,
   check, components).
-- `src/api.ts` — the programmatic API (the library entry): `render(source, { out? })` (returns the
-  HTML string, throws `InvalidPlanError` on an invalid plan, optional file write), `check(source)`,
-  and one named re-export per catalog entry from `@visualplan/core` (`phase`, `chart`, ...). It is
-  source-string based on purpose: rendering a file is `render(await readFile(path, 'utf8'))`, which
-  avoids a path-vs-source overload. It wraps the same `buildHtml`/`checkSource` the CLI uses.
+- `src/api.ts` — the programmatic API (the library entry): `renderPlan(source, { out? })` (returns
+  the HTML string, throws `InvalidPlanError` on an invalid plan, optional file write),
+  `checkPlan(source)`, and one named re-export per catalog entry from `@visualplan/core` (`phase`,
+  `chart`, ...). It is source-string based on purpose: rendering a file is
+  `renderPlan(await readFile(path, 'utf8'))`, which avoids a path-vs-source overload. It wraps the
+  same `buildHtml`/`checkSource` the CLI uses. (NB: the API `checkPlan` is source-based; the internal
+  `build/check.ts checkPlan` is the file-path-based wrapper, a different signature.)
 - `src/build/compile.ts` — Vite orchestration. `buildHtml(source)` is the shared core: it compiles
   a plan from an in-memory MDX **string** and returns the self-contained HTML (single-file build via
   `vite-plugin-singlefile`). `renderToFile(path, out)` reads the file once and delegates; the API's

--- a/packages/cli/src/api.ts
+++ b/packages/cli/src/api.ts
@@ -1,8 +1,8 @@
 /**
  * The programmatic interface for `vplan`: render and validate a plan from an in-memory MDX string,
- * and introspect the component vocabulary. This is the package's import entry (`import { render }
+ * and introspect the component vocabulary. This is the package's import entry (`import { renderPlan }
  * from 'vplan'`); the CLI bin is a separate entry. Nothing here touches the filesystem unless you
- * pass `render`'s `out` option.
+ * pass `renderPlan`'s `out` option.
  */
 import { writeFile } from 'node:fs/promises'
 import { resolve } from 'node:path'
@@ -14,7 +14,7 @@ export interface RenderOptions {
   out?: string
 }
 
-/** Thrown by `render` when the plan fails validation, carrying the structured issues. */
+/** Thrown by `renderPlan` when the plan fails validation, carrying the structured issues. */
 export class InvalidPlanError extends Error {
   readonly issues: CheckIssue[]
   constructor(issues: CheckIssue[]) {
@@ -32,7 +32,7 @@ export class InvalidPlanError extends Error {
  * plan first and throws `InvalidPlanError` if it has any issues, so a programmatic caller gets the
  * same self-correction guarantee the CLI has. Pass `out` to also write the HTML to a file.
  */
-export async function render(source: string, options: RenderOptions = {}): Promise<string> {
+export async function renderPlan(source: string, options: RenderOptions = {}): Promise<string> {
   const issues = await checkSource(source)
   if (issues.length > 0) throw new InvalidPlanError(issues)
   const html = await buildHtml(source)
@@ -41,7 +41,7 @@ export async function render(source: string, options: RenderOptions = {}): Promi
 }
 
 /** Validate a plan's MDX source, returning the issues (an empty array when the plan is valid). */
-export async function check(source: string): Promise<CheckIssue[]> {
+export async function checkPlan(source: string): Promise<CheckIssue[]> {
   return checkSource(source)
 }
 

--- a/packages/cli/tests/api.test.ts
+++ b/packages/cli/tests/api.test.ts
@@ -5,8 +5,8 @@ import { join } from 'node:path'
 import { CATALOG } from '@visualplan/core'
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 import * as api from '../src/api.js'
-import { InvalidPlanError, check, render } from '../src/api.js'
-import { checkPlan } from '../src/build/check.js'
+import { InvalidPlanError, checkPlan, renderPlan } from '../src/api.js'
+import { checkPlan as checkPlanFile } from '../src/build/check.js'
 
 const VALID_PLAN = '# A plan\n\n<Phase title="Build">\n  1. Do the thing\n</Phase>\n'
 const INVALID_PLAN = '# Bad\n\n<Phase status="nope">x</Phase>\n'
@@ -27,7 +27,7 @@ describe('render', () => {
 
   beforeAll(async () => {
     const out = join(workDir, 'plan.html')
-    html = await render(VALID_PLAN, { out })
+    html = await renderPlan(VALID_PLAN, { out })
     written = await readFile(out, 'utf8')
   }, 60_000)
 
@@ -45,37 +45,37 @@ describe('render', () => {
   })
 
   it('throws InvalidPlanError carrying the issues for an invalid plan (error)', async () => {
-    await expect(render(INVALID_PLAN)).rejects.toBeInstanceOf(InvalidPlanError)
-    const error = await render(INVALID_PLAN).catch((caught: unknown) => caught)
+    await expect(renderPlan(INVALID_PLAN)).rejects.toBeInstanceOf(InvalidPlanError)
+    const error = await renderPlan(INVALID_PLAN).catch((caught: unknown) => caught)
     expect(error).toBeInstanceOf(InvalidPlanError)
     expect((error as InvalidPlanError).issues).toHaveLength(1)
     expect((error as InvalidPlanError).issues[0].message).toContain('status="nope"')
   })
 
   it('renders an effectively empty plan without throwing (edge)', async () => {
-    const empty = await render('   \n')
+    const empty = await renderPlan('   \n')
     expect(empty).toContain('<!doctype html>')
     expect(empty).toContain('id="root"')
   }, 60_000)
 })
 
-describe('check', () => {
+describe('checkPlan', () => {
   it('returns no issues for a valid plan (golden)', async () => {
-    expect(await check(VALID_PLAN)).toEqual([])
+    expect(await checkPlan(VALID_PLAN)).toEqual([])
   })
 
   it('returns issues with a line and column for an invalid plan (error)', async () => {
-    const issues = await check(INVALID_PLAN)
+    const issues = await checkPlan(INVALID_PLAN)
     expect(issues).toHaveLength(1)
     expect(issues[0].line).toBeGreaterThan(0)
     expect(issues[0].column).toBeGreaterThan(0)
     expect(issues[0].message).toContain('status="nope"')
   })
 
-  it('matches the file-based checkPlan on the same source (edge)', async () => {
+  it('matches the file-based checker on the same source (edge)', async () => {
     const path = join(workDir, 'parity.mdx')
     await writeFile(path, INVALID_PLAN)
-    expect(await check(INVALID_PLAN)).toEqual(await checkPlan(path))
+    expect(await checkPlan(INVALID_PLAN)).toEqual(await checkPlanFile(path))
   })
 })
 


### PR DESCRIPTION
## What

Renames the programmatic API exports so they read clearly when imported alongside other functions:

- `render` -> `renderPlan`
- `check` -> `checkPlan`

```ts
import { renderPlan, checkPlan } from 'vplan'
```

`InvalidPlanError`, `RenderOptions`, and the per-component catalog exports (`phase`, `chart`, ...) are unchanged. The CLI bin (`vplan render` / `check` / `components`) is unchanged.

## Breaking change

This breaks the API shipped in 0.11.0. Consumers must update their imports:

```diff
-import { render, check } from 'vplan'
-const html = await render(source)
-const issues = await check(source)
+import { renderPlan, checkPlan } from 'vplan'
+const html = await renderPlan(source)
+const issues = await checkPlan(source)
```

In 0.x a breaking change is a minor bump, so this would release as **0.12.0** (not cut here).

## Verification

- `pnpm test` (195 passing), `pnpm typecheck` (0 errors), `pnpm build`, biome clean on touched files.
- Built `dist/api.js`/`dist/api.d.ts` confirmed to export `renderPlan`/`checkPlan` and no longer export `render`/`check`.