### PR TITLE
feat(cli): interactive review mode (--review)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,9 +17,10 @@ polished, self-contained HTML page, so an AI agent can present plans as scannabl
   plan's MDX (deflate + base64url), validating first so a broken plan is never shared. Reads a file
   or stdin.
 - `vplan render --review <file.mdx|->` opens the plan as an interactive review session: the user
-  comments on sections and clicks Approve / Deny / Iterate, and the CLI blocks until then, prints the
-  feedback to stdout, and exits (approve 0, deny 1, iterate 2, timeout 3). `--timeout` (default 15m)
-  bounds the wait; a closed tab resolves as Deny.
+  comments on sections (or selected text) and clicks Approve / Deny / Iterate, and the CLI blocks
+  until then, prints the feedback to stdout, and exits (approve 0, deny 1, iterate 2, timeout 3).
+  `--timeout` (default 15m) bounds the wait; a closed tab resolves as Deny. `-i/--iteration N` shows
+  the revision number in the review bar (the agent increments it each re-review).
 - `vplan components` prints the component vocabulary cheat-sheet.
 - A programmatic API (`import { renderPlan, checkPlan } from 'vplan'`) renders/validates a plan from
   an in-memory MDX string, with a named export per catalog entry. See `packages/cli/src/api.ts`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,10 @@ polished, self-contained HTML page, so an AI agent can present plans as scannabl
 - `vplan share <file.mdx|->` prints a stateless `visualplan.dev/view?data=...` link encoding the
   plan's MDX (deflate + base64url), validating first so a broken plan is never shared. Reads a file
   or stdin.
+- `vplan render --review <file.mdx|->` opens the plan as an interactive review session: the user
+  comments on sections and clicks Approve / Deny / Iterate, and the CLI blocks until then, prints the
+  feedback to stdout, and exits (approve 0, deny 1, iterate 2, timeout 3). `--timeout` (default 15m)
+  bounds the wait; a closed tab resolves as Deny.
 - `vplan components` prints the component vocabulary cheat-sheet.
 - A programmatic API (`import { renderPlan, checkPlan } from 'vplan'`) renders/validates a plan from
   an in-memory MDX string, with a named export per catalog entry. See `packages/cli/src/api.ts`.

--- a/packages/cli/AGENTS.md
+++ b/packages/cli/AGENTS.md
@@ -14,7 +14,18 @@ programmatic Node API at `dist/api.js` (the package's `import` entry, `exports["
   `share`. Returns the MDX source plus a diagnostics `label` and a `fromStdin` flag. Reads stdin when
   the arg is `-` or (no arg given) stdin is piped (`!process.stdin.isTTY`); a bare invocation on an
   interactive terminal throws rather than hang. `render` routes stdin output to stdout by default,
-  and `--stdout`/`--out`/`--watch` have mutual-exclusion guards (watch needs a real file to re-read).
+  and `--stdout`/`--out`/`--watch`/`--review` have mutual-exclusion guards (watch needs a real file
+  to re-read; review is a server, not a file output).
+- `src/review/` — interactive review mode (`--review`). `session.ts` `runReview` serves the plan via
+  `startReviewServer`, opens it, and races `server.feedback` against `--timeout` (`ms`-parsed); it
+  prints the feedback to **stdout** (the agent reads it) and status to **stderr**, sets the exit code
+  from the outcome, and handles Ctrl+C (close + exit 130). `format.ts` is the pure formatter
+  (`formatFeedback` -> readable text, `exitCodeFor`: approve 0 / deny 1 / iterate 2 / timeout 3). The
+  transport lives in `compile.ts` `startReviewServer`: a one-shot Vite server over a frozen snapshot
+  (a string input, so no watch/hot-reload, which is what lets the page collect comments without
+  re-rendering) that injects `__VP_REVIEW__` and exposes `POST /__vp_feedback`, validating the body
+  against `@visualplan/core`'s `feedbackSchema` and resolving the session (a tab-close `sendBeacon`
+  hits the same endpoint).
 - `src/config.ts` — the persistent CLI config at `~/.vplan/config.json` (literal path via
   `homedir()`, deliberately NOT `env-paths`). Only setting today is `theme` (`light`|`dark`|
   `system`). `readConfig` is tolerant (missing/malformed/unknown-theme -> `{ theme: 'system' }`) so a

--- a/packages/cli/AGENTS.md
+++ b/packages/cli/AGENTS.md
@@ -23,9 +23,12 @@ programmatic Node API at `dist/api.js` (the package's `import` entry, `exports["
   (`formatFeedback` -> readable text, `exitCodeFor`: approve 0 / deny 1 / iterate 2 / timeout 3). The
   transport lives in `compile.ts` `startReviewServer`: a one-shot Vite server over a frozen snapshot
   (a string input, so no watch/hot-reload, which is what lets the page collect comments without
-  re-rendering) that injects `__VP_REVIEW__` and exposes `POST /__vp_feedback`, validating the body
-  against `@visualplan/core`'s `feedbackSchema` and resolving the session (a tab-close `sendBeacon`
-  hits the same endpoint).
+  re-rendering) that injects `__VP_REVIEW__` and exposes three endpoints, all settling the session
+  once: `POST /__vp_feedback` (the explicit decision, validated against `@visualplan/core`'s
+  `feedbackSchema`), `POST /__vp_draft` (the page keeps the Deny-on-close payload current as comments
+  are added), and `GET /__vp_alive` (a connection the page holds open; its drop resolves Deny with the
+  latest draft). Detecting that socket close server-side is what makes a real tab close reliable,
+  where an unload-time `sendBeacon` is not (verified: the beacon survives navigation but not a close).
 - `src/config.ts` — the persistent CLI config at `~/.vplan/config.json` (literal path via
   `homedir()`, deliberately NOT `env-paths`). Only setting today is `theme` (`light`|`dark`|
   `system`). `readConfig` is tolerant (missing/malformed/unknown-theme -> `{ theme: 'system' }`) so a

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -88,6 +88,7 @@
     "@types/ms": "^2.1.0",
     "@visualplan/compile": "workspace:*",
     "@visualplan/core": "workspace:*",
-    "@visualplan/runtime": "workspace:*"
+    "@visualplan/runtime": "workspace:*",
+    "playwright-core": "^1.61.0"
   }
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -65,6 +65,7 @@
     "fflate": "^0.8.2",
     "hast-util-from-html": "^2.0.3",
     "material-icon-theme": "^5.35.0",
+    "ms": "^2.1.3",
     "open": "^11.0.0",
     "react": "^19.2.7",
     "react-dom": "^19.2.7",
