### PR TITLE
Theme config persistence, settings cog, and renderPlan view options

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,8 +12,8 @@ polished, self-contained HTML page, so an AI agent can present plans as scannabl
 - `vplan check <file.mdx>` validates a plan without rendering (the self-correction
   loop): MDX compile errors plus static component checks, printed as `file:line:col`.
 - `vplan components` prints the component vocabulary cheat-sheet.
-- A programmatic API (`import { render, check } from 'vplan'`) renders/validates a plan from an
-  in-memory MDX string, with a named export per catalog entry. See `packages/cli/src/api.ts`.
+- A programmatic API (`import { renderPlan, checkPlan } from 'vplan'`) renders/validates a plan from
+  an in-memory MDX string, with a named export per catalog entry. See `packages/cli/src/api.ts`.
 
 Plans use a fixed, tiny component vocabulary (`Phase`, `FileTree`, `Chart`, `Compare`, `Matrix`,
 `Callout`, `Questions`, `Checklist`, and ` ```mermaid ` / ` ```math ` fences) with no imports — the

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,7 @@ polished, self-contained HTML page, so an AI agent can present plans as scannabl
   an in-memory MDX string, with a named export per catalog entry. See `packages/cli/src/api.ts`.
 - A persistent CLI config at `~/.vplan/config.json` (`packages/cli/src/config.ts`) sets the default
   `theme` (`light`|`dark`|`system`) baked into a rendered plan; the plan's in-page cog overrides it
-  per-view via `localStorage`.
+  per-view via `localStorage`. `vplan config [get|set|path]` views and edits it.
 
 Plans use a fixed, tiny component vocabulary (`Phase`, `FileTree`, `Chart`, `Compare`, `Matrix`,
 `Callout`, `Questions`, `Checklist`, and ` ```mermaid ` / ` ```math ` fences) with no imports — the

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,9 @@ polished, self-contained HTML page, so an AI agent can present plans as scannabl
 - `vplan components` prints the component vocabulary cheat-sheet.
 - A programmatic API (`import { renderPlan, checkPlan } from 'vplan'`) renders/validates a plan from
   an in-memory MDX string, with a named export per catalog entry. See `packages/cli/src/api.ts`.
+- A persistent CLI config at `~/.vplan/config.json` (`packages/cli/src/config.ts`) sets the default
+  `theme` (`light`|`dark`|`system`) baked into a rendered plan; the plan's in-page cog overrides it
+  per-view via `localStorage`.
 
 Plans use a fixed, tiny component vocabulary (`Phase`, `FileTree`, `Chart`, `Compare`, `Matrix`,
 `Callout`, `Questions`, `Checklist`, and ` ```mermaid ` / ` ```math ` fences) with no imports — the
@@ -118,6 +121,10 @@ A release is cut by creating a GitHub release; the tag is the published version 
 
 ## Key Decisions
 
+- 2026-06-22: CLI config persists to `~/.vplan/config.json` (literal path via `homedir()`, NOT
+  `env-paths`); the only setting is the default `theme`. The in-page theme cog overrides per-view via
+  `localStorage` and never writes the file. Why: a static `file://` plan cannot reach the disk, so
+  the on-disk default and the in-page override are deliberately separate layers.
 - 2026-06-21: Plan sharing encodes the plan's **MDX source** (deflate + base64url) into a
   `visualplan.dev/view?data=...` link, not the compiled output. Why: the source is small, compresses
   well, and is the one form `/view` recompiles in-browser with the same plugins (`@visualplan/compile`);

--- a/packages/app/src/pages/docs/programmatic.md
+++ b/packages/app/src/pages/docs/programmatic.md
@@ -33,7 +33,11 @@ const html = await renderPlan(source) // a self-contained HTML string
 ## renderPlan
 
 ```ts
-renderPlan(source: string, options?: { out?: string }): Promise<string>
+renderPlan(source: string, options?: {
+  out?: string
+  theme?: 'light' | 'dark' | 'system'
+  enableSharing?: boolean
+}): Promise<string>
 ```
 
 Compiles a plan's MDX source to a self-contained HTML page and returns it as a string. Pass `out`
@@ -42,6 +46,26 @@ to also write the HTML to a file:
 ```ts
 const html = await renderPlan(source)              // string in, string out
 await renderPlan(source, { out: 'plan.html' })     // also write a file
+```
+
+### Controlling the rendered page
+
+By default the page shows the in-page settings cog (so the viewer can switch theme) and hides the
+share button. Two options change that:
+
+- **`theme`** fixes the color scheme. When set, the page renders in that scheme and the settings cog
+  is hidden, so the viewer cannot change it (a locked theme also ignores the per-view `localStorage`
+  override). When omitted, the page defaults to `system` and shows the cog.
+- **`enableSharing`** (default `false`) shows the share button, which copies a
+  `visualplan.dev/view?data=...` link encoding the plan. Leave it off for an embedded render that
+  should not expose sharing.
+
+```ts
+// A fixed dark page with no settings cog and no share button (both defaults for an embed):
+const html = await renderPlan(source, { theme: 'dark' })
+
+// Opt back into the share button:
+const shareable = await renderPlan(source, { enableSharing: true })
 ```
 
 `renderPlan` validates the plan first and **throws `InvalidPlanError` if it is invalid**, so a

--- a/packages/app/src/pages/docs/programmatic.md
+++ b/packages/app/src/pages/docs/programmatic.md
@@ -18,7 +18,7 @@ Everything works on an in-memory MDX **string**, nothing touches the filesystem 
 to:
 
 ```ts
-import { render, check } from 'vplan'
+import { renderPlan, checkPlan } from 'vplan'
 
 const source = `# Add rate limiting
 
@@ -27,32 +27,32 @@ const source = `# Add rate limiting
 </Phase>
 `
 
-const html = await render(source) // a self-contained HTML string
+const html = await renderPlan(source) // a self-contained HTML string
 ```
 
-## render
+## renderPlan
 
 ```ts
-render(source: string, options?: { out?: string }): Promise<string>
+renderPlan(source: string, options?: { out?: string }): Promise<string>
 ```
 
 Compiles a plan's MDX source to a self-contained HTML page and returns it as a string. Pass `out`
 to also write the HTML to a file:
 
 ```ts
-const html = await render(source)              // string in, string out
-await render(source, { out: 'plan.html' })     // also write a file
+const html = await renderPlan(source)              // string in, string out
+await renderPlan(source, { out: 'plan.html' })     // also write a file
 ```
 
-`render` validates the plan first and **throws `InvalidPlanError` if it is invalid**, so a
+`renderPlan` validates the plan first and **throws `InvalidPlanError` if it is invalid**, so a
 programmatic caller gets the same self-correction guarantee the CLI has. The error carries the
 structured issues:
 
 ```ts
