### PR TITLE
feat(cli): port flag, stdin/stdout I/O, and a share command

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,11 +7,15 @@ polished, self-contained HTML page, so an AI agent can present plans as scannabl
 ## What it does
 
 - `vplan <file.mdx>` (alias `render`) compiles a plan to a single self-contained
-  `<file>.plan.html` and opens it. `--watch` starts a hot-reloading dev server instead (on
-  `--port`, default 9140, auto-incrementing if taken); `--out <path>` sets the output; `--no-open`
-  suppresses the browser.
+  `<file>.plan.html` and opens it. Input is a file, `-`, or piped stdin; `--stdout` writes the HTML
+  to stdout instead (so it composes in a pipeline). `--watch` starts a hot-reloading dev server
+  instead (on `--port`, default 9140, auto-incrementing if taken; needs a real file, not stdin);
+  `--out <path>` sets the output; `--no-open` suppresses the browser.
 - `vplan check <file.mdx>` validates a plan without rendering (the self-correction
   loop): MDX compile errors plus static component checks, printed as `file:line:col`.
+- `vplan share <file.mdx|->` prints a stateless `visualplan.dev/view?data=...` link encoding the
+  plan's MDX (deflate + base64url), validating first so a broken plan is never shared. Reads a file
+  or stdin.
 - `vplan components` prints the component vocabulary cheat-sheet.
 - A programmatic API (`import { renderPlan, checkPlan } from 'vplan'`) renders/validates a plan from
   an in-memory MDX string, with a named export per catalog entry. See `packages/cli/src/api.ts`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,8 +7,9 @@ polished, self-contained HTML page, so an AI agent can present plans as scannabl
 ## What it does
 
 - `vplan <file.mdx>` (alias `render`) compiles a plan to a single self-contained
-  `<file>.plan.html` and opens it. `--watch` starts a hot-reloading dev server instead;
-  `--out <path>` sets the output; `--no-open` suppresses the browser.
+  `<file>.plan.html` and opens it. `--watch` starts a hot-reloading dev server instead (on
+  `--port`, default 9140, auto-incrementing if taken); `--out <path>` sets the output; `--no-open`
+  suppresses the browser.
 - `vplan check <file.mdx>` validates a plan without rendering (the self-correction
   loop): MDX compile errors plus static component checks, printed as `file:line:col`.
 - `vplan components` prints the component vocabulary cheat-sheet.

--- a/packages/cli/AGENTS.md
+++ b/packages/cli/AGENTS.md
@@ -7,9 +7,14 @@ programmatic Node API at `dist/api.js` (the package's `import` entry, `exports["
 ## Structure
 
 - `src/index.ts` — commander dispatch (the `bin`). `src/commands/` — one file per command (render,
-  check, components, config). `config` is a parent command: bare `config` shows the settings + path,
-  `config get <key>` / `config set <key> <value>` / `config path` are subcommands. Invalid key/value
-  throws, which the top-level catch turns into a stderr message + exit 1.
+  check, components, config, share). `config` is a parent command: bare `config` shows the settings
+  + path, `config get <key>` / `config set <key> <value>` / `config path` are subcommands. Invalid
+  key/value throws, which the top-level catch turns into a stderr message + exit 1.
+- `src/commands/input.ts` — `readPlanSource(file?)`, the shared input layer for `render` and
+  `share`. Returns the MDX source plus a diagnostics `label` and a `fromStdin` flag. Reads stdin when
+  the arg is `-` or (no arg given) stdin is piped (`!process.stdin.isTTY`); a bare invocation on an
+  interactive terminal throws rather than hang. `render` routes stdin output to stdout by default,
+  and `--stdout`/`--out`/`--watch` have mutual-exclusion guards (watch needs a real file to re-read).
 - `src/config.ts` — the persistent CLI config at `~/.vplan/config.json` (literal path via
   `homedir()`, deliberately NOT `env-paths`). Only setting today is `theme` (`light`|`dark`|
   `system`). `readConfig` is tolerant (missing/malformed/unknown-theme -> `{ theme: 'system' }`) so a