@@ -84,6 +85,7 @@
   },
   "devDependencies": {
     "@types/hast": "^3.0.4",
+    "@types/ms": "^2.1.0",
     "@visualplan/compile": "workspace:*",
     "@visualplan/core": "workspace:*",
     "@visualplan/runtime": "workspace:*"

--- a/packages/cli/src/build/compile.ts
+++ b/packages/cli/src/build/compile.ts
@@ -381,13 +381,28 @@ interface ReviewState {
  *   before a decision, that abandonment resolves as Deny carrying the latest draft. Detecting the
  *   socket close server-side is reliable on a real tab close, unlike an unload-time `sendBeacon`.
  */
-function reviewPlugin(settle: (feedback: Feedback) => void, state: ReviewState): Plugin {
+function reviewPlugin(
+  settle: (feedback: Feedback) => void,
+  state: ReviewState,
+  iteration?: number,
+): Plugin {
   return {
     name: 'visualplan:review',
     transformIndexHtml: {
       order: 'pre',
       handler() {
-        return [{ tag: 'script', injectTo: 'head', children: 'globalThis.__VP_REVIEW__=true' }]
+        const tags = [
+          { tag: 'script', injectTo: 'head' as const, children: 'globalThis.__VP_REVIEW__=true' },
+        ]
+        // `iteration` is a validated number, so it is safe to inline; the bar shows "Iteration N".
+        if (iteration !== undefined) {
+          tags.push({
+            tag: 'script',
+            injectTo: 'head' as const,
+            children: `globalThis.__VP_REVIEW_ITERATION__=${iteration}`,
+          })
+        }
+        return tags
       },
     },
     configureServer(server) {
@@ -458,6 +473,7 @@ export interface ReviewServer {
 export async function startReviewServer(
   source: string,
   theme: Theme = 'system',
+  iteration?: number,
 ): Promise<ReviewServer> {
   const paths = findRuntimePaths()
   let settled = false
@@ -473,13 +489,16 @@ export async function startReviewServer(
   }
   const state: ReviewState = { draft: { decision: 'deny', comments: [] } }
   const config = baseConfig(paths, source, { theme })
+  // Use the same default port as the `--watch` dev server (Vite auto-increments if it is taken).
   const server = await createServer({
     ...config,
-    plugins: [...(config.plugins ?? []), reviewPlugin(settle, state)],
+    server: { ...config.server, port: DEFAULT_DEV_PORT },
+    plugins: [...(config.plugins ?? []), reviewPlugin(settle, state, iteration)],
   })
   await server.listen()
   const url =
-    server.resolvedUrls?.local[0] ?? `http://localhost:${server.config.server.port ?? 5173}`
+    server.resolvedUrls?.local[0] ??
+    `http://localhost:${server.config.server.port ?? DEFAULT_DEV_PORT}`
   return {
     url,
     feedback,

--- a/packages/cli/src/build/compile.ts
+++ b/packages/cli/src/build/compile.ts
@@ -8,6 +8,7 @@ import { compile, type CompileOptions } from '@mdx-js/mdx'
 import { baseExpressiveCodeOptions, remarkPlugins } from '@visualplan/compile'
 import { pluginFileIcons } from '@visualplan/compile/file-icons'
 import { remarkFileTreeIcons } from '@visualplan/compile/filetree-icons'
+import { type Feedback, feedbackSchema } from '@visualplan/core'
 import { encodePlan } from '@visualplan/core/share'
 import rehypeExpressiveCode, { type RehypeExpressiveCodeOptions } from 'rehype-expressive-code'
 import { build, createServer, type InlineConfig, type Plugin } from 'vite'
@@ -344,6 +345,98 @@ export async function startDevServer(
     server.resolvedUrls?.local[0] ?? `http://localhost:${server.config.server.port ?? port}`
   return {
     url,
+    close: () => server.close(),
+  }
+}
+
+/** Read a request body to a string, capped so a malformed client cannot stream unbounded data. */
+function readRequestBody(
+  req: import('node:http').IncomingMessage,
+  maxBytes = 1_000_000,
+): Promise<string> {
+  return new Promise((resolve, reject) => {
+    let raw = ''
+    req.on('data', (chunk: Buffer) => {
+      raw += chunk
+      if (raw.length > maxBytes) reject(new Error('feedback body too large'))
+    })
+    req.on('end', () => resolve(raw))
+    req.on('error', reject)
+  })
+}
+
+/**
+ * Serve the plan in review mode and add the `/__vp_feedback` endpoint. Injects `__VP_REVIEW__` so the
+ * runtime mounts its feedback layer (mirroring how `planSharePlugin` injects `__VP_SHARE__`), and on
+ * a POST validates the body against the shared `feedbackSchema` and resolves the session. `sendBeacon`
+ * from the page's unload handler hits this same endpoint, so it accepts any content type.
+ */
+function reviewPlugin(onFeedback: (feedback: Feedback) => void): Plugin {
+  return {
+    name: 'visualplan:review',
+    transformIndexHtml: {
+      order: 'pre',
+      handler() {
+        return [{ tag: 'script', injectTo: 'head', children: 'globalThis.__VP_REVIEW__=true' }]
+      },
+    },
+    configureServer(server) {
+      server.middlewares.use('/__vp_feedback', (req, res) => {
+        if (req.method !== 'POST') {
+          res.statusCode = 405
+          res.end('method not allowed')
+          return
+        }
+        readRequestBody(req)
+          .then(raw => {
+            const feedback = feedbackSchema.parse(JSON.parse(raw))
+            res.statusCode = 200
+            res.setHeader('content-type', 'text/plain; charset=utf-8')
+            res.end('ok')
+            onFeedback(feedback)
+          })
+          .catch(() => {
+            res.statusCode = 400
+            res.end('invalid feedback')
+          })
+      })
+    },
+  }
+}
+
+export interface ReviewServer {
+  url: string
+  /** Resolves when the page submits a decision (via POST or an unload `sendBeacon`). */
+  feedback: Promise<Feedback>
+  close: () => Promise<void>
+}
+
+/**
+ * Start a one-shot review server for a plan's in-memory source. Unlike `startDevServer` it serves a
+ * frozen snapshot (a string input, so no watch file and no hot-reload), which is what lets the page
+ * collect comments without re-rendering underneath them. The returned `feedback` promise resolves
+ * with the reviewer's decision; the caller opens the URL, awaits it, then closes the server.
+ */
+export async function startReviewServer(
+  source: string,
+  theme: Theme = 'system',
+): Promise<ReviewServer> {
+  const paths = findRuntimePaths()
+  let resolveFeedback!: (feedback: Feedback) => void
+  const feedback = new Promise<Feedback>(resolve => {
+    resolveFeedback = resolve
+  })
+  const config = baseConfig(paths, source, { theme })
+  const server = await createServer({
+    ...config,
+    plugins: [...(config.plugins ?? []), reviewPlugin(resolveFeedback)],
+  })
+  await server.listen()
+  const url =
+    server.resolvedUrls?.local[0] ?? `http://localhost:${server.config.server.port ?? 5173}`
+  return {
+    url,
+    feedback,
     close: () => server.close(),
   }
 }

--- a/packages/cli/src/build/compile.ts
+++ b/packages/cli/src/build/compile.ts
@@ -365,13 +365,23 @@ function readRequestBody(
   })
 }
 
+/** Mutable holder for the payload to resolve with if the tab closes; kept current by `/__vp_draft`. */
+interface ReviewState {
+  /** The Deny-on-close payload, refreshed as the reviewer adds comments. */
+  draft: Feedback
+}
+
 /**
- * Serve the plan in review mode and add the `/__vp_feedback` endpoint. Injects `__VP_REVIEW__` so the
- * runtime mounts its feedback layer (mirroring how `planSharePlugin` injects `__VP_SHARE__`), and on
- * a POST validates the body against the shared `feedbackSchema` and resolves the session. `sendBeacon`
- * from the page's unload handler hits this same endpoint, so it accepts any content type.
+ * Serve the plan in review mode and add its three endpoints. Injects `__VP_REVIEW__` so the runtime
+ * mounts its feedback layer (mirroring how `planSharePlugin` injects `__VP_SHARE__`). `settle`
+ * resolves the session exactly once:
+ * - `POST /__vp_feedback` — the reviewer's explicit decision (validated against `feedbackSchema`).
+ * - `POST /__vp_draft` — the page keeps the Deny-on-close payload current as comments are added.
+ * - `GET /__vp_alive` — a connection the page holds open; when it drops (tab closed / navigated away)
+ *   before a decision, that abandonment resolves as Deny carrying the latest draft. Detecting the
+ *   socket close server-side is reliable on a real tab close, unlike an unload-time `sendBeacon`.
  */
-function reviewPlugin(onFeedback: (feedback: Feedback) => void): Plugin {
+function reviewPlugin(settle: (feedback: Feedback) => void, state: ReviewState): Plugin {
   return {
     name: 'visualplan:review',
     transformIndexHtml: {
@@ -393,12 +403,40 @@ function reviewPlugin(onFeedback: (feedback: Feedback) => void): Plugin {
             res.statusCode = 200
             res.setHeader('content-type', 'text/plain; charset=utf-8')
             res.end('ok')
-            onFeedback(feedback)
+            settle(feedback)
           })
           .catch(() => {
             res.statusCode = 400
             res.end('invalid feedback')
           })
+      })
+      server.middlewares.use('/__vp_draft', (req, res) => {
+        if (req.method !== 'POST') {
+          res.statusCode = 405
+          res.end('method not allowed')
+          return
+        }
+        readRequestBody(req)
+          .then(raw => {
+            state.draft = feedbackSchema.parse(JSON.parse(raw))
+            res.statusCode = 200
+            res.end('ok')
+          })
+          .catch(() => {
+            res.statusCode = 400
+            res.end('invalid draft')
+          })
+      })
+      server.middlewares.use('/__vp_alive', (_req, res) => {
+        res.writeHead(200, {
+          'content-type': 'text/event-stream',
+          'cache-control': 'no-cache',
+          connection: 'keep-alive',
+        })
+        res.write(': ok\n\n')
+        // The response is never ended, so 'close' fires only on a client disconnect (tab close), not
+        // a normal response end. A backgrounded tab keeps the connection, so it never false-denies.
+        res.on('close', () => settle(state.draft))
       })
     },
   }
@@ -406,7 +444,7 @@ function reviewPlugin(onFeedback: (feedback: Feedback) => void): Plugin {
 
 export interface ReviewServer {
   url: string
-  /** Resolves when the page submits a decision (via POST or an unload `sendBeacon`). */
+  /** Resolves once: the submitted decision, or Deny when the review tab is closed. */
   feedback: Promise<Feedback>
   close: () => Promise<void>
 }
@@ -415,21 +453,29 @@ export interface ReviewServer {
  * Start a one-shot review server for a plan's in-memory source. Unlike `startDevServer` it serves a
  * frozen snapshot (a string input, so no watch file and no hot-reload), which is what lets the page
  * collect comments without re-rendering underneath them. The returned `feedback` promise resolves
- * with the reviewer's decision; the caller opens the URL, awaits it, then closes the server.
+ * with the reviewer's decision (or Deny on tab close); the caller opens the URL, awaits it, closes.
  */
 export async function startReviewServer(
   source: string,
   theme: Theme = 'system',
 ): Promise<ReviewServer> {
   const paths = findRuntimePaths()
+  let settled = false
   let resolveFeedback!: (feedback: Feedback) => void
   const feedback = new Promise<Feedback>(resolve => {
     resolveFeedback = resolve
   })
+  // First signal wins: an explicit decision, or a tab-close Deny, but never both.
+  const settle = (value: Feedback) => {
+    if (settled) return
+    settled = true
+    resolveFeedback(value)
+  }
+  const state: ReviewState = { draft: { decision: 'deny', comments: [] } }
   const config = baseConfig(paths, source, { theme })
   const server = await createServer({
     ...config,
-    plugins: [...(config.plugins ?? []), reviewPlugin(resolveFeedback)],
+    plugins: [...(config.plugins ?? []), reviewPlugin(settle, state)],
   })
   await server.listen()
   const url =

--- a/packages/cli/src/commands/render.ts
+++ b/packages/cli/src/commands/render.ts
@@ -1,12 +1,17 @@
 import { writeFile } from 'node:fs/promises'
 import { basename, dirname, extname, join, resolve } from 'node:path'
 import { InvalidArgumentError } from 'commander'
+import ms from 'ms'
 import open from 'open'
 import { checkPlan, checkSource } from '../build/check.js'
 import { buildHtml, startDevServer } from '../build/compile.js'
 import { readConfig } from '../config.js'
+import { runReview } from '../review/session.js'
 import { printIssues, resolvePlanFile } from './check.js'
 import { readPlanSource } from './input.js'
+
+/** Default `--review` timeout: 15 minutes. A review waits on a human, so the window is generous. */
+export const DEFAULT_REVIEW_TIMEOUT_MS = 15 * 60 * 1000
 
 export interface RenderOptions {
   watch?: boolean
@@ -16,6 +21,10 @@ export interface RenderOptions {
   stdout?: boolean
   /** Port for the `--watch` dev server; ignored for a one-shot file render. */
   port?: number
+  /** Open the plan as an interactive review session and print the reviewer's feedback. */
+  review?: boolean
+  /** Max wait (ms) for review feedback before timing out; parsed from a duration by `parseTimeout`. */
+  timeout?: number
 }
 
 /** Parse and validate the `--port` value as a TCP port (1-65535). Commander calls this per option
@@ -26,6 +35,17 @@ export function parsePort(value: string): number {
     throw new InvalidArgumentError('port must be an integer between 1 and 65535')
   }
   return port
+}
+
+/** Parse the `--timeout` value (a duration like `15m`, `30s`, `1h`) to milliseconds via `ms`. */
+export function parseTimeout(value: string): number {
+  // ms's typed overload only accepts its `StringValue` template type, but at runtime it takes any
+  // string and returns undefined for an unparseable one.
+  const millis = (ms as (input: string) => number | undefined)(value)
+  if (typeof millis !== 'number' || millis <= 0) {
+    throw new InvalidArgumentError('timeout must be a positive duration like 15m, 30s, or 1h')
+  }
+  return millis
 }
 
 function defaultOutPath(absMdx: string): string {
@@ -46,8 +66,30 @@ export async function runRender(file: string | undefined, options: RenderOptions
       '--stdout cannot be combined with --watch; the watch server has no file output.',
     )
   }
+  if (options.review && (options.watch || options.stdout || options.out)) {
+    throw new Error('--review cannot be combined with --watch, --stdout, or --out.')
+  }
 
   const { theme } = await readConfig()
+
+  // Review is a one-shot server that blocks on human feedback; it accepts a file or piped stdin
+  // because it serves a snapshot read once (no watching), unlike --watch.
+  if (options.review) {
+    const { source, label } = await readPlanSource(file)
+    const issues = await checkSource(source)
+    if (issues.length > 0) {
+      printIssues(label, issues)
+      process.exitCode = 1
+      return
+    }
+    await runReview(
+      source,
+      theme,
+      options.timeout ?? DEFAULT_REVIEW_TIMEOUT_MS,
+      options.open !== false,
+    )
+    return
+  }
 
   // The watch server hot-reloads a file on disk, so it needs a real path; stdin has nothing to re-read.
   if (options.watch) {

--- a/packages/cli/src/commands/render.ts
+++ b/packages/cli/src/commands/render.ts
@@ -25,6 +25,17 @@ export interface RenderOptions {
   review?: boolean
   /** Max wait (ms) for review feedback before timing out; parsed from a duration by `parseTimeout`. */
   timeout?: number
+  /** Iteration number shown in the review bar (the agent sets it as it revises the plan). */
+  iteration?: number
+}
+
+/** Parse the `--iteration` value as a positive integer (the plan revision number shown in review). */
+export function parseIteration(value: string): number {
+  const n = Number(value)
+  if (!Number.isInteger(n) || n < 1) {
+    throw new InvalidArgumentError('iteration must be a positive integer')
+  }
+  return n
 }
 
 /** Parse and validate the `--port` value as a TCP port (1-65535). Commander calls this per option
@@ -87,6 +98,7 @@ export async function runRender(file: string | undefined, options: RenderOptions
       theme,
       options.timeout ?? DEFAULT_REVIEW_TIMEOUT_MS,
       options.open !== false,
+      options.iteration,
     )
     return
   }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -4,7 +4,13 @@ import { DEFAULT_DEV_PORT } from './build/compile.js'
 import { runCheck } from './commands/check.js'
 import { runComponents } from './commands/components.js'
 import { runConfigGet, runConfigPath, runConfigSet, runConfigShow } from './commands/config.js'
-import { parsePort, runRender, type RenderOptions } from './commands/render.js'
+import {
+  DEFAULT_REVIEW_TIMEOUT_MS,
+  parsePort,
+  parseTimeout,
+  runRender,
+  type RenderOptions,
+} from './commands/render.js'
 import { runShare } from './commands/share.js'
 
 const program = new Command('vplan')
@@ -19,6 +25,13 @@ program
   .option('--port <number>', 'port for the --watch dev server', parsePort, DEFAULT_DEV_PORT)
   .option('--out <path>', 'output HTML path (defaults to <file>.plan.html)')
   .option('--stdout', 'write the rendered HTML to stdout instead of a file')
+  .option('--review', 'open an interactive review session and print the reviewer feedback')
+  .option(
+    '--timeout <duration>',
+    'max wait for review feedback, e.g. 15m, 30s, 1h',
+    parseTimeout,
+    DEFAULT_REVIEW_TIMEOUT_MS,
+  )
   .option('--no-open', 'do not open the result in a browser')
   .action((file: string | undefined, options: RenderOptions) => runRender(file, options))
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -6,6 +6,7 @@ import { runComponents } from './commands/components.js'
 import { runConfigGet, runConfigPath, runConfigSet, runConfigShow } from './commands/config.js'
 import {
   DEFAULT_REVIEW_TIMEOUT_MS,
+  parseIteration,
   parsePort,
   parseTimeout,
   runRender,
@@ -26,6 +27,11 @@ program
   .option('--out <path>', 'output HTML path (defaults to <file>.plan.html)')
   .option('--stdout', 'write the rendered HTML to stdout instead of a file')
   .option('--review', 'open an interactive review session and print the reviewer feedback')
+  .option(
+    '-i, --iteration <number>',
+    'plan revision number shown in the review bar',
+    parseIteration,
+  )
   .option(
     '--timeout <duration>',
     'max wait for review feedback, e.g. 15m, 30s, 1h',

--- a/packages/cli/src/review/format.ts
+++ b/packages/cli/src/review/format.ts
@@ -1,0 +1,44 @@
+import type { Feedback, ReviewDecision } from '@visualplan/core'
+
+/** The terminal outcomes of a review session and their CLI exit codes. `timeout` is distinct from
+ * `deny` on purpose: "the human rejected" and "no human answered" are different situations for the
+ * calling agent, which may retry on a timeout but must stop on a deny. */
+export type ReviewOutcome = ReviewDecision | 'timeout'
+
+const EXIT_CODES: Record<ReviewOutcome, number> = {
+  approve: 0,
+  deny: 1,
+  iterate: 2,
+  timeout: 3,
+}
+
+/** Map a review outcome to the process exit code the agent reads. */
+export function exitCodeFor(outcome: ReviewOutcome): number {
+  return EXIT_CODES[outcome]
+}
+
+/**
+ * Render the feedback as a readable text block for the calling agent (an LLM reads it directly, so
+ * this is plain prose, not JSON, consistent with the rest of the CLI's output).
+ */
+export function formatFeedback(feedback: Feedback): string {
+  const lines: string[] = [`DECISION: ${feedback.decision}`]
+
+  for (const comment of feedback.comments) {
+    lines.push('', `Comment on "${comment.section}":`, indent(comment.body))
+  }
+
+  if (feedback.note) {
+    lines.push('', 'General note:', indent(feedback.note))
+  }
+
+  return lines.join('\n')
+}
+
+/** Indent every line of a comment body by two spaces so it reads as a nested block. */
+function indent(text: string): string {
+  return text
+    .split('\n')
+    .map(line => `  ${line}`)
+    .join('\n')
+}

--- a/packages/cli/src/review/session.ts
+++ b/packages/cli/src/review/session.ts
@@ -18,8 +18,9 @@ export async function runReview(
   theme: Theme,
   timeoutMs: number,
   openBrowser: boolean,
+  iteration?: number,
 ): Promise<void> {
-  const server = await startReviewServer(source, theme)
+  const server = await startReviewServer(source, theme, iteration)
   process.stderr.write(
     `Visual Plan review at\n  ${server.url}\n  (comment on sections, then Approve / Deny / Iterate; Ctrl+C to cancel)\n`,
   )

--- a/packages/cli/src/review/session.ts
+++ b/packages/cli/src/review/session.ts
@@ -1,0 +1,55 @@
+import ms from 'ms'
+import open from 'open'
+import { startReviewServer } from '../build/compile.js'
+import type { Theme } from '../config.js'
+import { exitCodeFor, formatFeedback } from './format.js'
+
+/** Exit code for a Ctrl+C cancel: the conventional 128 + SIGINT(2). */
+const SIGINT_EXIT = 130
+
+/**
+ * Run an interactive review session: serve the plan, open it, and block until the reviewer submits a
+ * decision (via the page) or `timeoutMs` elapses. The feedback is printed to **stdout** (the calling
+ * agent reads it) while status and the URL go to **stderr**, so a captured stdout is exactly the
+ * feedback. Sets `process.exitCode` from the outcome (approve 0, deny 1, iterate 2, timeout 3).
+ */
+export async function runReview(
+  source: string,
+  theme: Theme,
+  timeoutMs: number,
+  openBrowser: boolean,
+): Promise<void> {
+  const server = await startReviewServer(source, theme)
+  process.stderr.write(
+    `Visual Plan review at\n  ${server.url}\n  (comment on sections, then Approve / Deny / Iterate; Ctrl+C to cancel)\n`,
+  )
+  if (openBrowser) await open(server.url)
+
+  // Ctrl+C must release the port and exit, or the dev server keeps the process alive.
+  const onSigint = () => {
+    void server.close().finally(() => process.exit(SIGINT_EXIT))
+  }
+  process.once('SIGINT', onSigint)
+
+  let timer: ReturnType<typeof setTimeout> | undefined
+  const timeout = new Promise<'timeout'>(resolve => {
+    timer = setTimeout(() => resolve('timeout'), timeoutMs)
+  })
+
+  try {
+    const result = await Promise.race([server.feedback, timeout])
+    if (result === 'timeout') {
+      process.stderr.write(
+        `\nReview timed out after ${ms(timeoutMs, { long: true })} with no response.\n`,
+      )
+      process.exitCode = exitCodeFor('timeout')
+      return
+    }
+    process.stdout.write(`${formatFeedback(result)}\n`)
+    process.exitCode = exitCodeFor(result.decision)
+  } finally {
+    clearTimeout(timer)
+    process.off('SIGINT', onSigint)
+    await server.close()
+  }
+}

--- a/packages/cli/tests/review-tab-close.e2e.test.ts
+++ b/packages/cli/tests/review-tab-close.e2e.test.ts
@@ -1,0 +1,93 @@
+// @vitest-environment node
+//
+// End-to-end check for the tab-close -> Deny path. A static unit test cannot cover it: the deny is
+// emitted by the page's `pagehide` handler via `navigator.sendBeacon`, which only a real browser
+// does. This drives a headless browser against an in-process review server and asserts the server's
+// feedback promise resolves to a Deny carrying the comment made before closing.
+//
+// Gated on a locally installed Playwright Chromium shell; it SKIPS where none exists (e.g. CI), so
+// it never fails for lack of a browser. Run it on a machine with `npx playwright install chromium`.
+import { existsSync, readdirSync } from 'node:fs'
+import { homedir } from 'node:os'
+import { join } from 'node:path'
+import { type Browser, chromium } from 'playwright-core'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { type ReviewServer, startReviewServer } from '../src/build/compile.js'
+
+const PLAN = '# Tab close test\n\n<Phase title="Only phase">\n- a step\n</Phase>\n'
+
+/** Find a locally installed Playwright chromium headless-shell binary, or null to skip. We launch by
+ * explicit path so a browser-build version skew with playwright-core does not block the run. */
+function findHeadlessShell(): string | null {
+  const root =
+    process.env.PLAYWRIGHT_BROWSERS_PATH ||
+    (process.platform === 'darwin'
+      ? join(homedir(), 'Library/Caches/ms-playwright')
+      : process.platform === 'win32'
+        ? join(homedir(), 'AppData/Local/ms-playwright')
+        : join(homedir(), '.cache/ms-playwright'))
+  if (!existsSync(root)) return null
+  for (const dir of readdirSync(root).filter(d => d.startsWith('chromium_headless_shell-'))) {
+    const candidates = [
+      join(root, dir, 'chrome-headless-shell-mac-arm64', 'chrome-headless-shell'),
+      join(root, dir, 'chrome-headless-shell-mac-x64', 'chrome-headless-shell'),
+      join(root, dir, 'chrome-headless-shell-linux', 'chrome-headless-shell'),
+      join(root, dir, 'chrome-headless-shell-win', 'chrome-headless-shell.exe'),
+    ]
+    const found = candidates.find(existsSync)
+    if (found) return found
+  }
+  return null
+}
+
+const executablePath = findHeadlessShell()
+
+describe.skipIf(!executablePath)('review tab-close -> Deny (e2e)', () => {
+  let browser: Browser
+  let server: ReviewServer
+
+  beforeAll(async () => {
+    browser = await chromium.launch({ executablePath: executablePath as string })
+  }, 60_000)
+
+  afterAll(async () => {
+    await browser?.close()
+    await server?.close()
+  })
+
+  it('beacons a Deny on unload mid-review, carrying the comments made', async () => {
+    server = await startReviewServer(PLAN)
+    const page = await browser.newPage()
+    // beforeunload shows a native confirm on close; auto-accept it so the unload proceeds.
+    page.on('dialog', dialog => void dialog.accept().catch(() => {}))
+
+    await page.goto(server.url, { waitUntil: 'domcontentloaded' })
+    await page.waitForSelector('.vp-review-bar', { timeout: 20_000 })
+
+    // Add one comment so the test also proves the tab-close Deny carries comments, not just the
+    // verdict. Wait for the draft sync to land so the server has the comment before the tab "closes".
+    await page.hover('.vp-phase')
+    await page.waitForSelector('.vp-review-add', { timeout: 8_000 })
+    await page.click('.vp-review-add')
+    await page.fill('.vp-review-composer__input', 'closing without deciding')
+    const draftSynced = page.waitForResponse(
+      res => res.url().endsWith('/__vp_draft') && res.request().method() === 'POST',
+    )
+    await page.click('.vp-review-btn--primary')
+    await draftSynced
+
+    // Navigate the document away without deciding. This drops the keepalive connection, which the
+    // server detects exactly as it would a real tab close (the literal close is covered manually).
+    await page.goto('about:blank', { waitUntil: 'load' })
+
+    const feedback = await Promise.race([
+      server.feedback,
+      new Promise<never>((_, reject) =>
+        setTimeout(() => reject(new Error('no deny beacon received before timeout')), 15_000),
+      ),
+    ])
+
+    expect(feedback.decision).toBe('deny')
+    expect(feedback.comments).toEqual([{ section: 'Only phase', body: 'closing without deciding' }])
+  }, 60_000)
+})

--- a/packages/cli/tests/review.test.ts
+++ b/packages/cli/tests/review.test.ts
@@ -1,0 +1,103 @@
+// @vitest-environment node
+import { afterEach, describe, expect, it } from 'vitest'
+import { type ReviewServer, startReviewServer } from '../src/build/compile.js'
+import { parseTimeout, runRender } from '../src/commands/render.js'
+import { exitCodeFor, formatFeedback } from '../src/review/format.js'
+
+const PLAN = '# Plan\n\ntext\n'
+
+function feedbackUrl(server: ReviewServer): string {
+  return new URL('/__vp_feedback', server.url).href
+}
+
+describe('formatFeedback', () => {
+  it('renders decision, comments, and note as readable text (golden)', () => {
+    const text = formatFeedback({
+      decision: 'iterate',
+      comments: [{ section: 'Phase 2', body: 'fix this' }],
+      note: 'overall good',
+    })
+    expect(text).toContain('DECISION: iterate')
+    expect(text).toContain('Comment on "Phase 2":')
+    expect(text).toContain('  fix this')
+    expect(text).toContain('General note:')
+    expect(text).toContain('  overall good')
+  })
+
+  it('renders a bare approve with no comments or note (edge)', () => {
+    expect(formatFeedback({ decision: 'approve', comments: [] })).toBe('DECISION: approve')
+  })
+})
+
+describe('exitCodeFor', () => {
+  it('maps every outcome to its exit code (golden + edge)', () => {
+    expect(exitCodeFor('approve')).toBe(0)
+    expect(exitCodeFor('deny')).toBe(1)
+    expect(exitCodeFor('iterate')).toBe(2)
+    expect(exitCodeFor('timeout')).toBe(3)
+  })
+})
+
+describe('parseTimeout', () => {
+  it('parses a duration string to milliseconds (golden)', () => {
+    expect(parseTimeout('15m')).toBe(900_000)
+    expect(parseTimeout('30s')).toBe(30_000)
+  })
+
+  it('rejects an unparseable duration (error)', () => {
+    expect(() => parseTimeout('soon')).toThrow(/positive duration/)
+  })
+})
+
+describe('runRender --review guards', () => {
+  it('rejects --review combined with an output flag (error)', async () => {
+    await expect(runRender('plan.mdx', { review: true, stdout: true })).rejects.toThrow(
+      /--review cannot be combined/,
+    )
+  })
+})
+
+describe('startReviewServer /__vp_feedback', () => {
+  let server: ReviewServer
+
+  afterEach(async () => {
+    await server?.close()
+  })
+
+  it('resolves the feedback promise on a valid POST (golden)', async () => {
+    server = await startReviewServer(PLAN)
+    const payload = { decision: 'iterate', comments: [{ section: 'Phase 1', body: 'tweak' }] }
+    const res = await fetch(feedbackUrl(server), { method: 'POST', body: JSON.stringify(payload) })
+    expect(res.status).toBe(200)
+    await expect(server.feedback).resolves.toMatchObject({
+      decision: 'iterate',
+      comments: [{ section: 'Phase 1', body: 'tweak' }],
+    })
+  }, 60_000)
+
+  it('defaults comments to empty for a bare decision (edge)', async () => {
+    server = await startReviewServer(PLAN)
+    await fetch(feedbackUrl(server), {
+      method: 'POST',
+      body: JSON.stringify({ decision: 'approve' }),
+    })
+    await expect(server.feedback).resolves.toEqual({ decision: 'approve', comments: [] })
+  }, 60_000)
+
+  it('rejects an invalid body with 400 and leaves feedback pending (error)', async () => {
+    server = await startReviewServer(PLAN)
+    const res = await fetch(feedbackUrl(server), { method: 'POST', body: '{"decision":"nope"}' })
+    expect(res.status).toBe(400)
+    const outcome = await Promise.race([
+      server.feedback.then(() => 'resolved'),
+      new Promise(resolve => setTimeout(() => resolve('pending'), 250)),
+    ])
+    expect(outcome).toBe('pending')
+  }, 60_000)
+
+  it('rejects a non-POST request with 405 (error)', async () => {
+    server = await startReviewServer(PLAN)
+    const res = await fetch(feedbackUrl(server))
+    expect(res.status).toBe(405)
+  }, 60_000)
+})

--- a/packages/cli/tests/review.test.ts
+++ b/packages/cli/tests/review.test.ts
@@ -101,3 +101,63 @@ describe('startReviewServer /__vp_feedback', () => {
     expect(res.status).toBe(405)
   }, 60_000)
 })
+
+describe('startReviewServer tab-close (keepalive drop)', () => {
+  let server: ReviewServer
+
+  afterEach(async () => {
+    await server?.close()
+  })
+
+  /** Open the keepalive connection and abort it, simulating the tab closing. */
+  async function dropAfterConnecting(server: ReviewServer): Promise<void> {
+    const controller = new AbortController()
+    void fetch(new URL('/__vp_alive', server.url), { signal: controller.signal }).catch(() => {})
+    await new Promise(resolve => setTimeout(resolve, 150))
+    controller.abort()
+  }
+
+  it('resolves a bare Deny when the connection drops with no draft (golden)', async () => {
+    server = await startReviewServer(PLAN)
+    await dropAfterConnecting(server)
+    await expect(server.feedback).resolves.toEqual({ decision: 'deny', comments: [] })
+  }, 60_000)
+
+  it('carries the synced draft comments into the tab-close Deny (golden)', async () => {
+    server = await startReviewServer(PLAN)
+    const draft = { decision: 'deny', comments: [{ section: 'Phase 1', body: 'unfinished' }] }
+    await fetch(new URL('/__vp_draft', server.url), { method: 'POST', body: JSON.stringify(draft) })
+    await dropAfterConnecting(server)
+    await expect(server.feedback).resolves.toEqual(draft)
+  }, 60_000)
+
+  it('lets an explicit decision win over a later connection drop (edge)', async () => {
+    server = await startReviewServer(PLAN)
+    await fetch(feedbackUrl(server), {
+      method: 'POST',
+      body: JSON.stringify({ decision: 'approve' }),
+    })
+    await dropAfterConnecting(server)
+    // The POST settled first; the drop must not override it.
+    await expect(server.feedback).resolves.toEqual({ decision: 'approve', comments: [] })
+  }, 60_000)
+
+  it('closes promptly while the keepalive is still open, so the CLI never hangs (regression)', async () => {
+    const live = await startReviewServer(PLAN)
+    const controller = new AbortController()
+    void fetch(new URL('/__vp_alive', live.url), { signal: controller.signal }).catch(() => {})
+    await new Promise(resolve => setTimeout(resolve, 150))
+    await fetch(new URL('/__vp_feedback', live.url), {
+      method: 'POST',
+      body: JSON.stringify({ decision: 'approve' }),
+    })
+    await live.feedback
+    // The held-open keepalive must not keep close() (and therefore the process) from finishing.
+    const outcome = await Promise.race([
+      live.close().then(() => 'closed'),
+      new Promise(resolve => setTimeout(() => resolve('hung'), 3_000)),
+    ])
+    controller.abort()
+    expect(outcome).toBe('closed')
+  }, 60_000)
+})

--- a/packages/cli/tests/review.test.ts
+++ b/packages/cli/tests/review.test.ts
@@ -1,7 +1,7 @@
 // @vitest-environment node
 import { afterEach, describe, expect, it } from 'vitest'
 import { type ReviewServer, startReviewServer } from '../src/build/compile.js'
-import { parseTimeout, runRender } from '../src/commands/render.js'
+import { parseIteration, parseTimeout, runRender } from '../src/commands/render.js'
 import { exitCodeFor, formatFeedback } from '../src/review/format.js'
 
 const PLAN = '# Plan\n\ntext\n'
@@ -46,6 +46,19 @@ describe('parseTimeout', () => {
 
   it('rejects an unparseable duration (error)', () => {
     expect(() => parseTimeout('soon')).toThrow(/positive duration/)
+  })
+})
+
+describe('parseIteration', () => {
+  it('parses a positive integer (golden)', () => {
+    expect(parseIteration('3')).toBe(3)
+  })
+
+  it('rejects zero, negatives, and non-integers (error + edge)', () => {
+    expect(() => parseIteration('0')).toThrow(/positive integer/)
+    expect(() => parseIteration('-1')).toThrow()
+    expect(() => parseIteration('1.5')).toThrow()
+    expect(() => parseIteration('two')).toThrow()
   })
 })
 

--- a/packages/core/AGENTS.md
+++ b/packages/core/AGENTS.md
@@ -9,7 +9,9 @@ CLI's `check` and `components` commands. One file: `src/index.ts`.
 - **Stay isomorphic.** This module is imported by BOTH the browser runtime (`@visualplan/runtime`,
   for render-time validation) and the Node CLI (`vplan`, for static `check` and the catalog
   printer). It must have **no** React, recharts, or mermaid imports. `index.ts` depends only on
-  `zod`.
+  `zod`. This is also why the cross-cutting contracts live here: `SHARE_VIEW_URL` and `feedbackSchema`
+  (the `--review` decision payload the page constructs and the CLI validates) are shared by both
+  sides, so the index is their single source of truth.
 - **`src/share.ts` is the stateless-share codec** (`encodePlan`/`decodePlan`: deflate via `fflate`
   + a hand-rolled base64url). It is exposed as the `@visualplan/core/share` subpath (`exports` map)
   and is deliberately NOT re-exported from `index.ts`, so the vendored render path (only `index.ts`

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -14,6 +14,30 @@ import { z } from 'zod'
  * it for the share button; the CLI's `buildShareUrl` reads it from here too. One source of truth. */
 export const SHARE_VIEW_URL = 'https://visualplan.dev/view'
 
+/** The reviewer's verdict in interactive review mode (`vplan render --review`). */
+export const REVIEW_DECISION_VALUES = ['approve', 'deny', 'iterate'] as const
+
+/** A single targeted comment from a review session: which section it is about, and the note. */
+export const reviewCommentSchema = z.object({
+  section: z.string().min(1),
+  body: z.string().min(1),
+})
+
+/**
+ * The feedback payload the review page POSTs to the CLI's `/__vp_feedback` endpoint. Isomorphic so
+ * the page (which constructs it) and the CLI (which validates it) share one contract and cannot
+ * drift; `comments` defaults to empty because Approve and Deny may carry none.
+ */
+export const feedbackSchema = z.object({
+  decision: z.enum(REVIEW_DECISION_VALUES),
+  comments: z.array(reviewCommentSchema).default([]),
+  note: z.string().optional(),
+})
+
+export type ReviewDecision = (typeof REVIEW_DECISION_VALUES)[number]
+export type ReviewComment = z.infer<typeof reviewCommentSchema>
+export type Feedback = z.infer<typeof feedbackSchema>
+
 export const STATUS_VALUES = ['planned', 'active', 'done'] as const
 export const CHANGE_VALUES = ['add', 'modify', 'delete', 'move'] as const
 export const CHART_TYPE_VALUES = [

--- a/packages/runtime/AGENTS.md
+++ b/packages/runtime/AGENTS.md
@@ -16,6 +16,17 @@ the root AGENTS.md for why Vite is configured without `@vitejs/plugin-react`.
   `ThemeToggle` cog and the `ShareButton` (both fixed to the top-right corner). The cog is omitted
   when `isThemeLocked()` (the API's `renderPlan({ theme })` injects `lockTheme`), and the share
   button self-hides when no `__VP_SHARE__` was injected (the API's `enableSharing: false` default).
+  It also mounts `<ReviewLayer />`, which self-hides unless `__VP_REVIEW__` was injected.
+- `components/review/` is the interactive review UI (`vplan render --review`), gated on the injected
+  `__VP_REVIEW__` global (mirroring how `ShareButton` reads `__VP_SHARE__`), so it adds nothing to a
+  normal render. `ReviewLayer` owns the session state and overlays the plan with fixed-position
+  chrome only (the plan DOM is never mutated): `SectionComments` tracks the hovered major section (a
+  `.vp-phase` or top-level `h2`, found by walking the DOM) and floats one comment button beside it;
+  `CommentModal` is the bottom composer; `DecisionBar` submits Approve/Deny/Iterate. `feedback.ts`
+  POSTs `{decision, comments, note}` (shape = `@visualplan/core` `feedbackSchema`) to the CLI's
+  `/__vp_feedback`. **Unload handling:** a `beforeunload` prompt fires while undecided, and the real
+  `pagehide` sends a Deny via `navigator.sendBeacon` (a normal `fetch` is cancelled mid-unload, so
+  the beacon is mandatory); both read the latest state through a ref since they register once.
 - `components/ThemeToggle.tsx` is the fixed top-right cog, just left of the share button. Its menu
   picks `system` / `light` / `dark`; choosing one recolors the page live (all colors are CSS vars,
   so flipping `<html data-theme>` repaints with no React re-render) and persists the choice in

--- a/packages/runtime/AGENTS.md
+++ b/packages/runtime/AGENTS.md
@@ -23,10 +23,13 @@ the root AGENTS.md for why Vite is configured without `@vitejs/plugin-react`.
   chrome only (the plan DOM is never mutated): `SectionComments` tracks the hovered major section (a
   `.vp-phase` or top-level `h2`, found by walking the DOM) and floats one comment button beside it;
   `CommentModal` is the bottom composer; `DecisionBar` submits Approve/Deny/Iterate. `feedback.ts`
-  POSTs `{decision, comments, note}` (shape = `@visualplan/core` `feedbackSchema`) to the CLI's
-  `/__vp_feedback`. **Unload handling:** a `beforeunload` prompt fires while undecided, and the real
-  `pagehide` sends a Deny via `navigator.sendBeacon` (a normal `fetch` is cancelled mid-unload, so
-  the beacon is mandatory); both read the latest state through a ref since they register once.
+  POSTs an explicit decision `{decision, comments, note}` (shape = `@visualplan/core` `feedbackSchema`)
+  to `/__vp_feedback`. **Tab-close handling is server-detected, not beacon-based:** `ReviewLayer` holds
+  a `/__vp_alive` connection open and POSTs `/__vp_draft` whenever comments/note change; when the tab
+  closes the connection drops and the CLI resolves Deny with that draft. This replaced an unload
+  `sendBeacon`, which is dropped on a real close (it only survived navigation). A `beforeunload` prompt
+  while undecided is now just a courtesy, the actual Deny no longer depends on the page sending
+  anything during unload.
 - `components/ThemeToggle.tsx` is the fixed top-right cog, just left of the share button. Its menu
   picks `system` / `light` / `dark`; choosing one recolors the page live (all colors are CSS vars,
   so flipping `<html data-theme>` repaints with no React re-render) and persists the choice in

--- a/packages/runtime/Layout.tsx
+++ b/packages/runtime/Layout.tsx
@@ -1,4 +1,5 @@
 import { type ReactNode, useEffect } from 'react'
+import { ReviewLayer } from './components/review/ReviewLayer.js'
 import { ShareButton } from './components/ShareButton.js'
 import { ThemeToggle } from './components/ThemeToggle.js'
 import { initFullscreenControls } from './fullscreen.js'
@@ -20,6 +21,7 @@ export function Layout({ children }: { children: ReactNode }) {
       <ShareButton />
       {!isThemeLocked() && <ThemeToggle />}
       <main className='vp-main'>{children}</main>
+      <ReviewLayer />
     </div>
   )
 }

--- a/packages/runtime/components/review/CommentModal.tsx
+++ b/packages/runtime/components/review/CommentModal.tsx
@@ -1,0 +1,67 @@
+import { IconX } from '@tabler/icons-react'
+import { useState } from 'react'
+
+/**
+ * The bottom-of-screen composer for a single section comment. Saves on the button or Cmd/Ctrl+Enter,
+ * cancels on Escape. Empty comments are not savable.
+ */
+export function CommentModal({
+  section,
+  onSave,
+  onCancel,
+}: {
+  section: string
+  onSave: (body: string) => void
+  onCancel: () => void
+}) {
+  const [body, setBody] = useState('')
+  const trimmed = body.trim()
+
+  const save = () => {
+    if (trimmed) onSave(trimmed)
+  }
+
+  return (
+    <div className='vp-review-composer' role='dialog' aria-label={`Comment on ${section}`}>
+      <div className='vp-review-composer__head'>
+        <span className='vp-review-composer__target'>
+          Comment on <strong>{section}</strong>
+        </span>
+        <button
+          type='button'
+          className='vp-review-composer__close'
+          onClick={onCancel}
+          aria-label='Cancel'
+        >
+          <IconX size={16} />
+        </button>
+      </div>
+      <textarea
+        className='vp-review-composer__input'
+        // biome-ignore lint/a11y/noAutofocus: the composer opens on an explicit click, so focusing it is expected.
+        autoFocus
+        rows={3}
+        placeholder='What should change here?'
+        value={body}
+        onChange={event => setBody(event.target.value)}
+        onKeyDown={event => {
+          if (event.key === 'Escape') onCancel()
+          if (event.key === 'Enter' && (event.metaKey || event.ctrlKey)) save()
+        }}
+      />
+      <div className='vp-review-composer__actions'>
+        <button type='button' className='vp-review-btn' onClick={onCancel}>
+          Cancel
+        </button>
+        <button
+          type='button'
+          className='vp-review-btn vp-review-btn--primary'
+          onClick={save}
+          disabled={!trimmed}
+        >
+          Add comment
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/packages/runtime/components/review/CommentsPopover.tsx
+++ b/packages/runtime/components/review/CommentsPopover.tsx
@@ -1,0 +1,69 @@
+import { IconTrash, IconX } from '@tabler/icons-react'
+
+/** One comment shown in the popover. `quote` is set when the comment targets selected text. */
+export interface PopoverComment {
+  body: string
+  /** The quoted text, when this comment was made on a selection rather than the whole section. */
+  quote?: string
+}
+
+/**
+ * A small panel listing the comments on one section, so the reviewer can see what they wrote where
+ * (and remove a comment). Anchored to the section it belongs to; the caller positions it.
+ */
+export function CommentsPopover({
+  label,
+  comments,
+  anchor,
+  onDelete,
+  onClose,
+}: {
+  label: string
+  comments: PopoverComment[]
+  anchor: { top: number; left: number }
+  onDelete: (index: number) => void
+  onClose: () => void
+}) {
+  return (
+    <div
+      className='vp-review-popover'
+      style={{ top: anchor.top, left: anchor.left }}
+      role='dialog'
+      aria-label={`Comments on ${label}`}
+    >
+      <div className='vp-review-popover__head'>
+        <span className='vp-review-popover__title'>
+          Comments on <strong>{label}</strong>
+        </span>
+        <button
+          type='button'
+          className='vp-review-popover__close'
+          onClick={onClose}
+          aria-label='Close'
+        >
+          <IconX size={14} />
+        </button>
+      </div>
+      <ul className='vp-review-popover__list'>
+        {comments.map((comment, index) => (
+          // Comments have no id; index is stable within this render and the list is short.
+          // biome-ignore lint/suspicious/noArrayIndexKey: positional list, no stable id available.
+          <li key={index} className='vp-review-popover__item'>
+            <div className='vp-review-popover__text'>
+              {comment.quote && <span className='vp-review-popover__quote'>“{comment.quote}”</span>}
+              <span>{comment.body}</span>
+            </div>
+            <button
+              type='button'
+              className='vp-review-popover__delete'
+              onClick={() => onDelete(index)}
+              aria-label='Delete comment'
+            >
+              <IconTrash size={13} />
+            </button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}

--- a/packages/runtime/components/review/DecisionBar.tsx
+++ b/packages/runtime/components/review/DecisionBar.tsx
@@ -1,5 +1,6 @@
 import { IconCheck, IconRefresh, IconX } from '@tabler/icons-react'
 import type { ReviewDecision } from '@visualplan/core'
+import { reviewIteration } from './feedback.js'
 
 /**
  * The sticky decision bar. Approve and Deny always submit (comments optional); Iterate requires at
@@ -19,10 +20,14 @@ export function DecisionBar({
   busy: boolean
 }) {
   const canIterate = commentCount > 0 || note.trim().length > 0
+  const iteration = reviewIteration()
 
   return (
     <div className='vp-review-bar'>
       <div className='vp-review-bar__meta'>
+        {iteration !== null && (
+          <span className='vp-review-bar__iteration'>Iteration {iteration}</span>
+        )}
         <input
           className='vp-review-bar__note'
           placeholder='Optional overall note'

--- a/packages/runtime/components/review/DecisionBar.tsx
+++ b/packages/runtime/components/review/DecisionBar.tsx
@@ -1,0 +1,68 @@
+import { IconCheck, IconRefresh, IconX } from '@tabler/icons-react'
+import type { ReviewDecision } from '@visualplan/core'
+
+/**
+ * The sticky decision bar. Approve and Deny always submit (comments optional); Iterate requires at
+ * least one comment or a general note, since "revise with feedback" needs feedback to act on.
+ */
+export function DecisionBar({
+  commentCount,
+  note,
+  onNote,
+  onDecide,
+  busy,
+}: {
+  commentCount: number
+  note: string
+  onNote: (note: string) => void
+  onDecide: (decision: ReviewDecision) => void
+  busy: boolean
+}) {
+  const canIterate = commentCount > 0 || note.trim().length > 0
+
+  return (
+    <div className='vp-review-bar'>
+      <div className='vp-review-bar__meta'>
+        <input
+          className='vp-review-bar__note'
+          placeholder='Optional overall note'
+          value={note}
+          onChange={event => onNote(event.target.value)}
+          aria-label='Optional overall note'
+        />
+        <span className='vp-review-bar__count'>
+          {commentCount === 0
+            ? 'No comments yet'
+            : `${commentCount} comment${commentCount === 1 ? '' : 's'}`}
+        </span>
+      </div>
+      <div className='vp-review-bar__actions'>
+        <button
+          type='button'
+          className='vp-review-decision vp-review-decision--deny'
+          onClick={() => onDecide('deny')}
+          disabled={busy}
+        >
+          <IconX size={16} /> Deny
+        </button>
+        <button
+          type='button'
+          className='vp-review-decision vp-review-decision--iterate'
+          onClick={() => onDecide('iterate')}
+          disabled={busy || !canIterate}
+          title={canIterate ? undefined : 'Add a comment or a note to iterate'}
+        >
+          <IconRefresh size={16} /> Iterate
+        </button>
+        <button
+          type='button'
+          className='vp-review-decision vp-review-decision--approve'
+          onClick={() => onDecide('approve')}
+          disabled={busy}
+        >
+          <IconCheck size={16} /> Approve
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/packages/runtime/components/review/ReviewLayer.tsx
+++ b/packages/runtime/components/review/ReviewLayer.tsx
@@ -1,0 +1,105 @@
+import type { Feedback, ReviewComment, ReviewDecision } from '@visualplan/core'
+import { IconCheck } from '@tabler/icons-react'
+import { useEffect, useRef, useState } from 'react'
+import { CommentModal } from './CommentModal.js'
+import { DecisionBar } from './DecisionBar.js'
+import { beaconFeedback, isReviewMode, postFeedback } from './feedback.js'
+import { HoverCommentButton, useHoveredSection } from './SectionComments.js'
+import './review.css'
+
+/** Mounts the interactive review UI, but only when the CLI started the page in review mode. */
+export function ReviewLayer() {
+  if (!isReviewMode()) return null
+  return <ReviewSession />
+}
+
+function ReviewSession() {
+  const [comments, setComments] = useState<ReviewComment[]>([])
+  const [composing, setComposing] = useState<string | null>(null)
+  const [note, setNote] = useState('')
+  const [submitted, setSubmitted] = useState<ReviewDecision | null>(null)
+  const [busy, setBusy] = useState(false)
+
+  const { hovered, keepAlive } = useHoveredSection(submitted === null)
+
+  // The unload handlers register once but must see the latest state, so mirror it into a ref.
+  const stateRef = useRef({ comments, note, submitted })
+  stateRef.current = { comments, note, submitted }
+
+  useEffect(() => {
+    const onBeforeUnload = (event: BeforeUnloadEvent) => {
+      // Prompt before leaving only while the review is unresolved; a submitted decision closes freely.
+      if (!stateRef.current.submitted) {
+        event.preventDefault()
+        event.returnValue = ''
+      }
+    }
+    // pagehide fires when the page is actually torn down (the user confirmed leaving), so this is the
+    // "they really left" signal. Closing without a decision is a Deny, carrying any comments made.
+    const onPageHide = () => {
+      const { submitted: done, comments: made, note: overall } = stateRef.current
+      if (!done) {
+        beaconFeedback({ decision: 'deny', comments: made, note: overall.trim() || undefined })
+      }
+    }
+    window.addEventListener('beforeunload', onBeforeUnload)
+    window.addEventListener('pagehide', onPageHide)
+    return () => {
+      window.removeEventListener('beforeunload', onBeforeUnload)
+      window.removeEventListener('pagehide', onPageHide)
+    }
+  }, [])
+
+  const addComment = (body: string) => {
+    if (composing) setComments(prev => [...prev, { section: composing, body }])
+    setComposing(null)
+  }
+
+  const decide = async (decision: ReviewDecision) => {
+    const feedback: Feedback = { decision, comments, note: note.trim() || undefined }
+    setBusy(true)
+    const ok = await postFeedback(feedback)
+    if (ok) {
+      setSubmitted(decision)
+    } else {
+      setBusy(false)
+      window.alert('Could not reach the review server. Is the CLI still running?')
+    }
+  }
+
+  if (submitted) return <SubmittedNotice decision={submitted} />
+
+  return (
+    <>
+      {hovered && !composing && (
+        <HoverCommentButton
+          section={hovered}
+          onClick={() => setComposing(hovered.label)}
+          onKeepAlive={keepAlive}
+        />
+      )}
+      {composing && (
+        <CommentModal section={composing} onSave={addComment} onCancel={() => setComposing(null)} />
+      )}
+      <DecisionBar
+        commentCount={comments.length}
+        note={note}
+        onNote={setNote}
+        onDecide={decide}
+        busy={busy}
+      />
+    </>
+  )
+}
+
+/** Replaces the decision bar once a verdict is sent, so the reviewer knows it is safe to close. */
+function SubmittedNotice({ decision }: { decision: ReviewDecision }) {
+  return (
+    <div className='vp-review-done' data-decision={decision}>
+      <IconCheck size={18} />
+      <span>
+        Feedback submitted (<strong>{decision}</strong>). You can close this tab.
+      </span>
+    </div>
+  )
+}

--- a/packages/runtime/components/review/ReviewLayer.tsx
+++ b/packages/runtime/components/review/ReviewLayer.tsx
@@ -3,7 +3,7 @@ import { IconCheck } from '@tabler/icons-react'
 import { useEffect, useRef, useState } from 'react'
 import { CommentModal } from './CommentModal.js'
 import { DecisionBar } from './DecisionBar.js'
-import { beaconFeedback, isReviewMode, postFeedback } from './feedback.js'
+import { isReviewMode, openKeepalive, postDraft, postFeedback } from './feedback.js'
 import { HoverCommentButton, useHoveredSection } from './SectionComments.js'
 import './review.css'
 
@@ -22,32 +22,31 @@ function ReviewSession() {
 
   const { hovered, keepAlive } = useHoveredSection(submitted === null)
 
-  // The unload handlers register once but must see the latest state, so mirror it into a ref.
-  const stateRef = useRef({ comments, note, submitted })
-  stateRef.current = { comments, note, submitted }
+  // Hold a connection open so the server resolves Deny if the tab closes; the server, not an
+  // unreliable unload beacon, detects the drop. Aborted on unmount (e.g. after a submitted decision).
+  useEffect(() => {
+    const connection = openKeepalive()
+    return () => connection.abort()
+  }, [])
 
+  // Keep the server's Deny-on-close payload current, so a tab-close Deny still carries the comments.
+  useEffect(() => {
+    if (!submitted) postDraft({ decision: 'deny', comments, note: note.trim() || undefined })
+  }, [comments, note, submitted])
+
+  // Warn before leaving while undecided; the actual Deny is handled server-side via the dropped
+  // keepalive, so this prompt is purely a courtesy. It reads the latest `submitted` via a ref.
+  const submittedRef = useRef(submitted)
+  submittedRef.current = submitted
   useEffect(() => {
     const onBeforeUnload = (event: BeforeUnloadEvent) => {
-      // Prompt before leaving only while the review is unresolved; a submitted decision closes freely.
-      if (!stateRef.current.submitted) {
+      if (!submittedRef.current) {
         event.preventDefault()
         event.returnValue = ''
       }
     }
-    // pagehide fires when the page is actually torn down (the user confirmed leaving), so this is the
-    // "they really left" signal. Closing without a decision is a Deny, carrying any comments made.
-    const onPageHide = () => {
-      const { submitted: done, comments: made, note: overall } = stateRef.current
-      if (!done) {
-        beaconFeedback({ decision: 'deny', comments: made, note: overall.trim() || undefined })
-      }
-    }
     window.addEventListener('beforeunload', onBeforeUnload)
-    window.addEventListener('pagehide', onPageHide)
-    return () => {
-      window.removeEventListener('beforeunload', onBeforeUnload)
-      window.removeEventListener('pagehide', onPageHide)
-    }
+    return () => window.removeEventListener('beforeunload', onBeforeUnload)
   }, [])
 
   const addComment = (body: string) => {

--- a/packages/runtime/components/review/ReviewLayer.tsx
+++ b/packages/runtime/components/review/ReviewLayer.tsx
@@ -1,11 +1,36 @@
 import type { Feedback, ReviewComment, ReviewDecision } from '@visualplan/core'
-import { IconCheck } from '@tabler/icons-react'
+import { IconCheck, IconMessagePlus } from '@tabler/icons-react'
 import { useEffect, useRef, useState } from 'react'
 import { CommentModal } from './CommentModal.js'
+import { CommentsPopover } from './CommentsPopover.js'
 import { DecisionBar } from './DecisionBar.js'
 import { isReviewMode, openKeepalive, postDraft, postFeedback } from './feedback.js'
-import { HoverCommentButton, useHoveredSection } from './SectionComments.js'
+import {
+  type Section,
+  sectionAt,
+  SectionOverlays,
+  useReviewSections,
+  useTextSelection,
+} from './SectionComments.js'
 import './review.css'
+
+/** A pending comment, keyed by section index (labels repeat). `quote`/`range` are set for a
+ * selection comment; `range` lets the quoted text stay highlighted after the comment is added. */
+interface DraftComment {
+  sectionIndex: number
+  label: string
+  body: string
+  quote?: string
+  range?: Range
+}
+
+/** What a new comment will attach to: a section, optionally narrowed to a quoted text selection. */
+interface CommentTarget {
+  sectionIndex: number
+  label: string
+  quote?: string
+  range?: Range
+}
 
 /** Mounts the interactive review UI, but only when the CLI started the page in review mode. */
 export function ReviewLayer() {
@@ -14,13 +39,31 @@ export function ReviewLayer() {
 }
 
 function ReviewSession() {
-  const [comments, setComments] = useState<ReviewComment[]>([])
-  const [composing, setComposing] = useState<string | null>(null)
+  const [comments, setComments] = useState<DraftComment[]>([])
+  const [composing, setComposing] = useState<CommentTarget | null>(null)
+  const [viewing, setViewing] = useState<Section | null>(null)
   const [note, setNote] = useState('')
   const [submitted, setSubmitted] = useState<ReviewDecision | null>(null)
   const [busy, setBusy] = useState(false)
+  const [hoveredMark, setHoveredMark] = useState<{
+    body: string
+    top: number
+    left: number
+  } | null>(null)
 
-  const { hovered, keepAlive } = useHoveredSection(submitted === null)
+  const { sections, hoveredIndex } = useReviewSections(submitted === null)
+  const { selection, clear: clearSelection } = useTextSelection(submitted === null)
+
+  // A selection comment is sent under its quote so the agent can locate the exact text; a section
+  // comment is sent under the section label.
+  const payloadComments: ReviewComment[] = comments.map(c => ({
+    section: c.quote ?? c.label,
+    body: c.body,
+  }))
+  const commentCounts = new Map<number, number>()
+  for (const comment of comments) {
+    commentCounts.set(comment.sectionIndex, (commentCounts.get(comment.sectionIndex) ?? 0) + 1)
+  }
 
   // Hold a connection open so the server resolves Deny if the tab closes; the server, not an
   // unreliable unload beacon, detects the drop. Aborted on unmount (e.g. after a submitted decision).
@@ -30,8 +73,12 @@ function ReviewSession() {
   }, [])
 
   // Keep the server's Deny-on-close payload current, so a tab-close Deny still carries the comments.
+  // Build the payload from `comments` inside the effect so it runs only when the state actually changes.
   useEffect(() => {
-    if (!submitted) postDraft({ decision: 'deny', comments, note: note.trim() || undefined })
+    if (!submitted) {
+      const draft = comments.map(c => ({ section: c.quote ?? c.label, body: c.body }))
+      postDraft({ decision: 'deny', comments: draft, note: note.trim() || undefined })
+    }
   }, [comments, note, submitted])
 
   // Warn before leaving while undecided; the actual Deny is handled server-side via the dropped
@@ -50,16 +97,57 @@ function ReviewSession() {
   }, [])
 
   const addComment = (body: string) => {
-    if (composing) setComments(prev => [...prev, { section: composing, body }])
+    if (composing) {
+      const t = composing
+      setComments(prev => [
+        ...prev,
+        { sectionIndex: t.sectionIndex, label: t.label, body, quote: t.quote, range: t.range },
+      ])
+    }
     setComposing(null)
   }
 
+  /** Comment on the current text selection: anchor it to the section it sits in, carrying the quote
+   * and the range (so the text stays marked afterwards). */
+  const addSelectionComment = () => {
+    if (!selection) return
+    const target = sectionAt(sections, selection.range.getBoundingClientRect().top) ?? sections[0]
+    if (!target) return
+    const quote =
+      selection.text.length > 140 ? `${selection.text.slice(0, 140).trim()}…` : selection.text
+    setViewing(null)
+    setComposing({ sectionIndex: target.index, label: target.label, quote, range: selection.range })
+    clearSelection()
+  }
+
+  /** Remove the `bodyIndex`-th comment among those on `sectionIndex`. */
+  const deleteComment = (sectionIndex: number, bodyIndex: number) => {
+    setComments(prev => {
+      let seen = -1
+      return prev.filter(comment => {
+        if (comment.sectionIndex !== sectionIndex) return true
+        seen += 1
+        return seen !== bodyIndex
+      })
+    })
+  }
+
   const decide = async (decision: ReviewDecision) => {
-    const feedback: Feedback = { decision, comments, note: note.trim() || undefined }
+    const feedback: Feedback = {
+      decision,
+      comments: payloadComments,
+      note: note.trim() || undefined,
+    }
     setBusy(true)
     const ok = await postFeedback(feedback)
     if (ok) {
+      // Mark submitted on the ref synchronously so the beforeunload guard does not prompt for this
+      // programmatic close (it still prompts on a manual browser close while undecided).
+      submittedRef.current = decision
       setSubmitted(decision)
+      // Best-effort: close the tab now the review is done. Browsers block this for a user-opened
+      // tab, in which case the SubmittedNotice fallback tells them they can close it.
+      window.close()
     } else {
       setBusy(false)
       window.alert('Could not reach the review server. Is the CLI still running?')
@@ -68,17 +156,99 @@ function ReviewSession() {
 
   if (submitted) return <SubmittedNotice decision={submitted} />
 
+  const viewingComments = viewing
+    ? comments
+        .filter(comment => comment.sectionIndex === viewing.index)
+        .map(c => ({ body: c.body, quote: c.quote }))
+    : []
+  const viewingRect = viewing?.element.getBoundingClientRect()
+  const selectionRect = selection?.range.getBoundingClientRect()
+
   return (
     <>
-      {hovered && !composing && (
-        <HoverCommentButton
-          section={hovered}
-          onClick={() => setComposing(hovered.label)}
-          onKeepAlive={keepAlive}
-        />
+      {/* Persistent highlight over text that has a comment, so it is obvious where one was added. A
+          range can wrap lines, hence one mark per client rect. */}
+      {comments.map((comment, ci) =>
+        comment.range
+          ? Array.from(comment.range.getClientRects()).map((r, ri) => (
+              <button
+                type='button'
+                // biome-ignore lint/suspicious/noArrayIndexKey: positional marks, no stable id.
+                key={`${ci}-${ri}`}
+                className='vp-review-quote-mark'
+                style={{ top: r.top, left: r.left, width: r.width, height: r.height }}
+                onMouseEnter={() =>
+                  setHoveredMark({ body: comment.body, top: r.top, left: r.left })
+                }
+                onMouseLeave={() => setHoveredMark(null)}
+                onFocus={() => setHoveredMark({ body: comment.body, top: r.top, left: r.left })}
+                onBlur={() => setHoveredMark(null)}
+                onClick={() => {
+                  const section = sections[comment.sectionIndex]
+                  if (section) {
+                    setComposing(null)
+                    setViewing(section)
+                  }
+                }}
+                aria-label={`Comment: ${comment.body}`}
+              />
+            ))
+          : null,
+      )}
+      {hoveredMark && (
+        <div
+          className='vp-review-tip'
+          style={{
+            top: Math.max(hoveredMark.top - 38, 8),
+            left: Math.min(hoveredMark.left, window.innerWidth - 360),
+          }}
+        >
+          {hoveredMark.body}
+        </div>
+      )}
+      <SectionOverlays
+        sections={sections}
+        hoveredIndex={hoveredIndex}
+        commentCounts={commentCounts}
+        onAdd={section => {
+          setViewing(null)
+          setComposing({ sectionIndex: section.index, label: section.label })
+        }}
+        onView={section => {
+          setComposing(null)
+          setViewing(section)
+        }}
+      />
+      {selection && selectionRect && !composing && (
+        <button
+          type='button'
+          className='vp-review-select'
+          style={{
+            top: Math.max(selectionRect.top - 36, 8),
+            left: Math.min(Math.max(selectionRect.left, 8), window.innerWidth - 130),
+          }}
+          // Keep the text selection from collapsing when the button takes the press.
+          onMouseDown={event => event.preventDefault()}
+          onClick={addSelectionComment}
+        >
+          <IconMessagePlus size={14} /> Comment
+        </button>
       )}
       {composing && (
-        <CommentModal section={composing} onSave={addComment} onCancel={() => setComposing(null)} />
+        <CommentModal
+          section={composing.quote ?? composing.label}
+          onSave={addComment}
+          onCancel={() => setComposing(null)}
+        />
+      )}
+      {viewing && viewingRect && viewingComments.length > 0 && (
+        <CommentsPopover
+          label={viewing.label}
+          comments={viewingComments}
+          anchor={{ top: viewingRect.top, left: Math.max(viewingRect.left - 34, 8) }}
+          onDelete={index => deleteComment(viewing.index, index)}
+          onClose={() => setViewing(null)}
+        />
       )}
       <DecisionBar
         commentCount={comments.length}

--- a/packages/runtime/components/review/SectionComments.tsx
+++ b/packages/runtime/components/review/SectionComments.tsx
@@ -1,0 +1,114 @@
+import { IconMessagePlus } from '@tabler/icons-react'
+import { useEffect, useRef, useState } from 'react'
+
+/** A major section the reviewer can comment on: a `Phase` or a top-level `## heading`. */
+export interface HoveredSection {
+  label: string
+  rect: DOMRect
+}
+
+/** The hover-detect selector for a section's anchor element within the plan column. */
+const SECTION_SELECTOR = '.vp-phase, h2'
+
+/** Derive a human label the agent can map back to the MDX: a Phase's title or the heading's text. */
+function sectionLabel(element: Element): string {
+  if (element.classList.contains('vp-phase')) {
+    return element.querySelector('.vp-phase__title')?.textContent?.trim() || 'Phase'
+  }
+  return element.textContent?.trim() || 'Section'
+}
+
+/** The nearest *top-level* section (a direct child of `.vp-main`) under the pointer, or null. */
+function topLevelSection(target: EventTarget | null, main: Element): Element | null {
+  if (!(target instanceof Element)) return null
+  const section = target.closest(SECTION_SELECTOR)
+  return section && section.parentElement === main ? section : null
+}
+
+/**
+ * Track which major section the pointer is over, so a single comment button can follow it. Returns
+ * the hovered section (with a live rect, recomputed on scroll/resize) and `keepAlive`, which the
+ * button calls on hover so traveling from the section to the button does not dismiss it.
+ */
+export function useHoveredSection(active: boolean): {
+  hovered: HoveredSection | null
+  keepAlive: () => void
+} {
+  const [hovered, setHovered] = useState<HoveredSection | null>(null)
+  const elementRef = useRef<Element | null>(null)
+  const hideTimer = useRef<ReturnType<typeof setTimeout>>(undefined)
+
+  useEffect(() => {
+    if (!active) return
+    const main = document.querySelector('.vp-main')
+    if (!main) return
+
+    const reposition = () => {
+      if (elementRef.current) {
+        setHovered({
+          label: sectionLabel(elementRef.current),
+          rect: elementRef.current.getBoundingClientRect(),
+        })
+      }
+    }
+    const onPointerMove = (event: PointerEvent) => {
+      const section = topLevelSection(event.target, main)
+      if (section) {
+        clearTimeout(hideTimer.current)
+        if (section !== elementRef.current) {
+          elementRef.current = section
+          reposition()
+        }
+      }
+    }
+    // Delay the dismiss so the pointer can cross the small gap to the button (which calls keepAlive).
+    const onLeave = () => {
+      hideTimer.current = setTimeout(() => {
+        elementRef.current = null
+        setHovered(null)
+      }, 280)
+    }
+
+    document.addEventListener('pointermove', onPointerMove)
+    main.addEventListener('pointerleave', onLeave)
+    window.addEventListener('scroll', reposition, { passive: true })
+    window.addEventListener('resize', reposition)
+    return () => {
+      document.removeEventListener('pointermove', onPointerMove)
+      main.removeEventListener('pointerleave', onLeave)
+      window.removeEventListener('scroll', reposition)
+      window.removeEventListener('resize', reposition)
+      clearTimeout(hideTimer.current)
+    }
+  }, [active])
+
+  return { hovered, keepAlive: () => clearTimeout(hideTimer.current) }
+}
+
+/** The floating "comment on this section" button, pinned to the right of the hovered section. */
+export function HoverCommentButton({
+  section,
+  onClick,
+  onKeepAlive,
+}: {
+  section: HoveredSection
+  onClick: () => void
+  onKeepAlive: () => void
+}) {
+  // Right of the section's content column, aligned near its top; clamped into the viewport.
+  const left = Math.min(section.rect.right + 8, window.innerWidth - 44)
+  const top = Math.max(section.rect.top + 4, 8)
+  return (
+    <button
+      type='button'
+      className='vp-review-add'
+      style={{ top, left }}
+      onClick={onClick}
+      onMouseEnter={onKeepAlive}
+      aria-label={`Comment on "${section.label}"`}
+      title={`Comment on "${section.label}"`}
+    >
+      <IconMessagePlus size={17} />
+    </button>
+  )
+}

--- a/packages/runtime/components/review/SectionComments.tsx
+++ b/packages/runtime/components/review/SectionComments.tsx
@@ -1,14 +1,17 @@
-import { IconMessagePlus } from '@tabler/icons-react'
-import { useEffect, useRef, useState } from 'react'
+import { IconMessage2, IconMessagePlus } from '@tabler/icons-react'
+import { Fragment, useEffect, useState } from 'react'
 
-/** A major section the reviewer can comment on: a `Phase` or a top-level `## heading`. */
-export interface HoveredSection {
+/** A major section the reviewer can comment on: a `Phase` or a top-level `# / ## heading`. */
+export interface Section {
+  /** Document-order index, the stable key for comments (labels can repeat). */
+  index: number
   label: string
-  rect: DOMRect
+  /** The section's anchor (the phase or heading element). */
+  element: Element
+  /** The last top-level element this section owns (the one before the next section), so the
+   * highlight can wrap the actual content rather than the empty space up to the next section. */
+  lastElement: Element
 }
-
-/** The hover-detect selector for a section's anchor element within the plan column. */
-const SECTION_SELECTOR = '.vp-phase, h2'
 
 /** Derive a human label the agent can map back to the MDX: a Phase's title or the heading's text. */
 function sectionLabel(element: Element): string {
@@ -18,97 +21,233 @@ function sectionLabel(element: Element): string {
   return element.textContent?.trim() || 'Section'
 }
 
-/** The nearest *top-level* section (a direct child of `.vp-main`) under the pointer, or null. */
-function topLevelSection(target: EventTarget | null, main: Element): Element | null {
-  if (!(target instanceof Element)) return null
-  const section = target.closest(SECTION_SELECTOR)
-  return section && section.parentElement === main ? section : null
+/** Enumerate the plan's major sections in document order, each owning the elements up to the next
+ * section. Called once: the plan is a frozen snapshot. */
+export function collectSections(): Section[] {
+  const main = document.querySelector('.vp-main')
+  if (!main) return []
+  const children = Array.from(main.children)
+  const starts = children.filter(el => el.matches('.vp-phase, h1, h2'))
+  return starts.map((element, index) => {
+    const next = starts[index + 1]
+    const nextIdx = next ? children.indexOf(next) : children.length
+    const lastElement = children[nextIdx - 1] ?? element
+    return { index, label: sectionLabel(element), element, lastElement }
+  })
+}
+
+/** The viewport-relative bottom of the plan column, the lower bound of the last section's band. */
+function mainBottom(): number {
+  return document.querySelector('.vp-main')?.getBoundingClientRect().bottom ?? window.innerHeight
 }
 
 /**
- * Track which major section the pointer is over, so a single comment button can follow it. Returns
- * the hovered section (with a live rect, recomputed on scroll/resize) and `keepAlive`, which the
- * button calls on hover so traveling from the section to the button does not dismiss it.
+ * The vertical band a section occupies: from its own top down to the next section's top (the last
+ * runs to the column bottom). Hover is decided by which band the pointer's Y falls in, so the whole
+ * section, heading and the content beneath it, is the target, and the highlight spans it edge to edge.
  */
-export function useHoveredSection(active: boolean): {
-  hovered: HoveredSection | null
-  keepAlive: () => void
-} {
-  const [hovered, setHovered] = useState<HoveredSection | null>(null)
-  const elementRef = useRef<Element | null>(null)
-  const hideTimer = useRef<ReturnType<typeof setTimeout>>(undefined)
-
-  useEffect(() => {
-    if (!active) return
-    const main = document.querySelector('.vp-main')
-    if (!main) return
-
-    const reposition = () => {
-      if (elementRef.current) {
-        setHovered({
-          label: sectionLabel(elementRef.current),
-          rect: elementRef.current.getBoundingClientRect(),
-        })
-      }
-    }
-    const onPointerMove = (event: PointerEvent) => {
-      const section = topLevelSection(event.target, main)
-      if (section) {
-        clearTimeout(hideTimer.current)
-        if (section !== elementRef.current) {
-          elementRef.current = section
-          reposition()
-        }
-      }
-    }
-    // Delay the dismiss so the pointer can cross the small gap to the button (which calls keepAlive).
-    const onLeave = () => {
-      hideTimer.current = setTimeout(() => {
-        elementRef.current = null
-        setHovered(null)
-      }, 280)
-    }
-
-    document.addEventListener('pointermove', onPointerMove)
-    main.addEventListener('pointerleave', onLeave)
-    window.addEventListener('scroll', reposition, { passive: true })
-    window.addEventListener('resize', reposition)
-    return () => {
-      document.removeEventListener('pointermove', onPointerMove)
-      main.removeEventListener('pointerleave', onLeave)
-      window.removeEventListener('scroll', reposition)
-      window.removeEventListener('resize', reposition)
-      clearTimeout(hideTimer.current)
-    }
-  }, [active])
-
-  return { hovered, keepAlive: () => clearTimeout(hideTimer.current) }
+export function sectionBand(
+  sections: Section[],
+  arrayPos: number,
+): { top: number; bottom: number } {
+  const current = sections[arrayPos]
+  const top = current?.element.getBoundingClientRect().top ?? 0
+  const next = sections[arrayPos + 1]
+  return { top, bottom: next ? next.element.getBoundingClientRect().top : mainBottom() }
 }
 
-/** The floating "comment on this section" button, pinned to the right of the hovered section. */
-export function HoverCommentButton({
-  section,
-  onClick,
-  onKeepAlive,
+/** The rect wrapping a section's actual content (anchor top to its last owned element's bottom), so
+ * the highlight hugs the content instead of the empty space running up to the next section. */
+export function sectionContent(section: Section): { top: number; bottom: number } {
+  return {
+    top: section.element.getBoundingClientRect().top,
+    bottom: section.lastElement.getBoundingClientRect().bottom,
+  }
+}
+
+/** The section whose vertical band contains the viewport Y, or null (e.g. above the first section). */
+export function sectionAt(sections: Section[], y: number): Section | null {
+  for (let pos = 0; pos < sections.length; pos++) {
+    const section = sections[pos]
+    if (!section) continue
+    const band = sectionBand(sections, pos)
+    if (y >= band.top && y < band.bottom) return section
+  }
+  return null
+}
+
+/**
+ * Track the plan's sections and which band the pointer is in. Collects sections once after mount,
+ * then maps the pointer's Y to a section band, so hovering anywhere in a section (not just its
+ * header) selects it, and the highlight is a stable full-width band rather than something chasing the
+ * cursor. Re-runs on scroll with the last Y so the highlight follows the content, and bumps a tick so
+ * the overlays (which read live rects) stay pinned.
+ */
+export function useReviewSections(active: boolean): {
+  sections: Section[]
+  hoveredIndex: number | null
+} {
+  const [sections, setSections] = useState<Section[]>([])
+  const [hoveredIndex, setHoveredIndex] = useState<number | null>(null)
+  const [, setTick] = useState(0)
+
+  useEffect(() => setSections(collectSections()), [])
+
+  useEffect(() => {
+    if (!active || sections.length === 0) {
+      setHoveredIndex(null)
+      return
+    }
+    let lastY = -1
+    const detect = () => {
+      if (lastY < 0) return
+      setHoveredIndex(sectionAt(sections, lastY)?.index ?? null)
+    }
+    const onMove = (event: PointerEvent) => {
+      lastY = event.clientY
+      detect()
+    }
+    const onReflow = () => {
+      setTick(tick => tick + 1)
+      detect()
+    }
+
+    document.addEventListener('pointermove', onMove)
+    window.addEventListener('scroll', onReflow, { passive: true })
+    window.addEventListener('resize', onReflow)
+    return () => {
+      document.removeEventListener('pointermove', onMove)
+      window.removeEventListener('scroll', onReflow)
+      window.removeEventListener('resize', onReflow)
+    }
+  }, [active, sections])
+
+  return { sections, hoveredIndex }
+}
+
+/** A finalized text selection inside the plan: the quoted text and a snapshot of its range. */
+export interface TextSelection {
+  text: string
+  range: Range
+}
+
+/**
+ * Surface a text selection made within the plan so the reviewer can comment on an exact quote. Reads
+ * the selection on `mouseup`; ignores collapsed selections and any selection outside `.vp-main`. The
+ * range is cloned so its rect can be read live (it tracks scroll); `clear` dismisses the affordance.
+ */
+export function useTextSelection(active: boolean): {
+  selection: TextSelection | null
+  clear: () => void
+} {
+  const [selection, setSelection] = useState<TextSelection | null>(null)
+
+  useEffect(() => {
+    if (!active) {
+      setSelection(null)
+      return
+    }
+    const main = document.querySelector('.vp-main')
+    if (!main) return
+    const onMouseUp = () => {
+      const sel = window.getSelection()
+      if (!sel || sel.isCollapsed || sel.rangeCount === 0) {
+        setSelection(null)
+        return
+      }
+      const range = sel.getRangeAt(0)
+      const text = sel.toString().trim()
+      if (!text || !main.contains(range.commonAncestorContainer)) {
+        setSelection(null)
+        return
+      }
+      setSelection({ text, range: range.cloneRange() })
+    }
+    document.addEventListener('mouseup', onMouseUp)
+    return () => document.removeEventListener('mouseup', onMouseUp)
+  }, [active])
+
+  return { selection, clear: () => setSelection(null) }
+}
+
+/**
+ * The per-section overlay layer: highlights the hovered section and shows its add-comment button, and
+ * a persistent count badge on any section that already has comments. All fixed-position over the plan
+ * (read from live rects), so the plan DOM is never touched.
+ */
+export function SectionOverlays({
+  sections,
+  hoveredIndex,
+  commentCounts,
+  onAdd,
+  onView,
 }: {
-  section: HoveredSection
-  onClick: () => void
-  onKeepAlive: () => void
+  sections: Section[]
+  hoveredIndex: number | null
+  commentCounts: Map<number, number>
+  onAdd: (section: Section) => void
+  onView: (section: Section) => void
 }) {
-  // Right of the section's content column, aligned near its top; clamped into the viewport.
-  const left = Math.min(section.rect.right + 8, window.innerWidth - 44)
-  const top = Math.max(section.rect.top + 4, 8)
   return (
-    <button
-      type='button'
-      className='vp-review-add'
-      style={{ top, left }}
-      onClick={onClick}
-      onMouseEnter={onKeepAlive}
-      aria-label={`Comment on "${section.label}"`}
-      title={`Comment on "${section.label}"`}
-    >
-      <IconMessagePlus size={17} />
-    </button>
+    <>
+      {sections.map(section => {
+        const hovered = section.index === hoveredIndex
+        const count = commentCounts.get(section.index) ?? 0
+        if (!hovered && count === 0) return null
+        const rect = section.element.getBoundingClientRect()
+        const content = sectionContent(section)
+        // Center the controls on the section's actual content, kept on-screen and clear of the
+        // bottom bar when the content extends beyond the viewport (a tall section, or scrolled off).
+        const controlTop = Math.min(
+          Math.max((content.top + content.bottom) / 2 - 15, 8),
+          window.innerHeight - 72,
+        )
+        return (
+          <Fragment key={section.index}>
+            {hovered && (
+              // A wide band hugging the section's content (heading + its elements), not the empty
+              // space up to the next section. Side-inset for breathing space; overlay only, so it
+              // never shifts the page layout.
+              <div
+                className='vp-review-highlight'
+                style={{
+                  top: content.top,
+                  left: 10,
+                  right: 10,
+                  height: Math.max(content.bottom - content.top, 0),
+                }}
+              />
+            )}
+            {hovered && (
+              <button
+                type='button'
+                className='vp-review-add'
+                // Out in the right gutter with breathing room from the content, clamped on-screen.
+                style={{ top: controlTop, left: Math.min(rect.right + 18, window.innerWidth - 42) }}
+                onClick={() => onAdd(section)}
+                aria-label={`Comment on "${section.label}"`}
+                title={`Comment on "${section.label}"`}
+              >
+                <IconMessagePlus size={16} />
+              </button>
+            )}
+            {count > 0 && (
+              <button
+                type='button'
+                className='vp-review-badge'
+                // Out in the left gutter with breathing room from the content, clamped on-screen.
+                style={{ top: controlTop, left: Math.max(rect.left - 46, 10) }}
+                onClick={() => onView(section)}
+                aria-label={`${count} comment${count === 1 ? '' : 's'} on "${section.label}"`}
+                title={`View ${count} comment${count === 1 ? '' : 's'}`}
+              >
+                <IconMessage2 size={13} />
+                {count}
+              </button>
+            )}
+          </Fragment>
+        )
+      })}
+    </>
   )
 }

--- a/packages/runtime/components/review/feedback.ts
+++ b/packages/runtime/components/review/feedback.ts
@@ -1,14 +1,16 @@
 import type { Feedback } from '@visualplan/core'
 
-/** The endpoint the review server (`compile.ts` `reviewPlugin`) exposes for the decision payload. */
+/** The review server (`compile.ts` `reviewPlugin`) endpoints. */
 const FEEDBACK_ENDPOINT = '/__vp_feedback'
+const DRAFT_ENDPOINT = '/__vp_draft'
+const ALIVE_ENDPOINT = '/__vp_alive'
 
 /** True when the CLI started the page in review mode (`__VP_REVIEW__` injected by `reviewPlugin`). */
 export function isReviewMode(): boolean {
   return (globalThis as { __VP_REVIEW__?: boolean }).__VP_REVIEW__ === true
 }
 
-/** POST the decision to the CLI, which resolves the blocking session. Returns whether it was accepted. */
+/** POST the explicit decision to the CLI, which resolves the blocking session. Returns whether it was accepted. */
 export async function postFeedback(feedback: Feedback): Promise<boolean> {
   try {
     const res = await fetch(FEEDBACK_ENDPOINT, {
@@ -23,10 +25,24 @@ export async function postFeedback(feedback: Feedback): Promise<boolean> {
 }
 
 /**
- * Send the decision during page unload. A normal `fetch` is cancelled mid-unload, so the tab-close
- * deny must go out via `sendBeacon`, which the browser flushes even as the page tears down.
+ * Keep the server's Deny-on-close payload current. The server resolves with this draft if the tab
+ * closes without a decision, so the comments made so far still reach the agent. Fire-and-forget.
  */
-export function beaconFeedback(feedback: Feedback): void {
-  const blob = new Blob([JSON.stringify(feedback)], { type: 'application/json' })
-  navigator.sendBeacon(FEEDBACK_ENDPOINT, blob)
+export function postDraft(feedback: Feedback): void {
+  void fetch(DRAFT_ENDPOINT, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(feedback),
+  }).catch(() => {})
+}
+
+/**
+ * Open a connection the server holds for the tab's lifetime. When the tab closes, this socket drops
+ * and the server detects it (resolving Deny), which is reliable on a real close where an unload-time
+ * `sendBeacon` is not. Returns the controller so the caller can abort it on unmount.
+ */
+export function openKeepalive(): AbortController {
+  const controller = new AbortController()
+  void fetch(ALIVE_ENDPOINT, { signal: controller.signal }).catch(() => {})
+  return controller
 }

--- a/packages/runtime/components/review/feedback.ts
+++ b/packages/runtime/components/review/feedback.ts
@@ -1,0 +1,32 @@
+import type { Feedback } from '@visualplan/core'
+
+/** The endpoint the review server (`compile.ts` `reviewPlugin`) exposes for the decision payload. */
+const FEEDBACK_ENDPOINT = '/__vp_feedback'
+
+/** True when the CLI started the page in review mode (`__VP_REVIEW__` injected by `reviewPlugin`). */
+export function isReviewMode(): boolean {
+  return (globalThis as { __VP_REVIEW__?: boolean }).__VP_REVIEW__ === true
+}
+
+/** POST the decision to the CLI, which resolves the blocking session. Returns whether it was accepted. */
+export async function postFeedback(feedback: Feedback): Promise<boolean> {
+  try {
+    const res = await fetch(FEEDBACK_ENDPOINT, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(feedback),
+    })
+    return res.ok
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Send the decision during page unload. A normal `fetch` is cancelled mid-unload, so the tab-close
+ * deny must go out via `sendBeacon`, which the browser flushes even as the page tears down.
+ */
+export function beaconFeedback(feedback: Feedback): void {
+  const blob = new Blob([JSON.stringify(feedback)], { type: 'application/json' })
+  navigator.sendBeacon(FEEDBACK_ENDPOINT, blob)
+}

--- a/packages/runtime/components/review/feedback.ts
+++ b/packages/runtime/components/review/feedback.ts
@@ -10,6 +10,12 @@ export function isReviewMode(): boolean {
   return (globalThis as { __VP_REVIEW__?: boolean }).__VP_REVIEW__ === true
 }
 
+/** The plan revision number from the CLI's `--iteration` flag, or null when it was not passed. */
+export function reviewIteration(): number | null {
+  const value = (globalThis as { __VP_REVIEW_ITERATION__?: number }).__VP_REVIEW_ITERATION__
+  return typeof value === 'number' ? value : null
+}
+
 /** POST the explicit decision to the CLI, which resolves the blocking session. Returns whether it was accepted. */
 export async function postFeedback(feedback: Feedback): Promise<boolean> {
   try {

--- a/packages/runtime/components/review/review.css
+++ b/packages/runtime/components/review/review.css
@@ -2,33 +2,219 @@
    tracks light/dark with the rest of the page. Everything here is fixed-position overlay; the plan
    content underneath is untouched. */
 
+@keyframes vp-review-fade-in {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
 .vp-review-add {
   position: fixed;
-  z-index: 60;
+  z-index: 58;
   display: grid;
   place-items: center;
   width: 30px;
   height: 30px;
   padding: 0;
-  color: var(--vp-muted);
-  background: var(--vp-surface);
-  border: 1px solid var(--vp-border);
+  color: var(--vp-on-accent);
+  background: var(--vp-accent);
+  border: none;
   border-radius: 8px;
   cursor: pointer;
-  box-shadow: 0 1px 3px rgb(0 0 0 / 12%);
-  transition:
-    color 0.12s var(--vp-ease),
-    border-color 0.12s var(--vp-ease);
+  box-shadow: 0 2px 6px rgb(0 0 0 / 20%);
+  animation: vp-review-fade-in 0.12s var(--vp-ease);
+  transition: filter 0.12s var(--vp-ease);
 }
 
 .vp-review-add:hover {
-  color: var(--vp-accent);
-  border-color: var(--vp-border-strong);
+  filter: brightness(1.08);
+}
+
+/* Marks the section the hover targets, so it is unambiguous what a comment attaches to. A full-width
+   tint band (positioned edge to edge inline), faded in so moving between sections does not pop. */
+.vp-review-highlight {
+  position: fixed;
+  z-index: 54;
+  pointer-events: none;
+  border-radius: 10px;
+  background: color-mix(in srgb, var(--vp-accent) 6%, transparent);
+  animation: vp-review-fade-in 0.12s var(--vp-ease);
+}
+
+/* Persistent highlighter over text that already has a comment (a distinct gold tint from the accent
+   hover band), so it is obvious a comment was attached there. Hoverable to reveal the comment. */
+.vp-review-quote-mark {
+  position: fixed;
+  z-index: 53;
+  padding: 0;
+  cursor: help;
+  appearance: none;
+  border: none;
+  border-radius: 2px;
+  background: color-mix(in srgb, var(--vp-gold) 28%, transparent);
+}
+
+.vp-review-quote-mark:hover {
+  background: color-mix(in srgb, var(--vp-gold) 42%, transparent);
+}
+
+/* The comment shown when hovering a quote mark. */
+.vp-review-tip {
+  position: fixed;
+  z-index: 72;
+  pointer-events: none;
+  max-width: 22rem;
+  padding: 0.4rem 0.55rem;
+  font-size: 0.8rem;
+  line-height: 1.35;
+  color: var(--vp-text);
+  background: var(--vp-surface-2);
+  border: 1px solid var(--vp-border);
+  border-radius: 7px;
+  box-shadow: 0 4px 16px rgb(0 0 0 / 18%);
+  animation: vp-review-fade-in 0.1s var(--vp-ease);
+}
+
+/* Persistent count pill on a section that already has comments; click to view/manage them. */
+.vp-review-badge {
+  position: fixed;
+  z-index: 58;
+  display: inline-flex;
+  gap: 0.2rem;
+  align-items: center;
+  height: 22px;
+  padding: 0 0.45rem;
+  font: inherit;
+  font-size: 0.72rem;
+  font-weight: 600;
+  color: var(--vp-on-accent);
+  background: var(--vp-accent);
+  border: none;
+  border-radius: 11px;
+  cursor: pointer;
+  box-shadow: 0 1px 3px rgb(0 0 0 / 18%);
+}
+
+.vp-review-popover {
+  position: fixed;
+  z-index: 71;
+  width: min(20rem, calc(100vw - 1rem));
+  max-height: 50vh;
+  overflow: auto;
+  padding: 0.6rem 0.7rem;
+  background: var(--vp-surface-2);
+  border: 1px solid var(--vp-border);
+  border-radius: 10px;
+  box-shadow: 0 6px 24px rgb(0 0 0 / 18%);
+}
+
+.vp-review-popover__head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 0.4rem;
+  font-size: 0.8rem;
+  color: var(--vp-muted);
+}
+
+.vp-review-popover__title strong {
+  color: var(--vp-text);
+}
+
+.vp-review-popover__close {
+  display: grid;
+  place-items: center;
+  padding: 0.15rem;
+  color: var(--vp-muted);
+  background: none;
+  border: none;
+  cursor: pointer;
+}
+
+.vp-review-popover__close:hover {
+  color: var(--vp-text);
+}
+
+.vp-review-popover__list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.vp-review-popover__item {
+  display: flex;
+  gap: 0.4rem;
+  align-items: flex-start;
+  justify-content: space-between;
+  padding: 0.35rem 0.45rem;
+  font-size: 0.82rem;
+  color: var(--vp-text);
+  background: var(--vp-bg);
+  border: 1px solid var(--vp-border);
+  border-radius: 7px;
+}
+
+.vp-review-popover__delete {
+  display: grid;
+  flex-shrink: 0;
+  place-items: center;
+  padding: 0.1rem;
+  color: var(--vp-muted);
+  background: none;
+  border: none;
+  cursor: pointer;
+}
+
+.vp-review-popover__delete:hover {
+  color: var(--vp-risk);
+}
+
+.vp-review-popover__text {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+  min-width: 0;
+}
+
+.vp-review-popover__quote {
+  font-size: 0.72rem;
+  font-style: italic;
+  color: var(--vp-muted);
+}
+
+/* Floats next to a text selection so the reviewer can comment on an exact quote. */
+.vp-review-select {
+  position: fixed;
+  z-index: 60;
+  display: inline-flex;
+  gap: 0.3rem;
+  align-items: center;
+  padding: 0.3rem 0.55rem;
+  font: inherit;
+  font-size: 0.78rem;
+  font-weight: 600;
+  color: var(--vp-on-accent);
+  background: var(--vp-accent);
+  border: none;
+  border-radius: 7px;
+  cursor: pointer;
+  box-shadow: 0 2px 8px rgb(0 0 0 / 22%);
+  animation: vp-review-fade-in 0.1s var(--vp-ease);
+}
+
+.vp-review-select:hover {
+  filter: brightness(1.08);
 }
 
 .vp-review-bar {
   position: fixed;
-  z-index: 55;
+  z-index: 70;
   inset: auto 0 0 0;
   display: flex;
   gap: 1rem;
@@ -46,6 +232,17 @@
   align-items: center;
   min-width: 0;
   flex: 1;
+}
+
+.vp-review-bar__iteration {
+  padding: 0.22rem 0.55rem;
+  font-size: 0.74rem;
+  font-weight: 600;
+  color: var(--vp-text);
+  white-space: nowrap;
+  background: var(--vp-surface-2);
+  border: 1px solid var(--vp-border);
+  border-radius: 999px;
 }
 
 .vp-review-bar__note {
@@ -117,7 +314,7 @@
 
 .vp-review-composer {
   position: fixed;
-  z-index: 56;
+  z-index: 71;
   inset: auto 0 3.6rem 0;
   width: min(40rem, calc(100% - 2rem));
   margin: 0 auto;
@@ -211,7 +408,7 @@
 
 .vp-review-done {
   position: fixed;
-  z-index: 55;
+  z-index: 70;
   inset: auto 0 0 0;
   display: flex;
   gap: 0.5rem;

--- a/packages/runtime/components/review/review.css
+++ b/packages/runtime/components/review/review.css
@@ -1,0 +1,241 @@
+/* Interactive review-mode chrome (vplan render --review). All colors are theme.css CSS vars so it
+   tracks light/dark with the rest of the page. Everything here is fixed-position overlay; the plan
+   content underneath is untouched. */
+
+.vp-review-add {
+  position: fixed;
+  z-index: 60;
+  display: grid;
+  place-items: center;
+  width: 30px;
+  height: 30px;
+  padding: 0;
+  color: var(--vp-muted);
+  background: var(--vp-surface);
+  border: 1px solid var(--vp-border);
+  border-radius: 8px;
+  cursor: pointer;
+  box-shadow: 0 1px 3px rgb(0 0 0 / 12%);
+  transition:
+    color 0.12s var(--vp-ease),
+    border-color 0.12s var(--vp-ease);
+}
+
+.vp-review-add:hover {
+  color: var(--vp-accent);
+  border-color: var(--vp-border-strong);
+}
+
+.vp-review-bar {
+  position: fixed;
+  z-index: 55;
+  inset: auto 0 0 0;
+  display: flex;
+  gap: 1rem;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.7rem 1.25rem;
+  background: var(--vp-surface);
+  border-top: 1px solid var(--vp-border);
+  box-shadow: 0 -2px 12px rgb(0 0 0 / 8%);
+}
+
+.vp-review-bar__meta {
+  display: flex;
+  gap: 0.85rem;
+  align-items: center;
+  min-width: 0;
+  flex: 1;
+}
+
+.vp-review-bar__note {
+  flex: 1;
+  max-width: 28rem;
+  min-width: 0;
+  padding: 0.4rem 0.6rem;
+  font: inherit;
+  font-size: 0.85rem;
+  color: var(--vp-text);
+  background: var(--vp-bg);
+  border: 1px solid var(--vp-border);
+  border-radius: 7px;
+}
+
+.vp-review-bar__note:focus {
+  outline: none;
+  border-color: var(--vp-border-strong);
+}
+
+.vp-review-bar__count {
+  font-size: 0.8rem;
+  color: var(--vp-muted);
+  white-space: nowrap;
+}
+
+.vp-review-bar__actions {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.vp-review-decision {
+  display: inline-flex;
+  gap: 0.35rem;
+  align-items: center;
+  padding: 0.4rem 0.8rem;
+  font: inherit;
+  font-size: 0.85rem;
+  font-weight: 550;
+  color: var(--vp-text);
+  background: var(--vp-bg);
+  border: 1px solid var(--vp-border);
+  border-radius: 7px;
+  cursor: pointer;
+  transition:
+    border-color 0.12s var(--vp-ease),
+    background 0.12s var(--vp-ease);
+}
+
+.vp-review-decision:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.vp-review-decision--approve:not(:disabled):hover {
+  color: var(--vp-done);
+  border-color: var(--vp-done);
+}
+
+.vp-review-decision--deny:not(:disabled):hover {
+  color: var(--vp-risk);
+  border-color: var(--vp-risk);
+}
+
+.vp-review-decision--iterate:not(:disabled):hover {
+  color: var(--vp-gold);
+  border-color: var(--vp-gold);
+}
+
+.vp-review-composer {
+  position: fixed;
+  z-index: 56;
+  inset: auto 0 3.6rem 0;
+  width: min(40rem, calc(100% - 2rem));
+  margin: 0 auto;
+  padding: 0.85rem;
+  background: var(--vp-surface-2);
+  border: 1px solid var(--vp-border);
+  border-radius: 10px;
+  box-shadow: 0 6px 24px rgb(0 0 0 / 16%);
+}
+
+.vp-review-composer__head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 0.5rem;
+}
+
+.vp-review-composer__target {
+  font-size: 0.85rem;
+  color: var(--vp-muted);
+}
+
+.vp-review-composer__target strong {
+  color: var(--vp-text);
+}
+
+.vp-review-composer__close {
+  display: grid;
+  place-items: center;
+  padding: 0.2rem;
+  color: var(--vp-muted);
+  background: none;
+  border: none;
+  cursor: pointer;
+}
+
+.vp-review-composer__close:hover {
+  color: var(--vp-text);
+}
+
+.vp-review-composer__input {
+  width: 100%;
+  padding: 0.5rem 0.6rem;
+  font: inherit;
+  font-size: 0.9rem;
+  color: var(--vp-text);
+  background: var(--vp-bg);
+  border: 1px solid var(--vp-border);
+  border-radius: 7px;
+  resize: vertical;
+}
+
+.vp-review-composer__input:focus {
+  outline: none;
+  border-color: var(--vp-border-strong);
+}
+
+.vp-review-composer__actions {
+  display: flex;
+  gap: 0.5rem;
+  justify-content: flex-end;
+  margin-top: 0.6rem;
+}
+
+.vp-review-btn {
+  padding: 0.4rem 0.8rem;
+  font: inherit;
+  font-size: 0.85rem;
+  font-weight: 550;
+  color: var(--vp-text);
+  background: var(--vp-bg);
+  border: 1px solid var(--vp-border);
+  border-radius: 7px;
+  cursor: pointer;
+}
+
+.vp-review-btn:hover {
+  border-color: var(--vp-border-strong);
+}
+
+.vp-review-btn--primary {
+  color: var(--vp-on-accent);
+  background: var(--vp-accent);
+  border-color: var(--vp-accent);
+}
+
+.vp-review-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.vp-review-done {
+  position: fixed;
+  z-index: 55;
+  inset: auto 0 0 0;
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  justify-content: center;
+  padding: 0.9rem 1.25rem;
+  font-size: 0.9rem;
+  color: var(--vp-text);
+  background: var(--vp-surface);
+  border-top: 1px solid var(--vp-border);
+}
+
+.vp-review-done[data-decision="approve"] {
+  color: var(--vp-done);
+}
+
+.vp-review-done[data-decision="deny"] {
+  color: var(--vp-risk);
+}
+
+.vp-review-done[data-decision="iterate"] {
+  color: var(--vp-gold);
+}
+
+.vp-review-done strong {
+  text-transform: capitalize;
+}

--- a/packages/runtime/tests/review.test.tsx
+++ b/packages/runtime/tests/review.test.tsx
@@ -1,0 +1,55 @@
+import { renderToStaticMarkup } from 'react-dom/server'
+import { afterEach, describe, expect, it } from 'vitest'
+import { isReviewMode } from '../components/review/feedback.js'
+import { DecisionBar } from '../components/review/DecisionBar.js'
+import { ReviewLayer } from '../components/review/ReviewLayer.js'
+
+function setReviewMode(on: boolean): void {
+  ;(globalThis as { __VP_REVIEW__?: boolean }).__VP_REVIEW__ = on || undefined
+}
+
+afterEach(() => setReviewMode(false))
+
+describe('ReviewLayer gating', () => {
+  it('renders nothing outside review mode (edge)', () => {
+    setReviewMode(false)
+    expect(renderToStaticMarkup(<ReviewLayer />)).toBe('')
+  })
+
+  it('mounts the decision bar in review mode (golden)', () => {
+    setReviewMode(true)
+    const html = renderToStaticMarkup(<ReviewLayer />)
+    expect(html).toContain('vp-review-bar')
+    expect(html).toContain('Approve')
+    expect(html).toContain('Deny')
+    expect(html).toContain('Iterate')
+  })
+})
+
+describe('isReviewMode', () => {
+  it('reflects the injected flag (golden + edge)', () => {
+    setReviewMode(false)
+    expect(isReviewMode()).toBe(false)
+    setReviewMode(true)
+    expect(isReviewMode()).toBe(true)
+  })
+})
+
+describe('DecisionBar Iterate gating', () => {
+  const noop = () => {}
+
+  it('disables Iterate with no comments and no note (edge)', () => {
+    const html = renderToStaticMarkup(
+      <DecisionBar commentCount={0} note='' onNote={noop} onDecide={noop} busy={false} />,
+    )
+    // Only the Iterate button is disabled; Deny and Approve are always actionable when not busy.
+    expect((html.match(/disabled=""/g) || []).length).toBe(1)
+  })
+
+  it('enables Iterate once a comment exists (golden)', () => {
+    const html = renderToStaticMarkup(
+      <DecisionBar commentCount={1} note='' onNote={noop} onDecide={noop} busy={false} />,
+    )
+    expect((html.match(/disabled=""/g) || []).length).toBe(0)
+  })
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -202,6 +202,9 @@ importers:
       '@visualplan/runtime':
         specifier: workspace:*
         version: link:../runtime
+      playwright-core:
+        specifier: ^1.61.0
+        version: 1.61.0
 
   packages/compile:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -135,6 +135,9 @@ importers:
       material-icon-theme:
         specifier: ^5.35.0
         version: 5.35.0
+      ms:
+        specifier: ^2.1.3
+        version: 2.1.3
       open:
         specifier: ^11.0.0
         version: 11.0.0
@@ -187,6 +190,9 @@ importers:
       '@types/hast':
         specifier: ^3.0.4
         version: 3.0.4
+      '@types/ms':
+        specifier: ^2.1.0
+        version: 2.1.0
       '@visualplan/compile':
         specifier: workspace:*
         version: link:../compile

--- a/skills/visual-plan/SKILL.md
+++ b/skills/visual-plan/SKILL.md
@@ -46,7 +46,11 @@ and tables, with prose only connecting the visuals, not carrying the plan itself
      (`--iteration N`) incremented so the bar shows the round; repeat until Approve or Deny.
    - **Deny** -> stop and reconsider; do not proceed.
 
-   Reach for `--review` whenever the user wants to actively shape or approve the plan, not just see it.
+   **Strongly prefer `--review` as the way to iterate on any non-trivial plan with the user.** It is
+   the default loop for refining a plan together: the targeted comments drive sharper revisions than
+   back-and-forth chat, and the loop ends in an explicit Approve so you know when it is settled. Fall
+   back to a plain render (or `--watch`) only when the user just wants to look at the plan, not shape
+   or decide on it.
 
 Run `vplan components` anytime for the exact prop signatures.
 

--- a/skills/visual-plan/SKILL.md
+++ b/skills/visual-plan/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: visual-plan
-description: Always use when planning anything non-trivial (an implementation, design, refactor, or migration), as the default and better way to show your plan visually instead of as a wall of text, especially in plan mode. Authors the plan as an MDX file and renders it to a self-contained HTML page with the `vplan` CLI, using a fixed component vocabulary. Also use when the user says "make a visual plan", "render this plan", "show me the plan", or asks for a plan with diagrams/charts. Skip only for trivial one-step changes or prose-only notes.
+description: Always use when planning anything non-trivial (an implementation, design, refactor, or migration), as the default and better way to show your plan visually instead of as a wall of text, especially in plan mode. Authors the plan as an MDX file and renders it to a self-contained HTML page with the `vplan` CLI, using a fixed component vocabulary. Also use when the user says "make a visual plan", "render this plan", "show me the plan", or asks for a plan with diagrams/charts, and when they want to review, approve, or sign off on a plan or give structured feedback on it ("let me review the plan", "I want to give feedback", "get my approval") via `vplan render --review`. Skip only for trivial one-step changes or prose-only notes.
 ---
 
 # Visual Plan
@@ -35,14 +35,18 @@ and tables, with prose only connecting the visuals, not carrying the plan itself
    **Do not pass `--no-open`.** A plan the user never sees defeats the tool. Only suppress the
    browser when the user has explicitly asked for the HTML file alone (e.g. for CI or a headless
    run); a plan being generated for the user to read is never that case.
-4. To collect a decision on the plan, render it with `vplan render --review <file>.mdx`. This opens
-   the plan with a feedback layer (the user comments on sections and clicks Approve / Deny / Iterate),
-   **blocks** until they submit, then prints their decision and comments and exits: approve 0, deny 1,
-   iterate 2, timeout 3 (`--timeout`, default 15m; a closed tab counts as deny). Read the printed
-   feedback and act on it: on Iterate, revise the plan using the comments and review again; on Deny,
-   stop and reconsider. Use this when you want explicit sign-off, not just to show the plan. When you
-   re-review after revising, pass `-i N` (`--iteration N`) so the review bar shows the user which
-   revision they are looking at (increment it each round).
+4. **To get the user's decision on the plan** (a sign-off, not just a viewing), render with
+   `vplan render --review <file>.mdx`. It opens the plan with a feedback layer where the user comments
+   on whole sections or on selected text, then clicks Approve / Deny / Iterate. It **blocks** until
+   they submit, prints the decision and comments to stdout, and exits: approve 0, deny 1, iterate 2,
+   timeout 3 (`--timeout`, default 15m; closing the tab counts as deny). It is a long-running
+   foreground server, so run it in the background. Then act on the printed feedback:
+   - **Approve** -> proceed with the plan as written.
+   - **Iterate** -> revise the plan addressing each comment, then review again with `-i N`
+     (`--iteration N`) incremented so the bar shows the round; repeat until Approve or Deny.
+   - **Deny** -> stop and reconsider; do not proceed.
+
+   Reach for `--review` whenever the user wants to actively shape or approve the plan, not just see it.
 
 Run `vplan components` anytime for the exact prop signatures.
 

--- a/skills/visual-plan/SKILL.md
+++ b/skills/visual-plan/SKILL.md
@@ -35,6 +35,12 @@ and tables, with prose only connecting the visuals, not carrying the plan itself
    **Do not pass `--no-open`.** A plan the user never sees defeats the tool. Only suppress the
    browser when the user has explicitly asked for the HTML file alone (e.g. for CI or a headless
    run); a plan being generated for the user to read is never that case.
+4. To collect a decision on the plan, render it with `vplan render --review <file>.mdx`. This opens
+   the plan with a feedback layer (the user comments on sections and clicks Approve / Deny / Iterate),
+   **blocks** until they submit, then prints their decision and comments and exits: approve 0, deny 1,
+   iterate 2, timeout 3 (`--timeout`, default 15m; a closed tab counts as deny). Read the printed
+   feedback and act on it: on Iterate, revise the plan using the comments and review again; on Deny,
+   stop and reconsider. Use this when you want explicit sign-off, not just to show the plan.
 
 Run `vplan components` anytime for the exact prop signatures.
 

--- a/skills/visual-plan/SKILL.md
+++ b/skills/visual-plan/SKILL.md
@@ -40,7 +40,9 @@ and tables, with prose only connecting the visuals, not carrying the plan itself
    **blocks** until they submit, then prints their decision and comments and exits: approve 0, deny 1,
    iterate 2, timeout 3 (`--timeout`, default 15m; a closed tab counts as deny). Read the printed
    feedback and act on it: on Iterate, revise the plan using the comments and review again; on Deny,
-   stop and reconsider. Use this when you want explicit sign-off, not just to show the plan.
+   stop and reconsider. Use this when you want explicit sign-off, not just to show the plan. When you
+   re-review after revising, pass `-i N` (`--iteration N`) so the review bar shows the user which
+   revision they are looking at (increment it each round).
 
 Run `vplan components` anytime for the exact prop signatures.
 


### PR DESCRIPTION
## What

Add an interactive review mode to the CLI: `vplan render --review` opens the plan in the browser, the reviewer comments on sections (or selected text) and clicks Approve / Deny / Iterate, and the CLI blocks until then, prints the feedback to stdout, and exits with a decision-mapped code. This closes the loop so an agent can get explicit sign-off on a plan, not just show it.

## How

- **Transport** reuses the share-button pattern: the CLI serves a frozen snapshot, injects `__VP_REVIEW__`, and exposes endpoints. A held-open `/__vp_alive` connection makes a real tab close resolve reliably as Deny via server-side disconnect detection, an unload-time `sendBeacon` is dropped on a real close (only navigation survives it), which a manual test caught.
- **Runtime UI** overlays the plan without mutating its DOM: a stable full-width Y-band hover highlight per section, persistent comment badges + a view/delete popover, text-selection comments anchored to the exact quote (with persistent marks and hover tooltips), and the decision bar. Outcomes map to exit codes approve 0 / deny 1 / iterate 2 / timeout 3; `--timeout` (default 15m) bounds the wait and `-i/--iteration N` shows a revision chip. The review server defaults to the `--watch` port (9140).

## Verification

- [x] `pnpm lint` passes (via `pnpm check`)
- [x] `pnpm format` reports no changes (via `pnpm check`)
- [x] `pnpm typecheck` passes
- [x] `pnpm build` succeeds
- [x] `pnpm test` passes (265 tests)

Coverage includes reliable node-level tests of the connection-drop Deny path and a Playwright browser e2e (gated; skips where no chromium is installed). The full UI was also driven end-to-end with headless Playwright per behavior and validated manually (the reviewer approved the test plan through the tool itself).

## Notes

Adds `ms` (prod) and `playwright-core` (dev) dependencies; the browser e2e skips cleanly in CI where no browser is present.