-import { render, InvalidPlanError } from 'vplan'
+import { renderPlan, InvalidPlanError } from 'vplan'
 
 try {
-  await render('# Bad\n\n<Phase status="nope">x</Phase>\n')
+  await renderPlan('# Bad\n\n<Phase status="nope">x</Phase>\n')
 } catch (error) {
   if (error instanceof InvalidPlanError) {
     for (const issue of error.issues) {
@@ -62,10 +62,10 @@ try {
 }
 ```
 
-## check
+## checkPlan
 
 ```ts
-check(source: string): Promise<CheckIssue[]>
+checkPlan(source: string): Promise<CheckIssue[]>
 ```
 
 Validates a plan's MDX source without rendering it, returning the issues (an empty array when the
@@ -73,7 +73,7 @@ plan is valid). Each issue has a `line`, `column`, and `message`, the same check
 `vplan check` runs:
 
 ```ts
-const issues = await check(source)
+const issues = await checkPlan(source)
 if (issues.length === 0) {
   // safe to render
 }

--- a/packages/cli/AGENTS.md
+++ b/packages/cli/AGENTS.md
@@ -8,11 +8,13 @@ programmatic Node API at `dist/api.js` (the package's `import` entry, `exports["
 
 - `src/index.ts` — commander dispatch (the `bin`). `src/commands/` — one file per command (render,
   check, components).
-- `src/api.ts` — the programmatic API (the library entry): `render(source, { out? })` (returns the
-  HTML string, throws `InvalidPlanError` on an invalid plan, optional file write), `check(source)`,
-  and one named re-export per catalog entry from `@visualplan/core` (`phase`, `chart`, ...). It is
-  source-string based on purpose: rendering a file is `render(await readFile(path, 'utf8'))`, which
-  avoids a path-vs-source overload. It wraps the same `buildHtml`/`checkSource` the CLI uses.
+- `src/api.ts` — the programmatic API (the library entry): `renderPlan(source, { out? })` (returns
+  the HTML string, throws `InvalidPlanError` on an invalid plan, optional file write),
+  `checkPlan(source)`, and one named re-export per catalog entry from `@visualplan/core` (`phase`,
+  `chart`, ...). It is source-string based on purpose: rendering a file is
+  `renderPlan(await readFile(path, 'utf8'))`, which avoids a path-vs-source overload. It wraps the
+  same `buildHtml`/`checkSource` the CLI uses. (NB: the API `checkPlan` is source-based; the internal
+  `build/check.ts checkPlan` is the file-path-based wrapper, a different signature.)
 - `src/build/compile.ts` — Vite orchestration. `buildHtml(source)` is the shared core: it compiles
   a plan from an in-memory MDX **string** and returns the self-contained HTML (single-file build via
   `vite-plugin-singlefile`). `renderToFile(path, out)` reads the file once and delegates; the API's

--- a/packages/cli/AGENTS.md
+++ b/packages/cli/AGENTS.md
@@ -8,6 +8,14 @@ programmatic Node API at `dist/api.js` (the package's `import` entry, `exports["
 
 - `src/index.ts` — commander dispatch (the `bin`). `src/commands/` — one file per command (render,
   check, components).
+- `src/config.ts` — the persistent CLI config at `~/.vplan/config.json` (literal path via
+  `homedir()`, deliberately NOT `env-paths`). Only setting today is `theme` (`light`|`dark`|
+  `system`). `readConfig` is tolerant (missing/malformed/unknown-theme -> `{ theme: 'system' }`) so a
+  hand-broken config never breaks a render; `writeConfig` exists for a future `vplan config` command
+  and the tests (nothing in the render path writes it). The render command reads it and passes the
+  theme into the build; the rendered plan's in-page cog overrides per-view via `localStorage` and
+  never writes back here. Both `readConfig`/`writeConfig` take an optional `dir` so tests point at a
+  temp directory instead of the real home.
 - `src/api.ts` — the programmatic API (the library entry): `renderPlan(source, { out? })` (returns
   the HTML string, throws `InvalidPlanError` on an invalid plan, optional file write),
   `checkPlan(source)`, and one named re-export per catalog entry from `@visualplan/core` (`phase`,
@@ -39,7 +47,12 @@ programmatic Node API at `dist/api.js` (the package's `import` entry, `exports["
   size it). It also appends the Node-only `remarkFileTreeIcons` (`@visualplan/compile/filetree-icons`)
   to the remark chain, which inlines a Material file-type icon per `<FileTree>` entry; both are
   CLI-only so the browser bundle never loads `material-icon-theme`. Color chips and file icons both inline their output at build time, so the single-file
-  invariant holds. `src/build/check.ts` — the static AST
+  invariant holds. `buildHtml(source, theme)` and `renderToFile`/`startDevServer` take the
+  configured `theme` (default `system`; the programmatic `renderPlan` leaves it default).
+  `planConfigPlugin` injects a tiny non-module `<head>` script (`themeBootstrap`) that seeds
+  `globalThis.__VP_CONFIG__` and sets `<html data-theme>` before first paint, so a configured dark
+  plan has no light flash. That script's resolution (localStorage `vp-theme` -> injected default ->
+  `system`) MUST stay in sync with the runtime's `theme.ts`. `src/build/check.ts` — the static AST
   validator. It also runs each ` ```math ` block through Temml and each ` ```mermaid ` block through
   `beautiful-mermaid`'s `renderMermaidSVG` (the same renderer the runtime `Mermaid` component calls)
   to report bad LaTeX / an unrenderable diagram as `file:line:col`, so `check` and render agree on

--- a/packages/cli/AGENTS.md
+++ b/packages/cli/AGENTS.md
@@ -7,15 +7,17 @@ programmatic Node API at `dist/api.js` (the package's `import` entry, `exports["
 ## Structure
 
 - `src/index.ts` — commander dispatch (the `bin`). `src/commands/` — one file per command (render,
-  check, components).
+  check, components, config). `config` is a parent command: bare `config` shows the settings + path,
+  `config get <key>` / `config set <key> <value>` / `config path` are subcommands. Invalid key/value
+  throws, which the top-level catch turns into a stderr message + exit 1.
 - `src/config.ts` — the persistent CLI config at `~/.vplan/config.json` (literal path via
   `homedir()`, deliberately NOT `env-paths`). Only setting today is `theme` (`light`|`dark`|
   `system`). `readConfig` is tolerant (missing/malformed/unknown-theme -> `{ theme: 'system' }`) so a
-  hand-broken config never breaks a render; `writeConfig` exists for a future `vplan config` command
-  and the tests (nothing in the render path writes it). The render command reads it and passes the
-  theme into the build; the rendered plan's in-page cog overrides per-view via `localStorage` and
-  never writes back here. Both `readConfig`/`writeConfig` take an optional `dir` so tests point at a
-  temp directory instead of the real home.
+  hand-broken config never breaks a render; `writeConfig` backs `config set`. The render command
+  reads it and passes the theme into the build; the rendered plan's in-page cog overrides per-view
+  via `localStorage` and never writes back here. `readConfig`/`writeConfig`/`configFilePath` and the
+  `runConfig*` command fns all take an optional `dir` so tests point at a temp directory instead of
+  the real home.
 - `src/api.ts` — the programmatic API (the library entry): `renderPlan(source, { out? })` (returns
   the HTML string, throws `InvalidPlanError` on an invalid plan, optional file write),
   `checkPlan(source)`, and one named re-export per catalog entry from `@visualplan/core` (`phase`,

--- a/packages/cli/AGENTS.md
+++ b/packages/cli/AGENTS.md
@@ -18,10 +18,13 @@ programmatic Node API at `dist/api.js` (the package's `import` entry, `exports["
   via `localStorage` and never writes back here. `readConfig`/`writeConfig`/`configFilePath` and the
   `runConfig*` command fns all take an optional `dir` so tests point at a temp directory instead of
   the real home.
-- `src/api.ts` — the programmatic API (the library entry): `renderPlan(source, { out? })` (returns
-  the HTML string, throws `InvalidPlanError` on an invalid plan, optional file write),
-  `checkPlan(source)`, and one named re-export per catalog entry from `@visualplan/core` (`phase`,
-  `chart`, ...). It is source-string based on purpose: rendering a file is
+- `src/api.ts` — the programmatic API (the library entry): `renderPlan(source, { out?, theme?,
+  enableSharing? })` (returns the HTML string, throws `InvalidPlanError` on an invalid plan, optional
+  file write), `checkPlan(source)`, and one named re-export per catalog entry from `@visualplan/core`
+  (`phase`, `chart`, ...). The API view options differ from the CLI defaults on purpose: a set
+  `theme` LOCKS the scheme (hides the cog, ignores the `localStorage` override) via `lockTheme`, and
+  `enableSharing` defaults to **false** (the CLI always shares). They map to `buildHtml`'s
+  `BuildOptions`. `Theme` is re-exported for consumers. It is source-string based on purpose: rendering a file is
   `renderPlan(await readFile(path, 'utf8'))`, which avoids a path-vs-source overload. It wraps the
   same `buildHtml`/`checkSource` the CLI uses. (NB: the API `checkPlan` is source-based; the internal
   `build/check.ts checkPlan` is the file-path-based wrapper, a different signature.)
@@ -49,12 +52,16 @@ programmatic Node API at `dist/api.js` (the package's `import` entry, `exports["
   size it). It also appends the Node-only `remarkFileTreeIcons` (`@visualplan/compile/filetree-icons`)
   to the remark chain, which inlines a Material file-type icon per `<FileTree>` entry; both are
   CLI-only so the browser bundle never loads `material-icon-theme`. Color chips and file icons both inline their output at build time, so the single-file
-  invariant holds. `buildHtml(source, theme)` and `renderToFile`/`startDevServer` take the
-  configured `theme` (default `system`; the programmatic `renderPlan` leaves it default).
-  `planConfigPlugin` injects a tiny non-module `<head>` script (`themeBootstrap`) that seeds
-  `globalThis.__VP_CONFIG__` and sets `<html data-theme>` before first paint, so a configured dark
-  plan has no light flash. That script's resolution (localStorage `vp-theme` -> injected default ->
-  `system`) MUST stay in sync with the runtime's `theme.ts`. `src/build/check.ts` — the static AST
+  invariant holds. `buildHtml(source, BuildOptions)` is the shared core; `BuildOptions` is `{ theme,
+  lockTheme, enableSharing }` (defaults `system` / false / true = the CLI's behavior).
+  `renderToFile`/`startDevServer` keep a `theme` param and pass `{ theme }`. `planConfigPlugin`
+  injects a tiny non-module `<head>` script (`themeBootstrap`) that seeds `globalThis.__VP_CONFIG__`
+  (`{ theme, lockTheme }`) and sets `<html data-theme>` before first paint, so a configured dark plan
+  has no light flash. When `lockTheme` the bootstrap uses the theme directly (ignores localStorage);
+  otherwise localStorage `vp-theme` -> injected default -> `system`. `planSharePlugin` is only added
+  when `enableSharing`, so omitting it leaves the runtime `ShareButton` with no data to render. The
+  bootstrap's resolution + lock behavior MUST stay in sync with the runtime's `theme.ts`.
+  `src/build/check.ts` — the static AST
   validator. It also runs each ` ```math ` block through Temml and each ` ```mermaid ` block through
   `beautiful-mermaid`'s `renderMermaidSVG` (the same renderer the runtime `Mermaid` component calls)
   to report bad LaTeX / an unrenderable diagram as `file:line:col`, so `check` and render agree on

--- a/packages/cli/src/api.ts
+++ b/packages/cli/src/api.ts
@@ -1,8 +1,8 @@
 /**
  * The programmatic interface for `vplan`: render and validate a plan from an in-memory MDX string,
- * and introspect the component vocabulary. This is the package's import entry (`import { render }
+ * and introspect the component vocabulary. This is the package's import entry (`import { renderPlan }
  * from 'vplan'`); the CLI bin is a separate entry. Nothing here touches the filesystem unless you
- * pass `render`'s `out` option.
+ * pass `renderPlan`'s `out` option.
  */
 import { writeFile } from 'node:fs/promises'
 import { resolve } from 'node:path'
@@ -14,7 +14,7 @@ export interface RenderOptions {
   out?: string
 }
 
-/** Thrown by `render` when the plan fails validation, carrying the structured issues. */
+/** Thrown by `renderPlan` when the plan fails validation, carrying the structured issues. */
 export class InvalidPlanError extends Error {
   readonly issues: CheckIssue[]
   constructor(issues: CheckIssue[]) {
@@ -32,7 +32,7 @@ export class InvalidPlanError extends Error {
  * plan first and throws `InvalidPlanError` if it has any issues, so a programmatic caller gets the
  * same self-correction guarantee the CLI has. Pass `out` to also write the HTML to a file.
  */
-export async function render(source: string, options: RenderOptions = {}): Promise<string> {
+export async function renderPlan(source: string, options: RenderOptions = {}): Promise<string> {
   const issues = await checkSource(source)
   if (issues.length > 0) throw new InvalidPlanError(issues)
   const html = await buildHtml(source)
@@ -41,7 +41,7 @@ export async function render(source: string, options: RenderOptions = {}): Promi
 }
 
 /** Validate a plan's MDX source, returning the issues (an empty array when the plan is valid). */
-export async function check(source: string): Promise<CheckIssue[]> {
+export async function checkPlan(source: string): Promise<CheckIssue[]> {
   return checkSource(source)
 }
 

--- a/packages/cli/src/api.ts
+++ b/packages/cli/src/api.ts
@@ -6,12 +6,25 @@
  */
 import { writeFile } from 'node:fs/promises'
 import { resolve } from 'node:path'
-import { buildHtml } from './build/compile.js'
 import { type CheckIssue, checkSource } from './build/check.js'
+import { buildHtml } from './build/compile.js'
+import type { Theme } from './config.js'
 
 export interface RenderOptions {
   /** Also write the rendered HTML to this path. The HTML string is returned regardless. */
   out?: string
+  /**
+   * Fix the page's color scheme (`light` | `dark` | `system`). When set, the in-page settings cog
+   * is hidden and the theme cannot be changed by the viewer. When omitted, the page defaults to
+   * `system` and shows the cog so the viewer can switch.
+   */
+  theme?: Theme
+  /**
+   * Show the share button (which copies a `visualplan.dev/view?data=...` link encoding the plan).
+   * Defaults to `false` for the programmatic API, so an embedded render does not expose sharing
+   * unless asked.
+   */
+  enableSharing?: boolean
 }
 
 /** Thrown by `renderPlan` when the plan fails validation, carrying the structured issues. */
@@ -35,7 +48,12 @@ export class InvalidPlanError extends Error {
 export async function renderPlan(source: string, options: RenderOptions = {}): Promise<string> {
   const issues = await checkSource(source)
   if (issues.length > 0) throw new InvalidPlanError(issues)
-  const html = await buildHtml(source)
+  const html = await buildHtml(source, {
+    theme: options.theme,
+    // A caller-set theme is fixed: hide the cog and ignore any per-view override.
+    lockTheme: options.theme !== undefined,
+    enableSharing: options.enableSharing ?? false,
+  })
   if (options.out) await writeFile(resolve(options.out), html)
   return html
 }
@@ -46,6 +64,7 @@ export async function checkPlan(source: string): Promise<CheckIssue[]> {
 }
 
 export type { CheckIssue } from './build/check.js'
+export type { Theme } from './config.js'
 export type { CatalogEntry } from '@visualplan/core'
 // The component vocabulary, one named descriptor per component, so a consumer can introspect a
 // single component's props and enums (`import { chart } from 'vplan'`).

--- a/packages/cli/src/build/compile.ts
+++ b/packages/cli/src/build/compile.ts
@@ -208,37 +208,59 @@ function planSharePlugin(readSource: () => string): Plugin {
   }
 }
 
-/**
- * An inline `<head>` script that resolves the page's color scheme and sets `<html data-theme>`
- * before the body paints, so a rendered plan honors the configured default with no flash. It runs
- * as a plain (non-module) script during head parse, before the deferred app module. Precedence:
- * the per-view `localStorage` override the runtime cog writes, then the injected config default,
- * then `system` (the OS). It must stay in sync with the runtime's `theme.ts` (same key, same order).
- */
-function themeBootstrap(theme: Theme): string {
-  const def = JSON.stringify(theme)
-  return `globalThis.__VP_CONFIG__=${JSON.stringify({ theme })};(function(){var d=${def},p;try{p=localStorage.getItem("vp-theme")}catch(e){}if(p!=="light"&&p!=="dark"&&p!=="system")p=d;var dark=p==="dark"||(p==="system"&&typeof matchMedia==="function"&&matchMedia("(prefers-color-scheme: dark)").matches);document.documentElement.dataset.theme=dark?"dark":"light"})()`
+/** How a plan is rendered, beyond its source. Defaults match the CLI (cog + share both on). */
+export interface BuildOptions {
+  /** Default color scheme baked into the page. Default `system`. */
+  theme?: Theme
+  /** Lock the theme: hide the in-page cog and ignore the `localStorage` override, so the rendered
+   * theme is fixed. The programmatic API sets this when its caller passes a `theme`. Default false. */
+  lockTheme?: boolean
+  /** Inject the share button's data. The CLI shares; the programmatic API defaults this off. Default true. */
+  enableSharing?: boolean
 }
 
 /**
- * Inject the configured default theme (from `~/.vplan/config.json`) into the page: the
- * `themeBootstrap` script seeds `globalThis.__VP_CONFIG__` and sets the initial `data-theme`. The
- * runtime's cog can still override per-view via `localStorage`; this only sets the default.
+ * An inline `<head>` script that resolves the page's color scheme and sets `<html data-theme>`
+ * before the body paints, so a rendered plan honors the configured default with no flash. It runs
+ * as a plain (non-module) script during head parse, before the deferred app module. Precedence when
+ * unlocked: the per-view `localStorage` override the runtime cog writes, then the injected default,
+ * then `system` (the OS); when locked it uses the injected theme directly. It must stay in sync with
+ * the runtime's `theme.ts` (same key, same order, same lock behavior).
  */
-function planConfigPlugin(theme: Theme): Plugin {
+function themeBootstrap(theme: Theme, lockTheme: boolean): string {
+  const config = JSON.stringify({ theme, lockTheme })
+  return `globalThis.__VP_CONFIG__=${config};(function(){var c=globalThis.__VP_CONFIG__,d=c.theme,p;if(c.lockTheme){p=d}else{try{p=localStorage.getItem("vp-theme")}catch(e){}if(p!=="light"&&p!=="dark"&&p!=="system")p=d}var dark=p==="dark"||(p==="system"&&typeof matchMedia==="function"&&matchMedia("(prefers-color-scheme: dark)").matches);document.documentElement.dataset.theme=dark?"dark":"light"})()`
+}
+
+/**
+ * Inject the default theme and lock flag into the page: the `themeBootstrap` script seeds
+ * `globalThis.__VP_CONFIG__` and sets the initial `data-theme`. When unlocked, the runtime cog can
+ * override per-view via `localStorage`; when locked the cog is hidden and the theme is fixed.
+ */
+function planConfigPlugin(theme: Theme, lockTheme: boolean): Plugin {
   return {
     name: 'visualplan:config',
     transformIndexHtml: {
       order: 'pre',
       handler() {
-        return [{ tag: 'script', injectTo: 'head', children: themeBootstrap(theme) }]
+        return [{ tag: 'script', injectTo: 'head', children: themeBootstrap(theme, lockTheme) }]
       },
     },
   }
 }
 
-function baseConfig(paths: RuntimePaths, input: PlanInput, theme: Theme): InlineConfig {
+function baseConfig(paths: RuntimePaths, input: PlanInput, options: BuildOptions): InlineConfig {
   const readSource = sourceReader(input)
+  const theme = options.theme ?? 'system'
+  const lockTheme = options.lockTheme ?? false
+  const enableSharing = options.enableSharing ?? true
+  const plugins: Plugin[] = [
+    virtualPlanPlugin(input),
+    htmlTitlePlugin(readSource),
+    planConfigPlugin(theme, lockTheme),
+  ]
+  // The share button renders only when its data is injected, so omitting the plugin hides it.
+  if (enableSharing) plugins.push(planSharePlugin(readSource))
   return {
     root: paths.runtimeDir,
     configFile: false,
@@ -256,12 +278,7 @@ function baseConfig(paths: RuntimePaths, input: PlanInput, theme: Theme): Inline
       },
     },
     esbuild: { jsx: 'automatic', jsxImportSource: 'react' },
-    plugins: [
-      virtualPlanPlugin(input),
-      htmlTitlePlugin(readSource),
-      planSharePlugin(readSource),
-      planConfigPlugin(theme),
-    ],
+    plugins,
     // The runtime, core, and (for a file input) the user's plan span sibling dirs (and a hoisted
     // node_modules) in the monorepo, so the dev server cannot use a single allow root. This is a
     // local tool rendering the user's own plan, so fs is unrestricted.
@@ -270,15 +287,15 @@ function baseConfig(paths: RuntimePaths, input: PlanInput, theme: Theme): Inline
 }
 
 /**
- * Compile a plan's MDX source to a single self-contained HTML page, returned as a string. `theme`
- * is the default scheme baked into the page (the programmatic API leaves it `system`; the CLI passes
- * the configured value).
+ * Compile a plan's MDX source to a single self-contained HTML page, returned as a string.
+ * `options` control the baked theme, whether the theme is locked (cog hidden), and whether the
+ * share button is injected (see `BuildOptions`). Defaults match the CLI: `system`, unlocked, shared.
  */
-export async function buildHtml(source: string, theme: Theme = 'system'): Promise<string> {
+export async function buildHtml(source: string, options: BuildOptions = {}): Promise<string> {
   const paths = findRuntimePaths()
   const outDir = await mkdtemp(join(tmpdir(), 'visualplan-build-'))
   try {
-    const config = baseConfig(paths, source, theme)
+    const config = baseConfig(paths, source, options)
     await build({
       ...config,
       plugins: [...(config.plugins ?? []), viteSingleFile()],
@@ -301,7 +318,7 @@ export async function renderToFile(
   theme: Theme = 'system',
 ): Promise<void> {
   const source = readFileSync(resolve(mdxPath), 'utf8').replace(/^\ufeff/, '')
-  await writeFile(resolve(outPath), await buildHtml(source, theme))
+  await writeFile(resolve(outPath), await buildHtml(source, { theme }))
 }
 
 export interface DevServer {
@@ -312,7 +329,7 @@ export interface DevServer {
 /** Start a hot-reloading dev server for an MDX plan file and return its local URL. */
 export async function startDevServer(mdxPath: string, theme: Theme = 'system'): Promise<DevServer> {
   const paths = findRuntimePaths()
-  const server = await createServer(baseConfig(paths, { path: resolve(mdxPath) }, theme))
+  const server = await createServer(baseConfig(paths, { path: resolve(mdxPath) }, { theme }))
   await server.listen()
   const url =
     server.resolvedUrls?.local[0] ?? `http://localhost:${server.config.server.port ?? 5173}`

--- a/packages/cli/src/build/compile.ts
+++ b/packages/cli/src/build/compile.ts
@@ -12,6 +12,7 @@ import { encodePlan } from '@visualplan/core/share'
 import rehypeExpressiveCode, { type RehypeExpressiveCodeOptions } from 'rehype-expressive-code'
 import { build, createServer, type InlineConfig, type Plugin } from 'vite'
 import { viteSingleFile } from 'vite-plugin-singlefile'
+import type { Theme } from '../config.js'
 
 // The shared base options (themes, frames, color chips, ink styling) come from
 // `@visualplan/compile` so the CLI and the /view page highlight code identically; the CLI
@@ -207,7 +208,36 @@ function planSharePlugin(readSource: () => string): Plugin {
   }
 }
 
-function baseConfig(paths: RuntimePaths, input: PlanInput): InlineConfig {
+/**
+ * An inline `<head>` script that resolves the page's color scheme and sets `<html data-theme>`
+ * before the body paints, so a rendered plan honors the configured default with no flash. It runs
+ * as a plain (non-module) script during head parse, before the deferred app module. Precedence:
+ * the per-view `localStorage` override the runtime cog writes, then the injected config default,
+ * then `system` (the OS). It must stay in sync with the runtime's `theme.ts` (same key, same order).
+ */
+function themeBootstrap(theme: Theme): string {
+  const def = JSON.stringify(theme)
+  return `globalThis.__VP_CONFIG__=${JSON.stringify({ theme })};(function(){var d=${def},p;try{p=localStorage.getItem("vp-theme")}catch(e){}if(p!=="light"&&p!=="dark"&&p!=="system")p=d;var dark=p==="dark"||(p==="system"&&typeof matchMedia==="function"&&matchMedia("(prefers-color-scheme: dark)").matches);document.documentElement.dataset.theme=dark?"dark":"light"})()`
+}
+
+/**
+ * Inject the configured default theme (from `~/.vplan/config.json`) into the page: the
+ * `themeBootstrap` script seeds `globalThis.__VP_CONFIG__` and sets the initial `data-theme`. The
+ * runtime's cog can still override per-view via `localStorage`; this only sets the default.
+ */
+function planConfigPlugin(theme: Theme): Plugin {
+  return {
+    name: 'visualplan:config',
+    transformIndexHtml: {
+      order: 'pre',
+      handler() {
+        return [{ tag: 'script', injectTo: 'head', children: themeBootstrap(theme) }]
+      },
+    },
+  }
+}
+
+function baseConfig(paths: RuntimePaths, input: PlanInput, theme: Theme): InlineConfig {
   const readSource = sourceReader(input)
   return {
     root: paths.runtimeDir,
@@ -226,7 +256,12 @@ function baseConfig(paths: RuntimePaths, input: PlanInput): InlineConfig {
       },
     },
     esbuild: { jsx: 'automatic', jsxImportSource: 'react' },
-    plugins: [virtualPlanPlugin(input), htmlTitlePlugin(readSource), planSharePlugin(readSource)],
+    plugins: [
+      virtualPlanPlugin(input),
+      htmlTitlePlugin(readSource),
+      planSharePlugin(readSource),
+      planConfigPlugin(theme),
+    ],
     // The runtime, core, and (for a file input) the user's plan span sibling dirs (and a hoisted
     // node_modules) in the monorepo, so the dev server cannot use a single allow root. This is a
     // local tool rendering the user's own plan, so fs is unrestricted.
@@ -234,12 +269,16 @@ function baseConfig(paths: RuntimePaths, input: PlanInput): InlineConfig {
   }
 }
 
-/** Compile a plan's MDX source to a single self-contained HTML page, returned as a string. */
-export async function buildHtml(source: string): Promise<string> {
+/**
+ * Compile a plan's MDX source to a single self-contained HTML page, returned as a string. `theme`
+ * is the default scheme baked into the page (the programmatic API leaves it `system`; the CLI passes
+ * the configured value).
+ */
+export async function buildHtml(source: string, theme: Theme = 'system'): Promise<string> {
   const paths = findRuntimePaths()
   const outDir = await mkdtemp(join(tmpdir(), 'visualplan-build-'))
   try {
-    const config = baseConfig(paths, source)
+    const config = baseConfig(paths, source, theme)
     await build({
       ...config,
       plugins: [...(config.plugins ?? []), viteSingleFile()],
@@ -256,9 +295,13 @@ export async function buildHtml(source: string): Promise<string> {
 }
 
 /** Compile an MDX plan file to a single self-contained HTML file at `outPath`. */
-export async function renderToFile(mdxPath: string, outPath: string): Promise<void> {
+export async function renderToFile(
+  mdxPath: string,
+  outPath: string,
+  theme: Theme = 'system',
+): Promise<void> {
   const source = readFileSync(resolve(mdxPath), 'utf8').replace(/^\ufeff/, '')
-  await writeFile(resolve(outPath), await buildHtml(source))
+  await writeFile(resolve(outPath), await buildHtml(source, theme))
 }
 
 export interface DevServer {
@@ -267,9 +310,9 @@ export interface DevServer {
 }
 
 /** Start a hot-reloading dev server for an MDX plan file and return its local URL. */
-export async function startDevServer(mdxPath: string): Promise<DevServer> {
+export async function startDevServer(mdxPath: string, theme: Theme = 'system'): Promise<DevServer> {
   const paths = findRuntimePaths()
-  const server = await createServer(baseConfig(paths, { path: resolve(mdxPath) }))
+  const server = await createServer(baseConfig(paths, { path: resolve(mdxPath) }, theme))
   await server.listen()
   const url =
     server.resolvedUrls?.local[0] ?? `http://localhost:${server.config.server.port ?? 5173}`

--- a/packages/cli/src/commands/config.ts
+++ b/packages/cli/src/commands/config.ts
@@ -1,0 +1,54 @@
+import {
+  type Config,
+  type Theme,
+  THEMES,
+  configDir,
+  configFilePath,
+  readConfig,
+  writeConfig,
+} from '../config.js'
+
+/** The settable config keys. `theme` is the only one today. */
+const KEYS = ['theme'] as const
+type Key = (typeof KEYS)[number]
+
+function assertKey(key: string): asserts key is Key {
+  if (!(KEYS as readonly string[]).includes(key)) {
+    throw new Error(`Unknown config key "${key}". Valid keys: ${KEYS.join(', ')}`)
+  }
+}
+
+/** `vplan config` — print the current settings and where they live. */
+export async function runConfigShow(dir: string = configDir): Promise<void> {
+  const config = await readConfig(dir)
+  const lines = [`Config: ${configFilePath(dir)}`, '', `  theme = ${config.theme}`]
+  process.stdout.write(`${lines.join('\n')}\n`)
+}
+
+/** `vplan config get <key>` — print a single setting's value. */
+export async function runConfigGet(key: string, dir: string = configDir): Promise<void> {
+  assertKey(key)
+  const config = await readConfig(dir)
+  process.stdout.write(`${config[key]}\n`)
+}
+
+/** `vplan config set <key> <value>` — validate, persist, and confirm. */
+export async function runConfigSet(
+  key: string,
+  value: string,
+  dir: string = configDir,
+): Promise<void> {
+  assertKey(key)
+  // `theme` is the only key, so its value rules are the only ones to enforce.
+  if (!(THEMES as readonly string[]).includes(value)) {
+    throw new Error(`Invalid theme "${value}". Valid values: ${THEMES.join(' | ')}`)
+  }
+  const next: Config = { ...(await readConfig(dir)), theme: value as Theme }
+  await writeConfig(next, dir)
+  process.stdout.write(`Set ${key} = ${value}\n`)
+}
+
+/** `vplan config path` — print the config file path. */
+export function runConfigPath(dir: string = configDir): void {
+  process.stdout.write(`${configFilePath(dir)}\n`)
+}

--- a/packages/cli/src/commands/render.ts
+++ b/packages/cli/src/commands/render.ts
@@ -2,6 +2,7 @@ import { basename, dirname, extname, join, resolve } from 'node:path'
 import open from 'open'
 import { checkPlan } from '../build/check.js'
 import { renderToFile, startDevServer } from '../build/compile.js'
+import { readConfig } from '../config.js'
 import { printIssues, resolvePlanFile } from './check.js'
 
 export interface RenderOptions {
@@ -26,8 +27,10 @@ export async function runRender(file: string, options: RenderOptions): Promise<v
     return
   }
 
+  const { theme } = await readConfig()
+
   if (options.watch) {
-    const server = await startDevServer(absMdx)
+    const server = await startDevServer(absMdx, theme)
     process.stdout.write(
       `Visual Plan watching ${file}\n  ${server.url}\n  (edit the file to hot-reload; Ctrl+C to stop)\n`,
     )
@@ -36,7 +39,7 @@ export async function runRender(file: string, options: RenderOptions): Promise<v
   }
 
   const out = options.out ? resolve(options.out) : defaultOutPath(absMdx)
-  await renderToFile(absMdx, out)
+  await renderToFile(absMdx, out, theme)
   process.stdout.write(`Rendered ${out}\n`)
   if (options.open !== false) await open(out)
 }

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -2,7 +2,7 @@
  * The persistent CLI config, stored at `~/.vplan/config.json`. The only setting today is the
  * default `theme` (`light` | `dark` | `system`), which the render path bakes into a rendered plan
  * as its initial scheme. A rendered plan's in-page cog overrides this per-view via `localStorage`;
- * it never writes here. The file is changed by hand (or, later, a `vplan config` command).
+ * it never writes here. The file is changed by the `vplan config set` command (or by hand).
  */
 import { mkdir, readFile, writeFile } from 'node:fs/promises'
 import { homedir } from 'node:os'
@@ -14,13 +14,15 @@ export interface Config {
   theme: Theme
 }
 
-const THEMES: readonly Theme[] = ['light', 'dark', 'system']
+/** The valid `theme` values, in menu order. */
+export const THEMES: readonly Theme[] = ['light', 'dark', 'system']
 const DEFAULT_CONFIG: Config = { theme: 'system' }
 
 /** `~/.vplan` — the config directory. */
 export const configDir = join(homedir(), '.vplan')
 
-function configFile(dir: string): string {
+/** Path to the config file within `dir` (defaults to the real `~/.vplan`). */
+export function configFilePath(dir: string = configDir): string {
   return join(dir, 'config.json')
 }
 
@@ -35,7 +37,7 @@ function isTheme(value: unknown): value is Theme {
  */
 export async function readConfig(dir: string = configDir): Promise<Config> {
   try {
-    const parsed: unknown = JSON.parse(await readFile(configFile(dir), 'utf8'))
+    const parsed: unknown = JSON.parse(await readFile(configFilePath(dir), 'utf8'))
     const theme = (parsed as { theme?: unknown } | null)?.theme
     return { theme: isTheme(theme) ? theme : DEFAULT_CONFIG.theme }
   } catch {
@@ -44,10 +46,10 @@ export async function readConfig(dir: string = configDir): Promise<Config> {
 }
 
 /**
- * Write the config to `~/.vplan/config.json`, creating the directory if needed. Provided for a
- * future `vplan config` command (and the tests); the render path only reads.
+ * Write the config to `~/.vplan/config.json`, creating the directory if needed. Used by the
+ * `vplan config set` command; the render path only reads.
  */
 export async function writeConfig(config: Config, dir: string = configDir): Promise<void> {
   await mkdir(dir, { recursive: true })
-  await writeFile(configFile(dir), `${JSON.stringify(config, null, 2)}\n`)
+  await writeFile(configFilePath(dir), `${JSON.stringify(config, null, 2)}\n`)
 }

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -1,0 +1,53 @@
+/**
+ * The persistent CLI config, stored at `~/.vplan/config.json`. The only setting today is the
+ * default `theme` (`light` | `dark` | `system`), which the render path bakes into a rendered plan
+ * as its initial scheme. A rendered plan's in-page cog overrides this per-view via `localStorage`;
+ * it never writes here. The file is changed by hand (or, later, a `vplan config` command).
+ */
+import { mkdir, readFile, writeFile } from 'node:fs/promises'
+import { homedir } from 'node:os'
+import { join } from 'node:path'
+
+export type Theme = 'light' | 'dark' | 'system'
+
+export interface Config {
+  theme: Theme
+}
+
+const THEMES: readonly Theme[] = ['light', 'dark', 'system']
+const DEFAULT_CONFIG: Config = { theme: 'system' }
+
+/** `~/.vplan` — the config directory. */
+export const configDir = join(homedir(), '.vplan')
+
+function configFile(dir: string): string {
+  return join(dir, 'config.json')
+}
+
+function isTheme(value: unknown): value is Theme {
+  return typeof value === 'string' && (THEMES as readonly string[]).includes(value)
+}
+
+/**
+ * Read the persisted config. Returns defaults when the file is missing or malformed (an absent or
+ * hand-broken config must never break a render), and ignores an unknown `theme` value. `dir`
+ * overrides the config directory for tests; production calls it with the default `~/.vplan`.
+ */
+export async function readConfig(dir: string = configDir): Promise<Config> {
+  try {
+    const parsed: unknown = JSON.parse(await readFile(configFile(dir), 'utf8'))
+    const theme = (parsed as { theme?: unknown } | null)?.theme
+    return { theme: isTheme(theme) ? theme : DEFAULT_CONFIG.theme }
+  } catch {
+    return DEFAULT_CONFIG
+  }
+}
+
+/**
+ * Write the config to `~/.vplan/config.json`, creating the directory if needed. Provided for a
+ * future `vplan config` command (and the tests); the render path only reads.
+ */
+export async function writeConfig(config: Config, dir: string = configDir): Promise<void> {
+  await mkdir(dir, { recursive: true })
+  await writeFile(configFile(dir), `${JSON.stringify(config, null, 2)}\n`)
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -2,6 +2,7 @@ import { Command } from 'commander'
 import packageJson from '../package.json' with { type: 'json' }
 import { runCheck } from './commands/check.js'
 import { runComponents } from './commands/components.js'
+import { runConfigGet, runConfigPath, runConfigSet, runConfigShow } from './commands/config.js'
 import { runRender, type RenderOptions } from './commands/render.js'
 
 const program = new Command('vplan')
@@ -27,6 +28,29 @@ program
   .command('components')
   .description('Print the available plan components and their props')
   .action(() => runComponents())
+
+const config = program
+  .command('config')
+  .description('View or change persistent settings (stored in ~/.vplan/config.json)')
+  .action(() => runConfigShow())
+
+config
+  .command('get')
+  .description('Print a setting (theme)')
+  .argument('<key>', 'the setting to read')
+  .action((key: string) => runConfigGet(key))
+
+config
+  .command('set')
+  .description('Change a setting and persist it')
+  .argument('<key>', 'the setting to change (theme)')
+  .argument('<value>', 'the new value (theme: light | dark | system)')
+  .action((key: string, value: string) => runConfigSet(key, value))
+
+config
+  .command('path')
+  .description('Print the config file path')
+  .action(() => runConfigPath())
 
 program.parseAsync(process.argv).catch((error: unknown) => {
   process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`)

--- a/packages/cli/tests/api.test.ts
+++ b/packages/cli/tests/api.test.ts
@@ -5,8 +5,8 @@ import { join } from 'node:path'
 import { CATALOG } from '@visualplan/core'
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 import * as api from '../src/api.js'
-import { InvalidPlanError, check, render } from '../src/api.js'
-import { checkPlan } from '../src/build/check.js'
+import { InvalidPlanError, checkPlan, renderPlan } from '../src/api.js'
+import { checkPlan as checkPlanFile } from '../src/build/check.js'
 
 const VALID_PLAN = '# A plan\n\n<Phase title="Build">\n  1. Do the thing\n</Phase>\n'
 const INVALID_PLAN = '# Bad\n\n<Phase status="nope">x</Phase>\n'
@@ -27,7 +27,7 @@ describe('render', () => {
 
   beforeAll(async () => {
     const out = join(workDir, 'plan.html')
-    html = await render(VALID_PLAN, { out })
+    html = await renderPlan(VALID_PLAN, { out })
     written = await readFile(out, 'utf8')
   }, 60_000)
 
@@ -45,37 +45,37 @@ describe('render', () => {
   })
 
   it('throws InvalidPlanError carrying the issues for an invalid plan (error)', async () => {
-    await expect(render(INVALID_PLAN)).rejects.toBeInstanceOf(InvalidPlanError)
-    const error = await render(INVALID_PLAN).catch((caught: unknown) => caught)
+    await expect(renderPlan(INVALID_PLAN)).rejects.toBeInstanceOf(InvalidPlanError)
+    const error = await renderPlan(INVALID_PLAN).catch((caught: unknown) => caught)
     expect(error).toBeInstanceOf(InvalidPlanError)
     expect((error as InvalidPlanError).issues).toHaveLength(1)
     expect((error as InvalidPlanError).issues[0].message).toContain('status="nope"')
   })
 
   it('renders an effectively empty plan without throwing (edge)', async () => {
-    const empty = await render('   \n')
+    const empty = await renderPlan('   \n')
     expect(empty).toContain('<!doctype html>')
     expect(empty).toContain('id="root"')
   }, 60_000)
 })
 
-describe('check', () => {
+describe('checkPlan', () => {
   it('returns no issues for a valid plan (golden)', async () => {
-    expect(await check(VALID_PLAN)).toEqual([])
+    expect(await checkPlan(VALID_PLAN)).toEqual([])
   })
 
   it('returns issues with a line and column for an invalid plan (error)', async () => {
-    const issues = await check(INVALID_PLAN)
+    const issues = await checkPlan(INVALID_PLAN)
     expect(issues).toHaveLength(1)
     expect(issues[0].line).toBeGreaterThan(0)
     expect(issues[0].column).toBeGreaterThan(0)
     expect(issues[0].message).toContain('status="nope"')
   })
 
-  it('matches the file-based checkPlan on the same source (edge)', async () => {
+  it('matches the file-based checker on the same source (edge)', async () => {
     const path = join(workDir, 'parity.mdx')
     await writeFile(path, INVALID_PLAN)
-    expect(await check(INVALID_PLAN)).toEqual(await checkPlan(path))
+    expect(await checkPlan(INVALID_PLAN)).toEqual(await checkPlanFile(path))
   })
 })
 

--- a/packages/cli/tests/api.test.ts
+++ b/packages/cli/tests/api.test.ts
@@ -59,6 +59,27 @@ describe('render', () => {
   }, 60_000)
 })
 
+describe('render options', () => {
+  it('locks the theme and hides the cog when a theme is given (golden)', async () => {
+    const html = await renderPlan(VALID_PLAN, { theme: 'dark' })
+    // The runtime hides the cog and ignores localStorage when lockTheme is injected.
+    expect(html).toContain('"theme":"dark"')
+    expect(html).toContain('"lockTheme":true')
+  }, 60_000)
+
+  it('omits the share data by default, so the share button stays hidden (edge)', async () => {
+    // The component always reads globalThis.__VP_SHARE__; what gates the button is the injected
+    // assignment, which must be absent so the button renders null.
+    const html = await renderPlan(VALID_PLAN)
+    expect(html).not.toContain('globalThis.__VP_SHARE__=')
+  }, 60_000)
+
+  it('injects the share data when enableSharing is true (golden)', async () => {
+    const html = await renderPlan(VALID_PLAN, { enableSharing: true })
+    expect(html).toContain('globalThis.__VP_SHARE__=')
+  }, 60_000)
+})
+
 describe('checkPlan', () => {
   it('returns no issues for a valid plan (golden)', async () => {
     expect(await checkPlan(VALID_PLAN)).toEqual([])

--- a/packages/cli/tests/compile.test.ts
+++ b/packages/cli/tests/compile.test.ts
@@ -4,7 +4,7 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
-import { planTitle, renderToFile } from '../src/build/compile.js'
+import { buildHtml, planTitle, renderToFile } from '../src/build/compile.js'
 
 const examplePath = fileURLToPath(new URL('../templates/example.mdx', import.meta.url))
 let workDir: string
@@ -134,4 +134,20 @@ describe('planTitle', () => {
     await writeFile(path, '\ufeff# BOM Plan\n\nbody\n')
     expect(planTitle(path)).toBe('BOM Plan')
   })
+})
+
+describe('theme config injection', () => {
+  it('injects __VP_CONFIG__ and a data-theme bootstrap, defaulting to system (golden)', () => {
+    // The example render above uses the default theme (system).
+    expect(html).toContain('__VP_CONFIG__')
+    expect(html).toContain('"theme":"system"')
+    expect(html).toContain('document.documentElement.dataset.theme')
+  })
+
+  it('bakes a configured theme into the bootstrap default (golden)', async () => {
+    const dark = await buildHtml('# t\n\nbody\n', 'dark')
+    expect(dark).toContain('"theme":"dark"')
+    // The default feeds the resolver; localStorage still overrides it per-view.
+    expect(dark).toContain('localStorage.getItem("vp-theme")')
+  }, 60_000)
 })

--- a/packages/cli/tests/compile.test.ts
+++ b/packages/cli/tests/compile.test.ts
@@ -145,9 +145,9 @@ describe('theme config injection', () => {
   })
 
   it('bakes a configured theme into the bootstrap default (golden)', async () => {
-    const dark = await buildHtml('# t\n\nbody\n', 'dark')
+    const dark = await buildHtml('# t\n\nbody\n', { theme: 'dark' })
     expect(dark).toContain('"theme":"dark"')
-    // The default feeds the resolver; localStorage still overrides it per-view.
+    // Unlocked by default, so the resolver still reads the localStorage override per-view.
     expect(dark).toContain('localStorage.getItem("vp-theme")')
   }, 60_000)
 })

--- a/packages/cli/tests/config-command.test.ts
+++ b/packages/cli/tests/config-command.test.ts
@@ -1,0 +1,68 @@
+// @vitest-environment node
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { runConfigGet, runConfigPath, runConfigSet, runConfigShow } from '../src/commands/config.js'
+import { readConfig } from '../src/config.js'
+
+let dir: string
+let out: string[]
+
+beforeEach(async () => {
+  dir = await mkdtemp(join(tmpdir(), 'visualplan-config-cmd-test-'))
+  out = []
+  vi.spyOn(process.stdout, 'write').mockImplementation((chunk: string | Uint8Array) => {
+    out.push(String(chunk))
+    return true
+  })
+})
+
+afterEach(async () => {
+  vi.restoreAllMocks()
+  await rm(dir, { recursive: true, force: true })
+})
+
+describe('config set', () => {
+  it('persists a valid theme and confirms it (golden)', async () => {
+    await runConfigSet('theme', 'dark', dir)
+    expect(await readConfig(dir)).toEqual({ theme: 'dark' })
+    expect(out.join('')).toContain('Set theme = dark')
+  })
+
+  it('rejects an invalid value or unknown key without writing (error)', async () => {
+    await expect(runConfigSet('theme', 'neon', dir)).rejects.toThrow(/Invalid theme "neon"/)
+    await expect(runConfigSet('color', 'dark', dir)).rejects.toThrow(/Unknown config key "color"/)
+    // Nothing was written, so a read still returns the default.
+    expect(await readConfig(dir)).toEqual({ theme: 'system' })
+  })
+})
+
+describe('config get', () => {
+  it('prints the stored value (golden)', async () => {
+    await runConfigSet('theme', 'light', dir)
+    out = []
+    await runConfigGet('theme', dir)
+    expect(out.join('')).toBe('light\n')
+  })
+
+  it('rejects an unknown key (error)', async () => {
+    await expect(runConfigGet('color', dir)).rejects.toThrow(/Unknown config key "color"/)
+  })
+})
+
+describe('config show', () => {
+  it('prints the default theme and the path when no file exists yet (edge)', async () => {
+    await runConfigShow(dir)
+    const text = out.join('')
+    expect(text).toContain('theme = system')
+    expect(text).toContain(join(dir, 'config.json'))
+  })
+})
+
+describe('config path', () => {
+  it('prints the config file path (golden)', () => {
+    runConfigPath(dir)
+    expect(out.join('')).toBe(`${join(dir, 'config.json')}\n`)
+  })
+})

--- a/packages/cli/tests/config.test.ts
+++ b/packages/cli/tests/config.test.ts
@@ -1,0 +1,49 @@
+// @vitest-environment node
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { readConfig, writeConfig } from '../src/config.js'
+
+let dir: string
+
+beforeEach(async () => {
+  dir = await mkdtemp(join(tmpdir(), 'visualplan-config-test-'))
+})
+
+afterEach(async () => {
+  await rm(dir, { recursive: true, force: true })
+})
+
+describe('readConfig', () => {
+  it('reads a stored theme (golden)', async () => {
+    await writeFile(join(dir, 'config.json'), JSON.stringify({ theme: 'dark' }))
+    expect(await readConfig(dir)).toEqual({ theme: 'dark' })
+  })
+
+  it('defaults to system on malformed JSON or an unknown theme (error)', async () => {
+    await writeFile(join(dir, 'config.json'), '{ not json')
+    expect(await readConfig(dir)).toEqual({ theme: 'system' })
+
+    await writeFile(join(dir, 'config.json'), JSON.stringify({ theme: 'neon' }))
+    expect(await readConfig(dir)).toEqual({ theme: 'system' })
+  })
+
+  it('defaults to system when the file is absent (edge)', async () => {
+    expect(await readConfig(dir)).toEqual({ theme: 'system' })
+  })
+})
+
+describe('writeConfig', () => {
+  it('persists a config that readConfig round-trips (golden)', async () => {
+    await writeConfig({ theme: 'light' }, dir)
+    expect(await readConfig(dir)).toEqual({ theme: 'light' })
+  })
+
+  it('creates the config directory if it does not exist (edge)', async () => {
+    const nested = join(dir, 'does', 'not', 'exist')
+    await writeConfig({ theme: 'dark' }, nested)
+    const written = JSON.parse(await readFile(join(nested, 'config.json'), 'utf8'))
+    expect(written).toEqual({ theme: 'dark' })
+  })
+})

--- a/packages/compile/AGENTS.md
+++ b/packages/compile/AGENTS.md
@@ -49,7 +49,11 @@ through the workspace.
 - `src/remark-plan-blocks.ts` / `remark-mermaid.ts` / `remark-math.ts` — the three custom remark
   plugins. `remark-math` converts LaTeX to MathML with `temml` at build time (isomorphic).
 - `src/expressive-code.ts` — `baseExpressiveCodeOptions` (themes, frames, ink styling, color
-  chips). NO file-icons plugin (Node-only).
+  chips). NO file-icons plugin (Node-only). `themeCssSelector` keys each syntax theme off the page's
+  `[data-theme="light"|"dark"]` (via the EC theme's `type`), so the code theme follows the runtime
+  cog / CLI config, not just the OS. `useDarkModeMediaQuery` stays on as the pre-`data-theme`
+  fallback. Both consumers set `<html data-theme>` (the CLI's inline bootstrap; the runtime `mount`),
+  so do not drop the attribute or the syntax theme stops following an explicit light/dark choice.
 - `src/icon-resolution.ts` — the **isomorphic** Material-icon resolution core
   (`@visualplan/compile/icon-resolution` subpath): a pure `resolveIconName(manifest, ...)` over a
   passed-in manifest, no fs. Single-sources the resolution order for the Node `file-icons.ts` AND

--- a/packages/compile/src/expressive-code.ts
+++ b/packages/compile/src/expressive-code.ts
@@ -13,6 +13,12 @@ import type { RehypeExpressiveCodeOptions } from 'rehype-expressive-code'
 export const baseExpressiveCodeOptions: RehypeExpressiveCodeOptions = {
   themes: ['github-dark', 'github-light'],
   useDarkModeMediaQuery: true,
+  // Key each theme's CSS off the page's `data-theme` (the runtime cog and the CLI bootstrap set
+  // `<html data-theme="light|dark">`) so the syntax theme follows an explicit light/dark choice, not
+  // just the OS. Without this EC keys only off `prefers-color-scheme`, so forcing a theme that
+  // disagrees with the OS leaves code blocks on the wrong (unreadable) syntax theme.
+  // `useDarkModeMediaQuery` stays on as the fallback for any moment before `data-theme` is set.
+  themeCssSelector: theme => `[data-theme="${theme.type}"]`,
   plugins: [pluginColorChips()],
   // The copy-button script does not execute reliably in our client-rendered SPA;
   // frames (titles) are CSS-only, so keep those and drop the interactive button.

--- a/packages/runtime/AGENTS.md
+++ b/packages/runtime/AGENTS.md
@@ -13,7 +13,9 @@ the root AGENTS.md for why Vite is configured without `@vitejs/plugin-react`.
 - `index.tsx` defines `mount` and the `components` map auto-injected into MDX via `MDXProvider`.
   No plan ever writes an `import` — every component resolves through this map.
 - `Layout.tsx` is a single centered content column — no header and no sidebar. It mounts the
-  `ThemeToggle` cog and the `ShareButton` (both fixed to the top-right corner).
+  `ThemeToggle` cog and the `ShareButton` (both fixed to the top-right corner). The cog is omitted
+  when `isThemeLocked()` (the API's `renderPlan({ theme })` injects `lockTheme`), and the share
+  button self-hides when no `__VP_SHARE__` was injected (the API's `enableSharing: false` default).
 - `components/ThemeToggle.tsx` is the fixed top-right cog, just left of the share button. Its menu
   picks `system` / `light` / `dark`; choosing one recolors the page live (all colors are CSS vars,
   so flipping `<html data-theme>` repaints with no React re-render) and persists the choice in
@@ -25,7 +27,9 @@ the root AGENTS.md for why Vite is configured without `@vitejs/plugin-react`.
   devices neither hover nor focus a button on tap.
 - `theme.ts` resolves the color scheme. Precedence: the `localStorage` override, then the injected
   `globalThis.__VP_CONFIG__.theme` default (the CLI seeds it from `~/.vplan/config.json`), then
-  `system` (the OS via `matchMedia`). `system` is resolved to a concrete `light`/`dark` and written
+  `system` (the OS via `matchMedia`). When `__VP_CONFIG__.lockTheme` is set (the API fixed the
+  theme), `isThemeLocked()` is true and the localStorage override is ignored (the injected theme is
+  used verbatim). `system` is resolved to a concrete `light`/`dark` and written
   to `<html data-theme>`. This MUST stay in sync with the CLI's inline `themeBootstrap`
   (`compile.ts`), which does the same resolution in a tiny `<head>` script before first paint (so a
   configured dark plan has no light flash). `mount` also calls `applyThemePreference` for paths

--- a/packages/runtime/AGENTS.md
+++ b/packages/runtime/AGENTS.md
@@ -12,8 +12,24 @@ the root AGENTS.md for why Vite is configured without `@vitejs/plugin-react`.
   own first `# Heading`, rendered as normal markdown.
 - `index.tsx` defines `mount` and the `components` map auto-injected into MDX via `MDXProvider`.
   No plan ever writes an `import` — every component resolves through this map.
-- `Layout.tsx` is a single centered content column — no header and no sidebar. It also mounts
-  `ShareButton`.
+- `Layout.tsx` is a single centered content column — no header and no sidebar. It mounts the
+  `ThemeToggle` cog and the `ShareButton` (both fixed to the top-right corner).
+- `components/ThemeToggle.tsx` is the fixed top-right cog, just left of the share button. Its menu
+  picks `system` / `light` / `dark`; choosing one recolors the page live (all colors are CSS vars,
+  so flipping `<html data-theme>` repaints with no React re-render) and persists the choice in
+  `localStorage` under `vp-theme`. It NEVER writes the CLI's `~/.vplan/config.json` (a static
+  `file://` plan cannot reach the disk); the disk config is only the render-time default. The
+  preference logic lives in `theme.ts` (`getThemePreference`/`setThemePreference`/
+  `applyThemePreference`/`watchSystemScheme`); the cog is a thin view over it. The menu opens on
+  hover/focus-within AND an explicit click-toggle (`data-open`), because macOS Safari and touch
+  devices neither hover nor focus a button on tap.
+- `theme.ts` resolves the color scheme. Precedence: the `localStorage` override, then the injected
+  `globalThis.__VP_CONFIG__.theme` default (the CLI seeds it from `~/.vplan/config.json`), then
+  `system` (the OS via `matchMedia`). `system` is resolved to a concrete `light`/`dark` and written
+  to `<html data-theme>`. This MUST stay in sync with the CLI's inline `themeBootstrap`
+  (`compile.ts`), which does the same resolution in a tiny `<head>` script before first paint (so a
+  configured dark plan has no light flash). `mount` also calls `applyThemePreference` for paths
+  without that bootstrap (e.g. `/view`).
 - `components/ShareButton.tsx` is the fixed top-right "Share" button. It reads the plan's encoded
   MDX off `globalThis.__VP_SHARE__` (`{ data, dev }`, injected by the CLI build's `planSharePlugin`)
   and copies a `https://visualplan.dev/view?data=...` link. It renders nothing when that global is
@@ -123,8 +139,13 @@ page. The rules below are deliberate; changing them needs a reason.
   not make `--vp-accent` itself a colored hue.
 - **No side-stripe accents.** Callouts use a flat tint plus a full 1px border and a colored label,
   never a `border-left` color stripe (a hard ban).
-- **Off-white / off-black only**, never pure `#fff` / `#000`. All colors are CSS vars with a
-  `prefers-color-scheme: dark` block; both schemes must stay legible.
+- **Off-white / off-black only**, never pure `#fff` / `#000`. All colors are CSS vars. The dark
+  palette is applied two ways that MUST change together: `:root[data-theme="dark"]` (forced dark,
+  set by the cog or the configured default) and `@media (prefers-color-scheme: dark)` on
+  `:root:not([data-theme="light"])` (the system default; also the pre-script no-flash fallback).
+  Plain CSS cannot share one declaration block across a selector and a media query, so the two var
+  lists are duplicated on purpose. Both schemes must stay legible. (Mermaid still reads the CSS vars
+  with no scheme detection of its own, so toggling `data-theme` recolors a diagram for free.)
 - **Mermaid colors come from our CSS vars** (passed to `beautiful-mermaid` as `bg`/`fg`/`line`/
   `accent`/`surface`/`border`), so the diagram tracks the theme automatically. Do not hard-code
   diagram colors or reintroduce scheme detection.

--- a/packages/runtime/Layout.tsx
+++ b/packages/runtime/Layout.tsx
@@ -1,10 +1,11 @@
 import { type ReactNode, useEffect } from 'react'
 import { ShareButton } from './components/ShareButton.js'
+import { ThemeToggle } from './components/ThemeToggle.js'
 import { initFullscreenControls } from './fullscreen.js'
 
 /** Page shell: a single centered content column. The plan supplies its own
- * `# Title` heading; there is no frontmatter-driven header or sidebar. The share
- * button is fixed to the viewport corner, so its position in the tree is incidental. */
+ * `# Title` heading; there is no frontmatter-driven header or sidebar. The theme cog
+ * and share button are fixed to the viewport corner, so their position in the tree is incidental. */
 export function Layout({ children }: { children: ReactNode }) {
   // Fullscreen (diagrams + charts only) is wired up once the tree is committed.
   useEffect(() => {
@@ -13,6 +14,7 @@ export function Layout({ children }: { children: ReactNode }) {
 
   return (
     <div className='vp-shell'>
+      <ThemeToggle />
       <ShareButton />
       <main className='vp-main'>{children}</main>
     </div>

--- a/packages/runtime/Layout.tsx
+++ b/packages/runtime/Layout.tsx
@@ -14,8 +14,8 @@ export function Layout({ children }: { children: ReactNode }) {
 
   return (
     <div className='vp-shell'>
-      <ThemeToggle />
       <ShareButton />
+      <ThemeToggle />
       <main className='vp-main'>{children}</main>
     </div>
   )

--- a/packages/runtime/Layout.tsx
+++ b/packages/runtime/Layout.tsx
@@ -2,10 +2,13 @@ import { type ReactNode, useEffect } from 'react'
 import { ShareButton } from './components/ShareButton.js'
 import { ThemeToggle } from './components/ThemeToggle.js'
 import { initFullscreenControls } from './fullscreen.js'
+import { isThemeLocked } from './theme.js'
 
 /** Page shell: a single centered content column. The plan supplies its own
  * `# Title` heading; there is no frontmatter-driven header or sidebar. The theme cog
- * and share button are fixed to the viewport corner, so their position in the tree is incidental. */
+ * and share button are fixed to the viewport corner, so their position in the tree is incidental.
+ * The cog is hidden when the API locked the theme; the share button self-hides when its data was
+ * not injected (the API's `enableSharing: false`). */
 export function Layout({ children }: { children: ReactNode }) {
   // Fullscreen (diagrams + charts only) is wired up once the tree is committed.
   useEffect(() => {
@@ -15,7 +18,7 @@ export function Layout({ children }: { children: ReactNode }) {
   return (
     <div className='vp-shell'>
       <ShareButton />
-      <ThemeToggle />
+      {!isThemeLocked() && <ThemeToggle />}
       <main className='vp-main'>{children}</main>
     </div>
   )

--- a/packages/runtime/components/ThemeToggle.tsx
+++ b/packages/runtime/components/ThemeToggle.tsx
@@ -1,4 +1,4 @@
-import { IconCheck, IconSettings } from '@tabler/icons-react'
+import { IconSettings } from '@tabler/icons-react'
 import { useEffect, useRef, useState } from 'react'
 import {
   getThemePreference,
@@ -14,9 +14,9 @@ const OPTIONS: { value: ThemePreference; label: string }[] = [
 ]
 
 /**
- * A faint top-right cog (left of the share button) that opens a theme menu on hover or focus.
- * Choosing an option recolors the page live and remembers the choice in `localStorage` for this
- * plan; it never writes the CLI's `~/.vplan/config.json` (a static plan cannot reach the disk).
+ * A faint top-right cog (left of the share button) that opens a Settings menu on hover, focus, or
+ * click. The theme dropdown recolors the page live and remembers the choice in `localStorage` for
+ * this plan; it never writes the CLI's `~/.vplan/config.json` (a static plan cannot reach the disk).
  * The CLI's inline bootstrap already set the initial scheme, so this only re-applies on a change.
  */
 export function ThemeToggle() {
@@ -56,7 +56,6 @@ export function ThemeToggle() {
   const choose = (value: ThemePreference) => {
     setPreference(value)
     setThemePreference(value)
-    setOpen(false)
   }
 
   return (
@@ -64,29 +63,30 @@ export function ThemeToggle() {
       <button
         type='button'
         className='vp-theme__icon'
-        aria-label='Theme settings'
-        aria-haspopup='menu'
+        aria-label='Settings'
+        aria-haspopup='dialog'
         aria-expanded={open}
-        title='Theme settings'
+        title='Settings'
         onClick={() => setOpen(value => !value)}
       >
         <IconSettings size={17} />
       </button>
-      <div className='vp-theme__pop' role='menu'>
-        {OPTIONS.map(option => (
-          <button
-            key={option.value}
-            type='button'
-            className='vp-theme__opt'
-            role='menuitemradio'
-            aria-checked={preference === option.value}
-            data-active={preference === option.value}
-            onClick={() => choose(option.value)}
+      <div className='vp-theme__pop' role='dialog' aria-label='Settings'>
+        <p className='vp-theme__title'>Settings</p>
+        <label className='vp-theme__row'>
+          <span>Theme</span>
+          <select
+            className='vp-theme__select'
+            value={preference}
+            onChange={event => choose(event.target.value as ThemePreference)}
           >
-            <span>{option.label}</span>
-            {preference === option.value && <IconCheck size={15} />}
-          </button>
-        ))}
+            {OPTIONS.map(option => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
+            ))}
+          </select>
+        </label>
       </div>
     </div>
   )

--- a/packages/runtime/components/ThemeToggle.tsx
+++ b/packages/runtime/components/ThemeToggle.tsx
@@ -1,0 +1,93 @@
+import { IconCheck, IconSettings } from '@tabler/icons-react'
+import { useEffect, useRef, useState } from 'react'
+import {
+  getThemePreference,
+  setThemePreference,
+  type ThemePreference,
+  watchSystemScheme,
+} from '../theme.js'
+
+const OPTIONS: { value: ThemePreference; label: string }[] = [
+  { value: 'system', label: 'System' },
+  { value: 'light', label: 'Light' },
+  { value: 'dark', label: 'Dark' },
+]
+
+/**
+ * A faint top-right cog (left of the share button) that opens a theme menu on hover or focus.
+ * Choosing an option recolors the page live and remembers the choice in `localStorage` for this
+ * plan; it never writes the CLI's `~/.vplan/config.json` (a static plan cannot reach the disk).
+ * The CLI's inline bootstrap already set the initial scheme, so this only re-applies on a change.
+ */
+export function ThemeToggle() {
+  const [preference, setPreference] = useState<ThemePreference>('system')
+
+  // The persisted preference is read after mount: server-rendered markup and tests have no
+  // localStorage at module load, and the inline bootstrap has already applied the initial scheme.
+  useEffect(() => {
+    setPreference(getThemePreference())
+  }, [])
+
+  // Track the OS while the live preference is `system`; the cleanup runs when it changes away.
+  useEffect(() => watchSystemScheme(() => preference), [preference])
+
+  // Hover/focus-within reveals the menu on desktop, but macOS Safari and touch devices neither hover
+  // nor focus a button on tap, so the cog also toggles an explicit open state for them.
+  const [open, setOpen] = useState(false)
+  const container = useRef<HTMLDivElement>(null)
+
+  // While open, a click outside or Escape closes the menu (the hover state cannot cover touch).
+  useEffect(() => {
+    if (!open) return
+    const onPointerDown = (event: PointerEvent) => {
+      if (!container.current?.contains(event.target as Node)) setOpen(false)
+    }
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') setOpen(false)
+    }
+    document.addEventListener('pointerdown', onPointerDown)
+    document.addEventListener('keydown', onKeyDown)
+    return () => {
+      document.removeEventListener('pointerdown', onPointerDown)
+      document.removeEventListener('keydown', onKeyDown)
+    }
+  }, [open])
+
+  const choose = (value: ThemePreference) => {
+    setPreference(value)
+    setThemePreference(value)
+    setOpen(false)
+  }
+
+  return (
+    <div className='vp-theme' data-open={open} ref={container}>
+      <button
+        type='button'
+        className='vp-theme__icon'
+        aria-label='Theme settings'
+        aria-haspopup='menu'
+        aria-expanded={open}
+        title='Theme settings'
+        onClick={() => setOpen(value => !value)}
+      >
+        <IconSettings size={17} />
+      </button>
+      <div className='vp-theme__pop' role='menu'>
+        {OPTIONS.map(option => (
+          <button
+            key={option.value}
+            type='button'
+            className='vp-theme__opt'
+            role='menuitemradio'
+            aria-checked={preference === option.value}
+            data-active={preference === option.value}
+            onClick={() => choose(option.value)}
+          >
+            <span>{option.label}</span>
+            {preference === option.value && <IconCheck size={15} />}
+          </button>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/packages/runtime/index.tsx
+++ b/packages/runtime/index.tsx
@@ -13,6 +13,7 @@ import { Phase } from './components/Phase.js'
 import { Questions } from './components/Questions.js'
 import { Stat } from './components/Stat.js'
 import { Layout } from './Layout.js'
+import { applyThemePreference, getThemePreference } from './theme.js'
 import './theme.css'
 
 /**
@@ -38,6 +39,9 @@ export const components = {
 export function mount(Plan: ComponentType) {
   const container = document.getElementById('root')
   if (!container) throw new Error('Visual Plan: #root element not found')
+  // Resolve the scheme for paths without the CLI's inline bootstrap (e.g. /view); idempotent when
+  // the bootstrap already set it.
+  applyThemePreference(getThemePreference())
   createRoot(container).render(
     <MDXProvider components={components}>
       <Layout>

--- a/packages/runtime/tests/components.test.tsx
+++ b/packages/runtime/tests/components.test.tsx
@@ -11,6 +11,7 @@ import { Phase } from '../components/Phase.js'
 import { Questions } from '../components/Questions.js'
 import { copyText, ShareButton } from '../components/ShareButton.js'
 import { Stat } from '../components/Stat.js'
+import { ThemeToggle } from '../components/ThemeToggle.js'
 
 describe('Phase', () => {
   it('renders the title and a status badge for active/done (golden)', () => {
@@ -518,6 +519,22 @@ describe('ShareButton', () => {
     const html = renderToStaticMarkup(<ShareButton />)
     expect(html).toContain('vp-share__note')
     expect(html).toContain('snapshot')
+  })
+})
+
+describe('ThemeToggle', () => {
+  it('renders the cog and a menu of the three theme options (golden)', () => {
+    const html = renderToStaticMarkup(<ThemeToggle />)
+    expect(html).toContain('aria-label="Theme settings"')
+    expect(html).toContain('System')
+    expect(html).toContain('Light')
+    expect(html).toContain('Dark')
+  })
+
+  it('marks system active before any choice is made (edge)', () => {
+    // useEffect does not run under static rendering, so the initial preference (system) shows.
+    const html = renderToStaticMarkup(<ThemeToggle />)
+    expect(html).toMatch(/aria-checked="true"[^>]*>\s*<span>System/)
   })
 })
 

--- a/packages/runtime/tests/components.test.tsx
+++ b/packages/runtime/tests/components.test.tsx
@@ -12,6 +12,7 @@ import { Questions } from '../components/Questions.js'
 import { copyText, ShareButton } from '../components/ShareButton.js'
 import { Stat } from '../components/Stat.js'
 import { ThemeToggle } from '../components/ThemeToggle.js'
+import { Layout } from '../Layout.js'
 
 describe('Phase', () => {
   it('renders the title and a status badge for active/done (golden)', () => {
@@ -537,6 +538,32 @@ describe('ThemeToggle', () => {
     // useEffect does not run under static rendering, so the initial preference (system) shows.
     const html = renderToStaticMarkup(<ThemeToggle />)
     expect(html).toMatch(/<option value="system" selected=""?>System<\/option>/)
+  })
+})
+
+describe('Layout', () => {
+  const config = globalThis as { __VP_CONFIG__?: unknown }
+  afterEach(() => {
+    config.__VP_CONFIG__ = undefined
+  })
+
+  it('renders the theme cog when the theme is not locked (golden)', () => {
+    const html = renderToStaticMarkup(
+      <Layout>
+        <p>plan</p>
+      </Layout>,
+    )
+    expect(html).toContain('aria-label="Settings"')
+  })
+
+  it('hides the theme cog when the API locked the theme (edge)', () => {
+    config.__VP_CONFIG__ = { theme: 'dark', lockTheme: true }
+    const html = renderToStaticMarkup(
+      <Layout>
+        <p>plan</p>
+      </Layout>,
+    )
+    expect(html).not.toContain('aria-label="Settings"')
   })
 })
 

--- a/packages/runtime/tests/components.test.tsx
+++ b/packages/runtime/tests/components.test.tsx
@@ -523,18 +523,20 @@ describe('ShareButton', () => {
 })
 
 describe('ThemeToggle', () => {
-  it('renders the cog and a menu of the three theme options (golden)', () => {
+  it('renders the cog, a Settings title, and a theme dropdown of the three options (golden)', () => {
     const html = renderToStaticMarkup(<ThemeToggle />)
-    expect(html).toContain('aria-label="Theme settings"')
-    expect(html).toContain('System')
-    expect(html).toContain('Light')
-    expect(html).toContain('Dark')
+    expect(html).toContain('aria-label="Settings"')
+    expect(html).toContain('Settings')
+    expect(html).toContain('<select')
+    expect(html).toContain('>System</option>')
+    expect(html).toContain('<option value="light">Light</option>')
+    expect(html).toContain('<option value="dark">Dark</option>')
   })
 
-  it('marks system active before any choice is made (edge)', () => {
+  it('selects system before any choice is made (edge)', () => {
     // useEffect does not run under static rendering, so the initial preference (system) shows.
     const html = renderToStaticMarkup(<ThemeToggle />)
-    expect(html).toMatch(/aria-checked="true"[^>]*>\s*<span>System/)
+    expect(html).toMatch(/<option value="system" selected=""?>System<\/option>/)
   })
 })
 

--- a/packages/runtime/tests/theme.test.ts
+++ b/packages/runtime/tests/theme.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   applyThemePreference,
   getThemePreference,
+  isThemeLocked,
   setThemePreference,
   watchSystemScheme,
 } from '../theme.js'
@@ -32,6 +33,20 @@ beforeEach(() => {
 
 afterEach(() => {
   vi.unstubAllGlobals()
+})
+
+describe('isThemeLocked / locked getThemePreference', () => {
+  it('is unlocked with no injected config (golden)', () => {
+    expect(isThemeLocked()).toBe(false)
+  })
+
+  it('reports locked and ignores the localStorage override when locked (edge)', () => {
+    localStorage.setItem('vp-theme', 'light')
+    ;(globalThis as { __VP_CONFIG__?: unknown }).__VP_CONFIG__ = { theme: 'dark', lockTheme: true }
+    expect(isThemeLocked()).toBe(true)
+    // Locked: the injected theme wins over the stored override.
+    expect(getThemePreference()).toBe('dark')
+  })
 })
 
 describe('getThemePreference', () => {

--- a/packages/runtime/tests/theme.test.ts
+++ b/packages/runtime/tests/theme.test.ts
@@ -1,0 +1,106 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  applyThemePreference,
+  getThemePreference,
+  setThemePreference,
+  watchSystemScheme,
+} from '../theme.js'
+
+/** A controllable `matchMedia` stub (jsdom has none). Tracks listeners so a scheme change can be
+ * simulated, and lets a test set whether the OS currently prefers dark. */
+function stubMatchMedia(matches: boolean) {
+  const listeners = new Set<() => void>()
+  const mql = {
+    matches,
+    addEventListener: (_: string, fn: () => void) => listeners.add(fn),
+    removeEventListener: (_: string, fn: () => void) => listeners.delete(fn),
+  }
+  vi.stubGlobal('matchMedia', () => mql)
+  return {
+    mql,
+    fire: () => {
+      for (const fn of listeners) fn()
+    },
+  }
+}
+
+beforeEach(() => {
+  localStorage.clear()
+  delete document.documentElement.dataset.theme
+  ;(globalThis as { __VP_CONFIG__?: unknown }).__VP_CONFIG__ = undefined
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('getThemePreference', () => {
+  it('returns the stored override when present (golden)', () => {
+    localStorage.setItem('vp-theme', 'dark')
+    expect(getThemePreference()).toBe('dark')
+  })
+
+  it('falls back to the injected config default for an invalid stored value (error)', () => {
+    localStorage.setItem('vp-theme', 'neon')
+    ;(globalThis as { __VP_CONFIG__?: { theme: string } }).__VP_CONFIG__ = { theme: 'light' }
+    expect(getThemePreference()).toBe('light')
+  })
+
+  it('defaults to system with no override and no injected config (edge)', () => {
+    expect(getThemePreference()).toBe('system')
+  })
+})
+
+describe('setThemePreference', () => {
+  it('persists the preference and applies it to <html> (golden)', () => {
+    setThemePreference('dark')
+    expect(localStorage.getItem('vp-theme')).toBe('dark')
+    expect(document.documentElement.dataset.theme).toBe('dark')
+  })
+})
+
+describe('applyThemePreference', () => {
+  it('applies an explicit scheme without consulting the OS (golden)', () => {
+    applyThemePreference('light')
+    expect(document.documentElement.dataset.theme).toBe('light')
+  })
+
+  it('resolves system against the OS preference (edge)', () => {
+    stubMatchMedia(true)
+    applyThemePreference('system')
+    expect(document.documentElement.dataset.theme).toBe('dark')
+
+    stubMatchMedia(false)
+    applyThemePreference('system')
+    expect(document.documentElement.dataset.theme).toBe('light')
+  })
+})
+
+describe('watchSystemScheme', () => {
+  it('re-applies on an OS change while the preference is system (golden)', () => {
+    const { mql, fire } = stubMatchMedia(false)
+    applyThemePreference('system')
+    watchSystemScheme(() => 'system')
+    expect(document.documentElement.dataset.theme).toBe('light')
+
+    mql.matches = true
+    fire()
+    expect(document.documentElement.dataset.theme).toBe('dark')
+  })
+
+  it('ignores OS changes when the preference is not system (error)', () => {
+    const { mql, fire } = stubMatchMedia(false)
+    applyThemePreference('light')
+    watchSystemScheme(() => 'light')
+
+    mql.matches = true
+    fire()
+    expect(document.documentElement.dataset.theme).toBe('light')
+  })
+
+  it('returns a no-op cleanup when matchMedia is unavailable (edge)', () => {
+    expect(typeof matchMedia).toBe('undefined')
+    const cleanup = watchSystemScheme(() => 'system')
+    expect(() => cleanup()).not.toThrow()
+  })
+})

--- a/packages/runtime/theme.css
+++ b/packages/runtime/theme.css
@@ -1122,11 +1122,11 @@ body {
 
 /* Share: a faint fixed top-right icon that brightens and opens a copy popover on
    hover/focus, so the affordance stays out of the way until wanted. */
-/* The theme cog sits just left of the share button (which is at right: 1rem, width 32px). */
+/* The theme cog sits in the top-right corner; the share button is just left of it (width 32px). */
 .vp-theme {
   position: fixed;
   top: 1rem;
-  right: calc(1rem + 40px);
+  right: 1rem;
   z-index: 20;
 }
 
@@ -1231,7 +1231,7 @@ body {
 .vp-share {
   position: fixed;
   top: 1rem;
-  right: 1rem;
+  right: calc(1rem + 40px);
   z-index: 20;
 }
 

--- a/packages/runtime/theme.css
+++ b/packages/runtime/theme.css
@@ -1166,8 +1166,8 @@ body {
   top: calc(100% + 0.4rem);
   right: 0;
   width: max-content;
-  min-width: 8rem;
-  padding: 0.25rem;
+  min-width: 9rem;
+  padding: 0.5rem;
   border: 1px solid var(--vp-border);
   border-radius: 9px;
   background: var(--vp-surface);
@@ -1191,31 +1191,41 @@ body {
   pointer-events: auto;
 }
 
-.vp-theme__opt {
+.vp-theme__title {
+  margin: 0.15rem 0.35rem 0.45rem;
+  font-size: 0.68rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--vp-faint);
+}
+
+.vp-theme__row {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 1.25rem;
-  width: 100%;
-  padding: 0.4rem 0.55rem;
-  border: none;
-  border-radius: 6px;
-  background: transparent;
-  color: var(--vp-text);
-  font: inherit;
+  gap: 1rem;
+  padding: 0.1rem 0.35rem 0.2rem;
   font-size: 0.82rem;
   font-weight: 500;
   white-space: nowrap;
+  color: var(--vp-text);
+}
+
+.vp-theme__select {
+  padding: 0.2rem 0.4rem;
+  border: 1px solid var(--vp-border);
+  border-radius: 6px;
+  background: var(--vp-bg);
+  color: var(--vp-text);
+  font: inherit;
+  font-size: 0.8rem;
   cursor: pointer;
-  transition: background 120ms var(--vp-ease);
+  transition: border-color 120ms var(--vp-ease);
 }
 
-.vp-theme__opt:hover {
-  background: var(--vp-surface-2);
-}
-
-.vp-theme__opt[data-active="true"] {
-  color: var(--vp-accent);
+.vp-theme__select:hover {
+  border-color: var(--vp-border-strong);
 }
 
 .vp-share {
@@ -1340,7 +1350,7 @@ body {
 @media (prefers-reduced-motion: reduce) {
   .vp-theme__icon,
   .vp-theme__pop,
-  .vp-theme__opt,
+  .vp-theme__select,
   .vp-share__icon,
   .vp-share__pop {
     transition: none;

--- a/packages/runtime/theme.css
+++ b/packages/runtime/theme.css
@@ -35,10 +35,52 @@
   --vp-ease: cubic-bezier(0.25, 1, 0.5, 1);
   --vp-font: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
   --vp-mono: "SF Mono", ui-monospace, "JetBrains Mono", Menlo, Consolas, monospace;
+  color-scheme: light;
+}
+
+/* The dark palette is applied two ways: when the page is forced dark (`[data-theme="dark"]` from
+   the cog or the configured default under a light OS), and when the OS prefers dark and the page is
+   not forced light. The two var lists are identical and MUST change together; plain CSS cannot share
+   a declaration block across a selector and a media query. */
+:root[data-theme="dark"] {
+  --vp-bg: #161618;
+  --vp-surface: #1e1e21;
+  --vp-surface-2: #26262a;
+  --vp-text: #e9e9e6;
+  --vp-muted: #a1a1a8;
+  --vp-faint: #74747b;
+  --vp-border: #2b2b2f;
+  --vp-border-strong: #3a3a3f;
+  --vp-accent: #e9e9e6;
+  --vp-on-accent: #161618;
+  --vp-link: #7aa2ff;
+  --vp-done: #45c97a;
+  --vp-modify: #d99a3a;
+  --vp-risk: #ef8f8f;
+  --vp-move: #38b6cf;
+  --vp-gold: #e8c14f;
+  --vp-risk-tint: #241a1c;
+  --vp-risk-border: #43292c;
+  --vp-warn: #e3b54f;
+  --vp-warn-tint: #2a2310;
+  --vp-warn-border: #463a1b;
+  --vp-question: #7aa2ff;
+  --vp-question-tint: #161d2e;
+  --vp-question-border: #2b3a5e;
+  --vp-note: #7aa2ff;
+  --vp-note-tint: #161d2e;
+  --vp-note-border: #2b3a5e;
+  --vp-tip: #45c97a;
+  --vp-tip-tint: #13231a;
+  --vp-tip-border: #234a32;
+  --vp-decision: #b794f6;
+  --vp-decision-tint: #1d1830;
+  --vp-decision-border: #362a52;
+  color-scheme: dark;
 }
 
 @media (prefers-color-scheme: dark) {
-  :root {
+  :root:not([data-theme="light"]) {
     --vp-bg: #161618;
     --vp-surface: #1e1e21;
     --vp-surface-2: #26262a;
@@ -72,6 +114,7 @@
     --vp-decision: #b794f6;
     --vp-decision-tint: #1d1830;
     --vp-decision-border: #362a52;
+    color-scheme: dark;
   }
 }
 
@@ -1079,6 +1122,102 @@ body {
 
 /* Share: a faint fixed top-right icon that brightens and opens a copy popover on
    hover/focus, so the affordance stays out of the way until wanted. */
+/* The theme cog sits just left of the share button (which is at right: 1rem, width 32px). */
+.vp-theme {
+  position: fixed;
+  top: 1rem;
+  right: calc(1rem + 40px);
+  z-index: 20;
+}
+
+.vp-theme__icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  padding: 0;
+  border: 1px solid var(--vp-border);
+  border-radius: 8px;
+  background: var(--vp-surface);
+  color: var(--vp-muted);
+  cursor: pointer;
+  opacity: 0.4;
+  transition:
+    opacity 120ms var(--vp-ease),
+    color 120ms var(--vp-ease),
+    border-color 120ms var(--vp-ease);
+}
+
+.vp-theme:hover .vp-theme__icon,
+.vp-theme:focus-within .vp-theme__icon,
+.vp-theme[data-open="true"] .vp-theme__icon {
+  opacity: 1;
+}
+
+.vp-theme__icon:hover {
+  color: var(--vp-text);
+  border-color: var(--vp-border-strong);
+}
+
+/* The menu, hidden until the cog is hovered or focused. Anchored under the cog. */
+.vp-theme__pop {
+  position: absolute;
+  top: calc(100% + 0.4rem);
+  right: 0;
+  width: max-content;
+  min-width: 8rem;
+  padding: 0.25rem;
+  border: 1px solid var(--vp-border);
+  border-radius: 9px;
+  background: var(--vp-surface);
+  box-shadow: 0 6px 18px -10px rgba(0, 0, 0, 0.3);
+  opacity: 0;
+  visibility: hidden;
+  transform: translateY(-4px);
+  transition:
+    opacity 120ms var(--vp-ease),
+    transform 120ms var(--vp-ease),
+    visibility 120ms var(--vp-ease);
+  pointer-events: none;
+}
+
+.vp-theme:hover .vp-theme__pop,
+.vp-theme:focus-within .vp-theme__pop,
+.vp-theme[data-open="true"] .vp-theme__pop {
+  opacity: 1;
+  visibility: visible;
+  transform: translateY(0);
+  pointer-events: auto;
+}
+
+.vp-theme__opt {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1.25rem;
+  width: 100%;
+  padding: 0.4rem 0.55rem;
+  border: none;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--vp-text);
+  font: inherit;
+  font-size: 0.82rem;
+  font-weight: 500;
+  white-space: nowrap;
+  cursor: pointer;
+  transition: background 120ms var(--vp-ease);
+}
+
+.vp-theme__opt:hover {
+  background: var(--vp-surface-2);
+}
+
+.vp-theme__opt[data-active="true"] {
+  color: var(--vp-accent);
+}
+
 .vp-share {
   position: fixed;
   top: 1rem;
@@ -1199,6 +1338,9 @@ body {
 }
 
 @media (prefers-reduced-motion: reduce) {
+  .vp-theme__icon,
+  .vp-theme__pop,
+  .vp-theme__opt,
   .vp-share__icon,
   .vp-share__pop {
     transition: none;

--- a/packages/runtime/theme.ts
+++ b/packages/runtime/theme.ts
@@ -13,20 +13,35 @@ const PREFERENCES: readonly ThemePreference[] = ['light', 'dark', 'system']
 
 interface InjectedConfig {
   theme?: ThemePreference
+  /** When true the theme is fixed: the cog is hidden and the `localStorage` override is ignored. */
+  lockTheme?: boolean
 }
 
 function isPreference(value: unknown): value is ThemePreference {
   return typeof value === 'string' && (PREFERENCES as readonly string[]).includes(value)
 }
 
-/** The render-time default the CLI injected from `~/.vplan/config.json` (absent in tests / `/view`). */
+function injectedConfig(): InjectedConfig {
+  return (globalThis as { __VP_CONFIG__?: InjectedConfig }).__VP_CONFIG__ ?? {}
+}
+
+/** The render-time default the CLI/API injected (absent in tests / `/view`). */
 function injectedDefault(): ThemePreference {
-  const theme = (globalThis as { __VP_CONFIG__?: InjectedConfig }).__VP_CONFIG__?.theme
+  const theme = injectedConfig().theme
   return isPreference(theme) ? theme : 'system'
 }
 
-/** The active preference: the stored per-view override, else the injected default, else `system`. */
+/** Whether the API locked the theme (cog hidden, no per-view override). */
+export function isThemeLocked(): boolean {
+  return injectedConfig().lockTheme === true
+}
+
+/**
+ * The active preference. A locked theme is the injected value verbatim; otherwise the stored
+ * per-view override wins, then the injected default, then `system`.
+ */
 export function getThemePreference(): ThemePreference {
+  if (isThemeLocked()) return injectedDefault()
   try {
     const stored = localStorage.getItem(STORAGE_KEY)
     if (isPreference(stored)) return stored

--- a/packages/runtime/theme.ts
+++ b/packages/runtime/theme.ts
@@ -1,0 +1,77 @@
+/**
+ * The page's color-scheme preference, shared by the cog (`ThemeToggle`) and `mount`. The CLI bakes
+ * the configured default into `globalThis.__VP_CONFIG__` and sets the initial `<html data-theme>`
+ * via an inline script (see `compile.ts` `themeBootstrap`); this module is the runtime half that
+ * lets the cog override the scheme per-view, persisted in `localStorage`. Precedence matches the
+ * bootstrap: the stored override, then the injected default, then `system` (the OS).
+ */
+
+export type ThemePreference = 'light' | 'dark' | 'system'
+
+const STORAGE_KEY = 'vp-theme'
+const PREFERENCES: readonly ThemePreference[] = ['light', 'dark', 'system']
+
+interface InjectedConfig {
+  theme?: ThemePreference
+}
+
+function isPreference(value: unknown): value is ThemePreference {
+  return typeof value === 'string' && (PREFERENCES as readonly string[]).includes(value)
+}
+
+/** The render-time default the CLI injected from `~/.vplan/config.json` (absent in tests / `/view`). */
+function injectedDefault(): ThemePreference {
+  const theme = (globalThis as { __VP_CONFIG__?: InjectedConfig }).__VP_CONFIG__?.theme
+  return isPreference(theme) ? theme : 'system'
+}
+
+/** The active preference: the stored per-view override, else the injected default, else `system`. */
+export function getThemePreference(): ThemePreference {
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY)
+    if (isPreference(stored)) return stored
+  } catch {
+    // localStorage can be unavailable or blocked (some file:// contexts); fall back to the default.
+  }
+  return injectedDefault()
+}
+
+function prefersDark(): boolean {
+  return typeof matchMedia === 'function' && matchMedia('(prefers-color-scheme: dark)').matches
+}
+
+/** Resolve a preference to the concrete scheme to apply; `system` follows the OS. */
+function resolveScheme(preference: ThemePreference): 'light' | 'dark' {
+  if (preference === 'light' || preference === 'dark') return preference
+  return prefersDark() ? 'dark' : 'light'
+}
+
+/** Apply a preference to `<html data-theme>` now (recolors instantly; all colors are CSS vars). */
+export function applyThemePreference(preference: ThemePreference): void {
+  document.documentElement.dataset.theme = resolveScheme(preference)
+}
+
+/** Persist the per-view preference and apply it. The cog calls this; nothing writes to disk. */
+export function setThemePreference(preference: ThemePreference): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, preference)
+  } catch {
+    // Persistence unavailable; still apply it for this view.
+  }
+  applyThemePreference(preference)
+}
+
+/**
+ * Re-apply the theme when the OS scheme changes while the live preference is `system`, so a
+ * `system` plan tracks the OS without a reload. `getPreference` is read on each change so the
+ * listener reflects the latest choice. Returns a cleanup function.
+ */
+export function watchSystemScheme(getPreference: () => ThemePreference): () => void {
+  if (typeof matchMedia !== 'function') return () => {}
+  const query = matchMedia('(prefers-color-scheme: dark)')
+  const onChange = () => {
+    if (getPreference() === 'system') applyThemePreference('system')
+  }
+  query.addEventListener('change', onChange)
+  return () => query.removeEventListener('change', onChange)
+}


### PR DESCRIPTION
## Summary

Adds persistent theme configuration to the CLI, an in-page settings cog for viewers, view-control options to the programmatic API, and fixes a light-mode code-readability bug surfaced along the way.

## What's included

**CLI config persistence** (`~/.vplan/config.json`)
- Literal `~/.vplan/config.json` via `homedir()` (deliberately not `env-paths`), holding the default `theme` (`light` | `dark` | `system`).
- Read at render time and baked into the page via an inline `<head>` bootstrap that sets `<html data-theme>` before first paint (no flash). Tolerant reads (missing/malformed → `system`).
- New `vplan config` command: bare `config` shows settings + path; `config get|set|path` read, write (validated), and locate the file. Invalid key/value → stderr + exit 1.

**In-page settings cog** (runtime)
- A cog in the top-right opens a "Settings" menu with a theme dropdown (System / Light / Dark). Selecting recolors the page live with no re-render (all colors are CSS vars, including Mermaid/Charts), and persists per-view in `localStorage` (never writes the disk config).
- `theme.css` restructured to drive the dark palette off `:root[data-theme="dark"]`, keeping the `prefers-color-scheme` media query as the system / pre-script fallback.

**Programmatic API view options** (`renderPlan`)
- `theme?: 'light' | 'dark' | 'system'` — fixes the scheme and hides the cog (locked: ignores the per-view override).
- `enableSharing?: boolean` (default `false`) — gates the share button for embedded renders.
- Threaded through `buildHtml` as `BuildOptions`; the CLI keeps cog + share on. `Theme` is exported.

**Fix: light-mode code syntax theme**
- Expressive Code switched syntax themes only by OS (`prefers-color-scheme`), so forcing a theme against the OS left code blocks on the wrong (unreadable) theme. `themeCssSelector` now keys each EC theme off the page's `[data-theme]` via the theme's `type`.

## Verification
- `pnpm typecheck`, `pnpm check` (biome), `pnpm test` → all green (226 tests, including config, theme logic, cog/Layout gating, EC injection, and the three renderPlan option cases).
- End-to-end through the built CLI (`vplan config` + a dark-config render) and the built `dist/api.js` (theme lock + enableSharing markers).

## Notes / decisions
- `env-paths` was dropped: it cannot produce `~/.vplan`, and the literal path was chosen.
- The cog persists only to `localStorage`; the disk config is CLI-side (set via `vplan config set` or by hand).
- Known cosmetic quirk: with `theme` set (cog hidden) **and** `enableSharing: true`, the lone share button sits in the left slot leaving the corner empty (fixed-position slots, not a packing toolbar). Easy follow-up if wanted.