--- a/packages/cli/src/build/compile.ts
+++ b/packages/cli/src/build/compile.ts
@@ -326,13 +326,22 @@ export interface DevServer {
   close: () => Promise<void>
 }
 
+/** Default port for the `--watch` dev server. A fixed, memorable port avoids colliding with the
+ * many other tools that sit on Vite's own 5173 default. Vite still auto-increments if it is taken. */
+export const DEFAULT_DEV_PORT = 9140
+
 /** Start a hot-reloading dev server for an MDX plan file and return its local URL. */
-export async function startDevServer(mdxPath: string, theme: Theme = 'system'): Promise<DevServer> {
+export async function startDevServer(
+  mdxPath: string,
+  theme: Theme = 'system',
+  port: number = DEFAULT_DEV_PORT,
+): Promise<DevServer> {
   const paths = findRuntimePaths()
-  const server = await createServer(baseConfig(paths, { path: resolve(mdxPath) }, { theme }))
+  const config = baseConfig(paths, { path: resolve(mdxPath) }, { theme })
+  const server = await createServer({ ...config, server: { ...config.server, port } })
   await server.listen()
   const url =
-    server.resolvedUrls?.local[0] ?? `http://localhost:${server.config.server.port ?? 5173}`
+    server.resolvedUrls?.local[0] ?? `http://localhost:${server.config.server.port ?? port}`
   return {
     url,
     close: () => server.close(),

--- a/packages/cli/src/commands/input.ts
+++ b/packages/cli/src/commands/input.ts
@@ -1,0 +1,38 @@
+import { readFile } from 'node:fs/promises'
+import { resolvePlanFile } from './check.js'
+
+/** A plan's MDX source plus a label for diagnostics (the file path, or `<stdin>`). */
+export interface PlanSource {
+  source: string
+  /** What `check` issues are prefixed with: the file path, or `<stdin>` for piped input. */
+  label: string
+  fromStdin: boolean
+}
+
+const STDIN_LABEL = '<stdin>'
+
+/** Drain `process.stdin` to a UTF-8 string. Used when the plan is piped in rather than a file. */
+async function readStdin(): Promise<string> {
+  const chunks: Buffer[] = []
+  for await (const chunk of process.stdin) chunks.push(chunk as Buffer)
+  return Buffer.concat(chunks).toString('utf8')
+}
+
+/**
+ * Resolve a plan's MDX source from a file argument or stdin, BOM-stripped. The `file` arg is read
+ * as a path unless it is `-` (the explicit stdin sentinel). When no `file` is given, stdin is used
+ * if it is piped; a bare invocation on an interactive terminal throws rather than hang waiting for
+ * input that will never come.
+ */
+export async function readPlanSource(file?: string): Promise<PlanSource> {
+  const useStdin = file === '-' || (file === undefined && !process.stdin.isTTY)
+  if (useStdin) {
+    const source = (await readStdin()).replace(/^\ufeff/, '')
+    return { source, label: STDIN_LABEL, fromStdin: true }
+  }
+  if (file === undefined) {
+    throw new Error('No input: pass a plan file or pipe MDX to stdin.')
+  }
+  const source = (await readFile(resolvePlanFile(file), 'utf8')).replace(/^\ufeff/, '')
+  return { source, label: file, fromStdin: false }
+}

--- a/packages/cli/src/commands/render.ts
+++ b/packages/cli/src/commands/render.ts
@@ -1,4 +1,5 @@
 import { basename, dirname, extname, join, resolve } from 'node:path'
+import { InvalidArgumentError } from 'commander'
 import open from 'open'
 import { checkPlan } from '../build/check.js'
 import { renderToFile, startDevServer } from '../build/compile.js'
@@ -9,6 +10,18 @@ export interface RenderOptions {
   watch?: boolean
   out?: string
   open?: boolean
+  /** Port for the `--watch` dev server; ignored for a one-shot file render. */
+  port?: number
+}
+
+/** Parse and validate the `--port` value as a TCP port (1-65535). Commander calls this per option
+ * value, throwing `InvalidArgumentError` (which it renders as a usage error) on a bad port. */
+export function parsePort(value: string): number {
+  const port = Number(value)
+  if (!Number.isInteger(port) || port < 1 || port > 65535) {
+    throw new InvalidArgumentError('port must be an integer between 1 and 65535')
+  }
+  return port
 }
 
 function defaultOutPath(absMdx: string): string {
@@ -30,7 +43,7 @@ export async function runRender(file: string, options: RenderOptions): Promise<v
   const { theme } = await readConfig()
 
   if (options.watch) {
-    const server = await startDevServer(absMdx, theme)
+    const server = await startDevServer(absMdx, theme, options.port)
     process.stdout.write(
       `Visual Plan watching ${file}\n  ${server.url}\n  (edit the file to hot-reload; Ctrl+C to stop)\n`,
     )

--- a/packages/cli/src/commands/render.ts
+++ b/packages/cli/src/commands/render.ts
@@ -1,15 +1,19 @@
+import { writeFile } from 'node:fs/promises'
 import { basename, dirname, extname, join, resolve } from 'node:path'
 import { InvalidArgumentError } from 'commander'
 import open from 'open'
-import { checkPlan } from '../build/check.js'
-import { renderToFile, startDevServer } from '../build/compile.js'
+import { checkPlan, checkSource } from '../build/check.js'
+import { buildHtml, startDevServer } from '../build/compile.js'
 import { readConfig } from '../config.js'
 import { printIssues, resolvePlanFile } from './check.js'
+import { readPlanSource } from './input.js'
 
 export interface RenderOptions {
   watch?: boolean
   out?: string
   open?: boolean
+  /** Write the rendered HTML to stdout instead of a file (suppresses the browser open). */
+  stdout?: boolean
   /** Port for the `--watch` dev server; ignored for a one-shot file render. */
   port?: number
 }
@@ -29,20 +33,34 @@ function defaultOutPath(absMdx: string): string {
   return join(dirname(absMdx), `${stem}.plan.html`)
 }
 
-/** `vplan render <file>` — validate, then build a static page or start a watch server. */
-export async function runRender(file: string, options: RenderOptions): Promise<void> {
-  const absMdx = resolvePlanFile(file)
-
-  const issues = await checkPlan(absMdx)
-  if (issues.length > 0) {
-    printIssues(file, issues)
-    process.exitCode = 1
-    return
+/**
+ * `vplan render [file]` — validate, then build a static page or start a watch server. Input comes
+ * from a file, an explicit `-`, or piped stdin; output goes to a file (and opens) or to stdout.
+ */
+export async function runRender(file: string | undefined, options: RenderOptions): Promise<void> {
+  if (options.stdout && options.out) {
+    throw new Error('Pass either --stdout or --out, not both.')
+  }
+  if (options.stdout && options.watch) {
+    throw new Error(
+      '--stdout cannot be combined with --watch; the watch server has no file output.',
+    )
   }
 
   const { theme } = await readConfig()
 
+  // The watch server hot-reloads a file on disk, so it needs a real path; stdin has nothing to re-read.
   if (options.watch) {
+    if (file === undefined || file === '-') {
+      throw new Error('--watch needs a plan file; it cannot watch stdin.')
+    }
+    const absMdx = resolvePlanFile(file)
+    const issues = await checkPlan(absMdx)
+    if (issues.length > 0) {
+      printIssues(file, issues)
+      process.exitCode = 1
+      return
+    }
     const server = await startDevServer(absMdx, theme, options.port)
     process.stdout.write(
       `Visual Plan watching ${file}\n  ${server.url}\n  (edit the file to hot-reload; Ctrl+C to stop)\n`,
@@ -51,8 +69,25 @@ export async function runRender(file: string, options: RenderOptions): Promise<v
     return
   }
 
-  const out = options.out ? resolve(options.out) : defaultOutPath(absMdx)
-  await renderToFile(absMdx, out, theme)
+  const { source, label, fromStdin } = await readPlanSource(file)
+  const issues = await checkSource(source)
+  if (issues.length > 0) {
+    printIssues(label, issues)
+    process.exitCode = 1
+    return
+  }
+
+  const html = await buildHtml(source, { theme })
+
+  // Piped stdin with no explicit destination defaults to stdout, so the tool composes in a pipeline.
+  if (options.stdout || (fromStdin && !options.out)) {
+    process.stdout.write(html)
+    return
+  }
+
+  // Not stdout, so there is a file destination: --out, or the default beside a file input.
+  const out = options.out ? resolve(options.out) : defaultOutPath(resolve(file as string))
+  await writeFile(out, html)
   process.stdout.write(`Rendered ${out}\n`)
   if (options.open !== false) await open(out)
 }

--- a/packages/cli/src/commands/share.ts
+++ b/packages/cli/src/commands/share.ts
@@ -1,0 +1,24 @@
+import { buildShareUrl } from '@visualplan/core/share'
+import { checkSource } from '../build/check.js'
+import { printIssues } from './check.js'
+import { readPlanSource } from './input.js'
+
+/**
+ * `vplan share [file]` — print a stateless `visualplan.dev/view?data=...` link for a plan, reading
+ * its MDX from a file, an explicit `-`, or piped stdin. The plan is validated first: the link
+ * recompiles in-browser at view time, so a broken plan would render a broken view for the recipient.
+ * On issues it prints them to stderr and exits 1 without emitting a URL, keeping stdout clean.
+ */
+export async function runShare(file?: string): Promise<void> {
+  const { source, label } = await readPlanSource(file)
+
+  const issues = await checkSource(source)
+  if (issues.length > 0) {
+    printIssues(label, issues)
+    process.stderr.write(`\n${issues.length} issue(s) found\n`)
+    process.exitCode = 1
+    return
+  }
+
+  process.stdout.write(`${buildShareUrl(source)}\n`)
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,9 +1,10 @@
 import { Command } from 'commander'
 import packageJson from '../package.json' with { type: 'json' }
+import { DEFAULT_DEV_PORT } from './build/compile.js'
 import { runCheck } from './commands/check.js'
 import { runComponents } from './commands/components.js'
 import { runConfigGet, runConfigPath, runConfigSet, runConfigShow } from './commands/config.js'
-import { runRender, type RenderOptions } from './commands/render.js'
+import { parsePort, runRender, type RenderOptions } from './commands/render.js'
 
 const program = new Command('vplan')
   .description("Render an AI agent's plans as visual MDX pages instead of walls of text")
@@ -14,6 +15,7 @@ program
   .description('Compile a plan .mdx to a self-contained HTML page (default command)')
   .argument('<file>', 'the plan .mdx file to render')
   .option('--watch', 'start a hot-reloading dev server instead of writing a file')
+  .option('--port <number>', 'port for the --watch dev server', parsePort, DEFAULT_DEV_PORT)
   .option('--out <path>', 'output HTML path (defaults to <file>.plan.html)')
   .option('--no-open', 'do not open the result in a browser')
   .action((file: string, options: RenderOptions) => runRender(file, options))

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -5,6 +5,7 @@ import { runCheck } from './commands/check.js'
 import { runComponents } from './commands/components.js'
 import { runConfigGet, runConfigPath, runConfigSet, runConfigShow } from './commands/config.js'
 import { parsePort, runRender, type RenderOptions } from './commands/render.js'
+import { runShare } from './commands/share.js'
 
 const program = new Command('vplan')
   .description("Render an AI agent's plans as visual MDX pages instead of walls of text")
@@ -13,12 +14,19 @@ const program = new Command('vplan')
 program
   .command('render', { isDefault: true })
   .description('Compile a plan .mdx to a self-contained HTML page (default command)')
-  .argument('<file>', 'the plan .mdx file to render')
+  .argument('[file]', 'the plan .mdx file; - or omit to read from stdin')
   .option('--watch', 'start a hot-reloading dev server instead of writing a file')
   .option('--port <number>', 'port for the --watch dev server', parsePort, DEFAULT_DEV_PORT)
   .option('--out <path>', 'output HTML path (defaults to <file>.plan.html)')
+  .option('--stdout', 'write the rendered HTML to stdout instead of a file')
   .option('--no-open', 'do not open the result in a browser')
-  .action((file: string, options: RenderOptions) => runRender(file, options))
+  .action((file: string | undefined, options: RenderOptions) => runRender(file, options))
+
+program
+  .command('share')
+  .description('Print a shareable visualplan.dev/view link for a plan')
+  .argument('[file]', 'the plan .mdx file; - or omit to read from stdin')
+  .action((file: string | undefined) => runShare(file))
 
 program
   .command('check')

--- a/packages/cli/tests/io.test.ts
+++ b/packages/cli/tests/io.test.ts
@@ -1,0 +1,147 @@
+// @vitest-environment node
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { Readable } from 'node:stream'
+import { buildShareUrl, decodePlan } from '@visualplan/core/share'
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest'
+import { readPlanSource } from '../src/commands/input.js'
+import { runRender } from '../src/commands/render.js'
+import { runShare } from '../src/commands/share.js'
+
+const VALID_PLAN = '# Plan\n\nSome text.\n'
+const INVALID_PLAN = '# Plan\n\n<Bogus/>\n'
+
+let workDir: string
+const realStdin = Object.getOwnPropertyDescriptor(process, 'stdin')
+
+beforeAll(async () => {
+  workDir = await mkdtemp(join(tmpdir(), 'visualplan-io-test-'))
+})
+
+afterAll(async () => {
+  await rm(workDir, { recursive: true, force: true })
+})
+
+afterEach(() => {
+  // runShare/runRender set a non-zero exit code on the failure path; reset it so it does not leak
+  // into vitest's own process exit. Also restore any stdin we faked.
+  process.exitCode = 0
+  if (realStdin) Object.defineProperty(process, 'stdin', realStdin)
+  vi.restoreAllMocks()
+})
+
+/** Replace `process.stdin` with a finite in-memory stream so the stdin paths run in-process. */
+function fakeStdin(content: string, { tty = false } = {}): void {
+  const stream = Readable.from([Buffer.from(content, 'utf8')]) as Readable & { isTTY?: boolean }
+  stream.isTTY = tty
+  Object.defineProperty(process, 'stdin', { value: stream, configurable: true })
+}
+
+/** Capture everything written to a process stream during the callback. */
+function capture(stream: 'stdout' | 'stderr') {
+  const chunks: string[] = []
+  vi.spyOn(process[stream], 'write').mockImplementation((chunk: unknown) => {
+    chunks.push(String(chunk))
+    return true
+  })
+  return () => chunks.join('')
+}
+
+async function writePlan(name: string, content: string): Promise<string> {
+  const path = join(workDir, name)
+  await writeFile(path, content)
+  return path
+}
+
+describe('readPlanSource', () => {
+  it('reads a plan file (golden)', async () => {
+    const path = await writePlan('read.mdx', VALID_PLAN)
+    const result = await readPlanSource(path)
+    expect(result).toEqual({ source: VALID_PLAN, label: path, fromStdin: false })
+  })
+
+  it('throws a friendly error for a missing file (error)', async () => {
+    await expect(readPlanSource(join(workDir, 'nope.mdx'))).rejects.toThrow(/File not found/)
+  })
+
+  it('reads stdin for the explicit - sentinel (edge)', async () => {
+    fakeStdin(VALID_PLAN)
+    expect(await readPlanSource('-')).toEqual({
+      source: VALID_PLAN,
+      label: '<stdin>',
+      fromStdin: true,
+    })
+  })
+
+  it('auto-reads piped stdin when no file is given (edge)', async () => {
+    fakeStdin(VALID_PLAN, { tty: false })
+    const result = await readPlanSource(undefined)
+    expect(result.fromStdin).toBe(true)
+    expect(result.source).toBe(VALID_PLAN)
+  })
+
+  it('throws rather than hang when no file is given on an interactive terminal (error)', async () => {
+    fakeStdin('', { tty: true })
+    await expect(readPlanSource(undefined)).rejects.toThrow(/No input/)
+  })
+})
+
+describe('buildShareUrl', () => {
+  it('builds a view link whose payload round-trips to the source (golden)', () => {
+    const url = buildShareUrl(VALID_PLAN)
+    expect(url.startsWith('https://visualplan.dev/view?data=')).toBe(true)
+    expect(decodePlan(url.split('data=')[1])).toBe(VALID_PLAN)
+  })
+})
+
+describe('runShare', () => {
+  it('prints a round-tripping view link for a valid plan (golden)', async () => {
+    const path = await writePlan('share-ok.mdx', VALID_PLAN)
+    const out = capture('stdout')
+    await runShare(path)
+    const url = out().trim()
+    expect(url.startsWith('https://visualplan.dev/view?data=')).toBe(true)
+    expect(decodePlan(url.split('data=')[1])).toBe(VALID_PLAN)
+    expect(process.exitCode).not.toBe(1)
+  })
+
+  it('reads the plan from stdin (edge)', async () => {
+    fakeStdin(VALID_PLAN)
+    const out = capture('stdout')
+    await runShare('-')
+    expect(out().trim().startsWith('https://visualplan.dev/view?data=')).toBe(true)
+  })
+
+  it('refuses an invalid plan: issues to stderr, exit 1, no URL on stdout (error)', async () => {
+    const path = await writePlan('share-bad.mdx', INVALID_PLAN)
+    const out = capture('stdout')
+    const err = capture('stderr')
+    await runShare(path)
+    expect(process.exitCode).toBe(1)
+    expect(err()).toMatch(/Unknown component <Bogus>/)
+    expect(out()).not.toMatch(/visualplan\.dev/)
+  })
+})
+
+describe('runRender output routing', () => {
+  it('writes a self-contained HTML document to stdout with --stdout (golden)', async () => {
+    const path = await writePlan('render-stdout.mdx', VALID_PLAN)
+    const out = capture('stdout')
+    await runRender(path, { stdout: true, open: false })
+    const html = out()
+    expect(html.startsWith('<!doctype html>')).toBe(true)
+    expect(html).toContain('id="root"')
+  }, 60_000)
+
+  it('rejects --stdout combined with --out (error)', async () => {
+    const path = await writePlan('render-conflict.mdx', VALID_PLAN)
+    await expect(runRender(path, { stdout: true, out: 'x.html' })).rejects.toThrow(
+      /either --stdout or --out/,
+    )
+  })
+
+  it('rejects --watch on stdin input (edge)', async () => {
+    await expect(runRender('-', { watch: true })).rejects.toThrow(/--watch needs a plan file/)
+  })
+})

--- a/packages/cli/tests/render.test.ts
+++ b/packages/cli/tests/render.test.ts
@@ -1,0 +1,21 @@
+// @vitest-environment node
+import { describe, expect, it } from 'vitest'
+import { parsePort } from '../src/commands/render.js'
+
+describe('parsePort', () => {
+  it('parses a valid port string to a number (golden)', () => {
+    expect(parsePort('9140')).toBe(9140)
+  })
+
+  it('rejects a non-numeric port (error)', () => {
+    expect(() => parsePort('abc')).toThrow(/integer between 1 and 65535/)
+  })
+
+  it('rejects ports outside the 1-65535 range and non-integers (edge)', () => {
+    expect(() => parsePort('0')).toThrow()
+    expect(() => parsePort('65536')).toThrow()
+    expect(() => parsePort('9140.5')).toThrow()
+    expect(parsePort('1')).toBe(1)
+    expect(parsePort('65535')).toBe(65535)
+  })
+})

--- a/packages/cli/tests/watch.test.ts
+++ b/packages/cli/tests/watch.test.ts
@@ -3,7 +3,7 @@ import { mkdtemp, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
-import { type DevServer, startDevServer } from '../src/build/compile.js'
+import { DEFAULT_DEV_PORT, type DevServer, startDevServer } from '../src/build/compile.js'
 
 let workDir: string
 let planPath: string
@@ -26,6 +26,22 @@ describe('startDevServer (--watch)', () => {
     const html = await (await fetch(server.url)).text()
     expect(html).toContain('id="root"')
   })
+
+  it('defaults to DEFAULT_DEV_PORT when no port is passed (golden)', () => {
+    // The shared server has no explicit port, so it binds the default (or the next free port if
+    // 9140 is taken). Asserting the host distinguishes the default from Vite's old 5173.
+    expect(new URL(server.url).port).toBe(String(DEFAULT_DEV_PORT))
+  })
+
+  it('binds an explicitly requested port (edge)', async () => {
+    const requested = 9173
+    const custom = await startDevServer(planPath, 'system', requested)
+    try {
+      expect(new URL(custom.url).port).toBe(String(requested))
+    } finally {
+      await custom.close()
+    }
+  }, 60_000)
 
   it('pushes a full-reload over HMR when the watched plan is edited (regression)', async () => {
     // The plan is a virtual module backed by a file, so addWatchFile alone does not invalidate it

--- a/packages/core/AGENTS.md
+++ b/packages/core/AGENTS.md
@@ -19,6 +19,10 @@ CLI's `check` and `components` commands. One file: `src/index.ts`.
   `/view` passes it because the payload is untrusted, and the decode is then a BOUNDED streaming
   inflate that aborts with `PlanTooLargeError` rather than letting a decompression bomb (DEFLATE can
   expand ~1000x) exhaust memory. The CLI never decodes, so the trusted round-trip omits the cap.
+  `SHARE_VIEW_URL` (the `visualplan.dev/view` base) lives in `index.ts`, NOT here, because the
+  runtime share button imports it and must stay `fflate`-free; `share.ts`'s `buildShareUrl` (CLI
+  only) imports the constant from the index. The dependency is one-way (share -> index); never make
+  `index.ts` import `share.ts`, or `fflate` leaks into the vendored runtime path.
 - **The `exports` map MUST keep `"./package.json": "./package.json"`.** Once a package has an
   `exports` map, Node blocks every subpath not listed, including `package.json`. `compile.ts`'s
   `findRuntimePaths` resolves `@visualplan/core/package.json` to locate the core dir in the

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -9,6 +9,11 @@ import { z } from 'zod'
  * imports. Keep it isomorphic.
  */
 
+/** The visualplan.dev page that decodes a `?data=` share link and recompiles the plan in-browser.
+ * Lives in the index (not the `share` codec subpath) so the vendored, fflate-free runtime can import
+ * it for the share button; the CLI's `buildShareUrl` reads it from here too. One source of truth. */
+export const SHARE_VIEW_URL = 'https://visualplan.dev/view'
+
 export const STATUS_VALUES = ['planned', 'active', 'done'] as const
 export const CHANGE_VALUES = ['add', 'modify', 'delete', 'move'] as const
 export const CHART_TYPE_VALUES = [

--- a/packages/core/src/share.ts
+++ b/packages/core/src/share.ts
@@ -1,4 +1,5 @@
 import { deflateSync, Inflate, inflateSync, strFromU8, strToU8 } from 'fflate'
+import { SHARE_VIEW_URL } from './index.js'
 
 /**
  * Codec for the stateless plan-share URL (`?data=`). A plan's MDX source is
@@ -91,6 +92,12 @@ function base64UrlToBytes(data: string): Uint8Array {
 /** Encode a plan's MDX source into the URL-safe `?data=` payload. */
 export function encodePlan(mdx: string): string {
   return bytesToBase64Url(deflateSync(strToU8(mdx), { level: 9 }))
+}
+
+/** Build the full stateless share link for a plan's MDX source. `SHARE_VIEW_URL` lives in the core
+ * index (fflate-free) so the runtime can share it; this codec subpath carries the encode half. */
+export function buildShareUrl(mdx: string): string {
+  return `${SHARE_VIEW_URL}?data=${encodePlan(mdx)}`
 }
 
 /** Thrown by `decodePlan` when a payload decompresses past `maxBytes`. Distinct from a corrupt

--- a/packages/runtime/components/ShareButton.tsx
+++ b/packages/runtime/components/ShareButton.tsx
@@ -1,8 +1,6 @@
 import { IconCheck, IconCopy, IconShare3 } from '@tabler/icons-react'
+import { SHARE_VIEW_URL } from '@visualplan/core'
 import { useState } from 'react'
-
-/** The page `/view` lives at on visualplan.dev; the share link points here. */
-const VIEW_URL = 'https://visualplan.dev/view'
 
 /** Injected onto `globalThis` by the CLI build (compile.ts `planSharePlugin`). */
 interface PlanShare {
@@ -80,7 +78,7 @@ export function ShareButton() {
   const copied = status === 'copied'
 
   const onCopy = async () => {
-    const link = `${VIEW_URL}?data=${await currentData(share)}`
+    const link = `${SHARE_VIEW_URL}?data=${await currentData(share)}`
     setUrl(link)
     const ok = await copyText(link)
     setStatus(ok ? 'copied' : 'manual')

--- a/skills/visual-plan/SKILL.md
+++ b/skills/visual-plan/SKILL.md
@@ -24,10 +24,17 @@ and tables, with prose only connecting the visuals, not carrying the plan itself
 2. Validate before showing the user: `vplan check <file>.mdx`. Fix any reported
    `file:line:col` issues (it names the valid values for bad enums and flags unknown components).
 3. Render: `vplan <file>.mdx` writes a self-contained `<file>.plan.html` next to the source and
-   opens it. Pass `--no-open` to skip the browser, `--out <path>` to set the output location, or
-   `--watch` to start a live-reloading dev server while you refine the plan. `--watch` is a
-   long-running foreground server (it serves a local URL, writes no file, and only stops on
-   Ctrl+C), so for a one-shot HTML output use the plain render, not `--watch`.
+   **opens it in the browser**. Opening the rendered plan is the whole point of this tool, so let
+   it open by default. While you are iterating on the plan with the user, prefer
+   `vplan --watch <file>.mdx`: it starts a live-reloading dev server so your edits show up in the
+   open page without a re-run. `--watch` is a long-running foreground server (run it in the
+   background; it serves a local URL, writes no file, and only stops on Ctrl+C), so for a final
+   one-shot HTML output use the plain render, not `--watch`. `--out <path>` sets the output
+   location.
+
+   **Do not pass `--no-open`.** A plan the user never sees defeats the tool. Only suppress the
+   browser when the user has explicitly asked for the HTML file alone (e.g. for CI or a headless
+   run); a plan being generated for the user to read is never that case.
 
 Run `vplan components` anytime for the exact prop signatures.
 
@@ -217,6 +224,9 @@ it in paragraphs. Prose is the connective tissue between visuals, never the subs
 
 - **Always `vplan check` before presenting, and fix every reported `file:line:col` issue first.**
   The user should never see a broken render.
+- **Let the plan open; never pass `--no-open` for a user-facing plan.** The point of a visual plan
+  is that the user sees it. Use the plain render (which opens the page) to deliver, or `--watch`
+  while iterating. Reserve `--no-open` for an explicit headless/CI request only.
 - **No images or external assets.** The page is a single self-contained file, so a markdown image
   (`![](url)`) or any external asset cannot be embedded, and `check` rejects markdown images. Use a
   ` ```mermaid ` diagram for anything visual, or describe it in text.


### PR DESCRIPTION
## Summary

- Add `--port` to the `--watch` dev server (default **9140**, auto-incrementing if taken) so it stops colliding with other Vite tools on 5173.
- `render` now reads MDX from a file, `-`, or piped stdin, and `--stdout` writes the HTML to stdout, so `vplan` composes in a pipeline (`cat plan.mdx | vplan render - --stdout`).
- New `share` command prints a stateless `visualplan.dev/view?data=...` link (validating the plan first); the view URL is hoisted to one `fflate`-free source of truth in `@visualplan/core`, shared by the runtime button and the CLI.

Also includes a `visual-plan` skill-doc tweak steering agents away from `--no-open` and toward `--watch` while iterating with the user.

## Testing

- `pnpm -r typecheck` clean across all 5 packages; full vitest suite green (243 tests), including new `io.test.ts` and `render.test.ts` covering stdin/stdout routing, the conflict guards, the share round-trip (`buildShareUrl` -> `decodePlan`), and the `--port` validator.
- Verified end-to-end through the rebuilt `dist`: `share` (file and stdin) emits a round-tripping link, `render --stdout` produces a clean self-contained document with empty stderr, and the `--stdout`/`--out`/`--watch` conflicts exit non-zero with clear messages.
