### PR TITLE
feat(review): answerable Questions, blue glow, finer sections

### DIFF
--- a/packages/cli/src/build/compile.ts
+++ b/packages/cli/src/build/compile.ts
@@ -487,7 +487,7 @@ export async function startReviewServer(
     settled = true
     resolveFeedback(value)
   }
-  const state: ReviewState = { draft: { decision: 'deny', comments: [] } }
+  const state: ReviewState = { draft: { decision: 'deny', comments: [], answers: [] } }
   const config = baseConfig(paths, source, { theme })
   // Use the same default port as the `--watch` dev server (Vite auto-increments if it is taken).
   const server = await createServer({

--- a/packages/cli/src/review/format.ts
+++ b/packages/cli/src/review/format.ts
@@ -28,6 +28,10 @@ export function formatFeedback(feedback: Feedback): string {
     lines.push('', `Comment on "${comment.section}":`, indent(comment.body))
   }
 
+  for (const answer of feedback.answers) {
+    lines.push('', `Answer to "${answer.question}":`, indent(answer.answer))
+  }
+
   if (feedback.note) {
     lines.push('', 'General note:', indent(feedback.note))
   }

--- a/packages/cli/tests/review.test.ts
+++ b/packages/cli/tests/review.test.ts
@@ -11,21 +11,37 @@ function feedbackUrl(server: ReviewServer): string {
 }
 
 describe('formatFeedback', () => {
-  it('renders decision, comments, and note as readable text (golden)', () => {
+  it('renders decision, comments, answers, and note as readable text (golden)', () => {
     const text = formatFeedback({
       decision: 'iterate',
       comments: [{ section: 'Phase 2', body: 'fix this' }],
+      answers: [{ question: 'Fail open or closed?', answer: 'Fail closed' }],
       note: 'overall good',
     })
     expect(text).toContain('DECISION: iterate')
     expect(text).toContain('Comment on "Phase 2":')
     expect(text).toContain('  fix this')
+    expect(text).toContain('Answer to "Fail open or closed?":')
+    expect(text).toContain('  Fail closed')
     expect(text).toContain('General note:')
     expect(text).toContain('  overall good')
   })
 
-  it('renders a bare approve with no comments or note (edge)', () => {
-    expect(formatFeedback({ decision: 'approve', comments: [] })).toBe('DECISION: approve')
+  it('orders comments before answers before the note (golden)', () => {
+    const text = formatFeedback({
+      decision: 'iterate',
+      comments: [{ section: 'Phase 1', body: 'c' }],
+      answers: [{ question: 'q', answer: 'a' }],
+      note: 'n',
+    })
+    expect(text.indexOf('Comment on')).toBeLessThan(text.indexOf('Answer to'))
+    expect(text.indexOf('Answer to')).toBeLessThan(text.indexOf('General note'))
+  })
+
+  it('renders a bare approve with no comments, answers, or note (edge)', () => {
+    expect(formatFeedback({ decision: 'approve', comments: [], answers: [] })).toBe(
+      'DECISION: approve',
+    )
   })
 })
 
@@ -94,7 +110,11 @@ describe('startReviewServer /__vp_feedback', () => {
       method: 'POST',
       body: JSON.stringify({ decision: 'approve' }),
     })
-    await expect(server.feedback).resolves.toEqual({ decision: 'approve', comments: [] })
+    await expect(server.feedback).resolves.toEqual({
+      decision: 'approve',
+      comments: [],
+      answers: [],
+    })
   }, 60_000)
 
   it('rejects an invalid body with 400 and leaves feedback pending (error)', async () => {
@@ -133,12 +153,20 @@ describe('startReviewServer tab-close (keepalive drop)', () => {
   it('resolves a bare Deny when the connection drops with no draft (golden)', async () => {
     server = await startReviewServer(PLAN)
     await dropAfterConnecting(server)
-    await expect(server.feedback).resolves.toEqual({ decision: 'deny', comments: [] })
+    await expect(server.feedback).resolves.toEqual({
+      decision: 'deny',
+      comments: [],
+      answers: [],
+    })
   }, 60_000)
 
   it('carries the synced draft comments into the tab-close Deny (golden)', async () => {
     server = await startReviewServer(PLAN)
-    const draft = { decision: 'deny', comments: [{ section: 'Phase 1', body: 'unfinished' }] }
+    const draft = {
+      decision: 'deny',
+      comments: [{ section: 'Phase 1', body: 'unfinished' }],
+      answers: [],
+    }
     await fetch(new URL('/__vp_draft', server.url), { method: 'POST', body: JSON.stringify(draft) })
     await dropAfterConnecting(server)
     await expect(server.feedback).resolves.toEqual(draft)
@@ -152,7 +180,11 @@ describe('startReviewServer tab-close (keepalive drop)', () => {
     })
     await dropAfterConnecting(server)
     // The POST settled first; the drop must not override it.
-    await expect(server.feedback).resolves.toEqual({ decision: 'approve', comments: [] })
+    await expect(server.feedback).resolves.toEqual({
+      decision: 'approve',
+      comments: [],
+      answers: [],
+    })
   }, 60_000)
 
   it('closes promptly while the keepalive is still open, so the CLI never hangs (regression)', async () => {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -23,19 +23,28 @@ export const reviewCommentSchema = z.object({
   body: z.string().min(1),
 })
 
+/** A direct answer to one of a plan's `Questions`, keyed by the question text the reviewer answered. */
+export const reviewAnswerSchema = z.object({
+  question: z.string().min(1),
+  answer: z.string().min(1),
+})
+
 /**
  * The feedback payload the review page POSTs to the CLI's `/__vp_feedback` endpoint. Isomorphic so
  * the page (which constructs it) and the CLI (which validates it) share one contract and cannot
- * drift; `comments` defaults to empty because Approve and Deny may carry none.
+ * drift; `comments` and `answers` default to empty because Approve and Deny may carry neither.
+ * `answers` are distinct from `comments`: they are direct responses to the plan's `Questions`.
  */
 export const feedbackSchema = z.object({
   decision: z.enum(REVIEW_DECISION_VALUES),
   comments: z.array(reviewCommentSchema).default([]),
+  answers: z.array(reviewAnswerSchema).default([]),
   note: z.string().optional(),
 })
 
 export type ReviewDecision = (typeof REVIEW_DECISION_VALUES)[number]
 export type ReviewComment = z.infer<typeof reviewCommentSchema>
+export type ReviewAnswer = z.infer<typeof reviewAnswerSchema>
 export type Feedback = z.infer<typeof feedbackSchema>
 
 export const STATUS_VALUES = ['planned', 'active', 'done'] as const

--- a/packages/core/tests/feedback.test.ts
+++ b/packages/core/tests/feedback.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest'
+import { feedbackSchema, reviewAnswerSchema } from '../src/index.js'
+
+describe('reviewAnswerSchema', () => {
+  it('accepts a question paired with an answer (golden)', () => {
+    const answer = { question: 'Fail open or closed?', answer: 'Fail closed' }
+    expect(reviewAnswerSchema.parse(answer)).toEqual(answer)
+  })
+
+  it('rejects an empty question or empty answer (error)', () => {
+    expect(() => reviewAnswerSchema.parse({ question: '', answer: 'x' })).toThrow()
+    expect(() => reviewAnswerSchema.parse({ question: 'x', answer: '' })).toThrow()
+  })
+})
+
+describe('feedbackSchema answers', () => {
+  it('defaults answers to empty when omitted (edge)', () => {
+    expect(feedbackSchema.parse({ decision: 'approve' })).toEqual({
+      decision: 'approve',
+      comments: [],
+      answers: [],
+    })
+  })
+
+  it('keeps supplied answers alongside comments (golden)', () => {
+    const parsed = feedbackSchema.parse({
+      decision: 'iterate',
+      comments: [{ section: 'Phase 1', body: 'tweak' }],
+      answers: [{ question: 'TTL ok?', answer: 'Yes, 15m' }],
+    })
+    expect(parsed.answers).toEqual([{ question: 'TTL ok?', answer: 'Yes, 15m' }])
+  })
+})

--- a/packages/runtime/AGENTS.md
+++ b/packages/runtime/AGENTS.md
@@ -18,12 +18,20 @@ the root AGENTS.md for why Vite is configured without `@vitejs/plugin-react`.
   button self-hides when no `__VP_SHARE__` was injected (the API's `enableSharing: false` default).
   It also mounts `<ReviewLayer />`, which self-hides unless `__VP_REVIEW__` was injected.
 - `components/review/` is the interactive review UI (`vplan render --review`), gated on the injected
-  `__VP_REVIEW__` global (mirroring how `ShareButton` reads `__VP_SHARE__`), so it adds nothing to a
-  normal render. `ReviewLayer` owns the session state and overlays the plan with fixed-position
-  chrome only (the plan DOM is never mutated): `SectionComments` tracks the hovered major section (a
-  `.vp-phase` or top-level `h2`, found by walking the DOM) and floats one comment button beside it;
-  `CommentModal` is the bottom composer; `DecisionBar` submits Approve/Deny/Iterate. `feedback.ts`
-  POSTs an explicit decision `{decision, comments, note}` (shape = `@visualplan/core` `feedbackSchema`)
+  `__VP_REVIEW__` global (mirroring how `ShareButton` reads `__VP_SHARE__`), so the heavy review
+  chrome adds nothing to a normal render (`Questions` does import the tiny `isReviewMode` +
+  `ReviewAnswers` leaf modules, which are negligible). `ReviewLayer` owns the session state and
+  overlays the plan with fixed-position chrome only (the plan DOM is never mutated):
+  `SectionComments` tracks the hovered section and floats one comment button beside it. A section
+  starts at any `.vp-phase`, heading (`h1`-`h3`), or standalone block (`.vp-callout`, `.vp-mermaid`,
+  `.vp-chart`, `.vp-filetree`, `.vp-matrix-wrap`, `.vp-compare`, `.vp-checklist`, `.vp-stat`,
+  `.vp-questions`) that is a **direct** child of `.vp-main`, so loose top-level intro content does not
+  collapse into one oversized section while blocks nested inside a `<Phase>` stay part of it.
+  `CommentModal` is the bottom composer; `DecisionBar` submits Approve/Deny/Iterate. In review mode
+  `Questions` is **directly answerable**: each row renders an answer field whose value flows up via
+  the `ReviewAnswers` context (provided in `Layout`, shared by `Questions` and `ReviewSession`) into
+  the feedback's distinct `answers` channel. `feedback.ts` POSTs an explicit decision
+  `{decision, comments, answers, note}` (shape = `@visualplan/core` `feedbackSchema`)
   to `/__vp_feedback`. **Tab-close handling is server-detected, not beacon-based:** `ReviewLayer` holds
   a `/__vp_alive` connection open and POSTs `/__vp_draft` whenever comments/note change; when the tab
   closes the connection drops and the CLI resolves Deny with that draft. This replaced an unload
@@ -173,9 +181,12 @@ page. The rules below are deliberate; changing them needs a reason.
   CSS vars so dark mode is correct.
 - **Callout colors are semantic and distinct:** note (blue), tip (green), decision (purple), risk
   (red), warn (yellow). Each must stay visually different. `tip` green is its own `--vp-tip*` token
-  set, not the done/add status green, so the two can diverge. `Questions` is a **neutral** card
-  (surface tint) with a blue accent on its icon and numbers only, so it stays distinct from the
-  blue `note` callout.
+  set, not the done/add status green, so the two can diverge. `Questions` is **deliberately not
+  neutral**: it is a blue-tinted card with an always-on humming glow (`vp-questions-hum`, paused
+  under `prefers-reduced-motion`) so it reads as the panel to act on (and is directly answerable in
+  review mode). This is an intentional exception to the otherwise-monochrome chrome; it sits close to
+  the blue `note` callout on purpose. Earlier it was a neutral card kept distinct from `note`; that
+  was changed by request.
 - **Visual verification:** `playwright-core` (devDep) drives the system Chrome to screenshot a
   rendered `.plan.html` in light and dark. Re-check both schemes after any theme change.
   Screenshot pages that contain a `<Chart>` at a **fixed tall viewport, not `fullPage`**:

--- a/packages/runtime/Layout.tsx
+++ b/packages/runtime/Layout.tsx
@@ -1,4 +1,5 @@
 import { type ReactNode, useEffect } from 'react'
+import { ReviewAnswersProvider } from './components/review/ReviewAnswers.js'
 import { ReviewLayer } from './components/review/ReviewLayer.js'
 import { ShareButton } from './components/ShareButton.js'
 import { ThemeToggle } from './components/ThemeToggle.js'
@@ -17,11 +18,13 @@ export function Layout({ children }: { children: ReactNode }) {
   }, [])
 
   return (
-    <div className='vp-shell'>
-      <ShareButton />
-      {!isThemeLocked() && <ThemeToggle />}
-      <main className='vp-main'>{children}</main>
-      <ReviewLayer />
-    </div>
+    <ReviewAnswersProvider>
+      <div className='vp-shell'>
+        <ShareButton />
+        {!isThemeLocked() && <ThemeToggle />}
+        <main className='vp-main'>{children}</main>
+        <ReviewLayer />
+      </div>
+    </ReviewAnswersProvider>
   )
 }

--- a/packages/runtime/components/Questions.tsx
+++ b/packages/runtime/components/Questions.tsx
@@ -1,4 +1,6 @@
 import { questionsSchema } from '@visualplan/core'
+import { isReviewMode } from './review/feedback.js'
+import { useQuestionAnswers } from './review/ReviewAnswers.js'
 import { decodeJson, validateProps } from './validate.js'
 
 interface QuestionsProps {
@@ -6,12 +8,15 @@ interface QuestionsProps {
   items: unknown
 }
 
-/** Open questions for the reader to resolve before building, as a highlighted panel. */
+/** Open questions for the reader to resolve before building, as a highlighted panel. In a review
+ * session each question becomes directly answerable; otherwise it is a static numbered list. */
 export function Questions(props: QuestionsProps) {
   const { title, items } = validateProps('Questions', questionsSchema, {
     ...props,
     items: decodeJson(props.items),
   })
+  const answers = useQuestionAnswers()
+  const interactive = isReviewMode() && answers !== null
   return (
     <section className='vp-questions'>
       <div className='vp-questions__title'>{title}</div>
@@ -21,7 +26,19 @@ export function Questions(props: QuestionsProps) {
             <span className='vp-questions__num' aria-hidden='true'>
               {index + 1}
             </span>
-            <span className='vp-questions__text'>{item}</span>
+            <div className='vp-questions__body'>
+              <span className='vp-questions__text'>{item}</span>
+              {interactive && (
+                <textarea
+                  className='vp-questions__answer'
+                  rows={1}
+                  placeholder='Answer this question…'
+                  aria-label={`Answer: ${item}`}
+                  value={answers.answers.get(item) ?? ''}
+                  onChange={event => answers.setAnswer(item, event.target.value)}
+                />
+              )}
+            </div>
           </li>
         ))}
       </ol>

--- a/packages/runtime/components/review/DecisionBar.tsx
+++ b/packages/runtime/components/review/DecisionBar.tsx
@@ -2,24 +2,34 @@ import { IconCheck, IconRefresh, IconX } from '@tabler/icons-react'
 import type { ReviewDecision } from '@visualplan/core'
 import { reviewIteration } from './feedback.js'
 
+/** A compact "2 comments, 1 answer" tally for the bar, or a prompt when nothing is staged yet. */
+function feedbackSummary(commentCount: number, answerCount: number): string {
+  const parts: string[] = []
+  if (commentCount > 0) parts.push(`${commentCount} comment${commentCount === 1 ? '' : 's'}`)
+  if (answerCount > 0) parts.push(`${answerCount} answer${answerCount === 1 ? '' : 's'}`)
+  return parts.length === 0 ? 'No feedback yet' : parts.join(', ')
+}
+
 /**
- * The sticky decision bar. Approve and Deny always submit (comments optional); Iterate requires at
- * least one comment or a general note, since "revise with feedback" needs feedback to act on.
+ * The sticky decision bar. Approve and Deny always submit (feedback optional); Iterate requires at
+ * least one comment, answer, or a general note, since "revise with feedback" needs feedback to act on.
  */
 export function DecisionBar({
   commentCount,
+  answerCount,
   note,
   onNote,
   onDecide,
   busy,
 }: {
   commentCount: number
+  answerCount: number
   note: string
   onNote: (note: string) => void
   onDecide: (decision: ReviewDecision) => void
   busy: boolean
 }) {
-  const canIterate = commentCount > 0 || note.trim().length > 0
+  const canIterate = commentCount > 0 || answerCount > 0 || note.trim().length > 0
   const iteration = reviewIteration()
 
   return (
@@ -35,11 +45,7 @@ export function DecisionBar({
           onChange={event => onNote(event.target.value)}
           aria-label='Optional overall note'
         />
-        <span className='vp-review-bar__count'>
-          {commentCount === 0
-            ? 'No comments yet'
-            : `${commentCount} comment${commentCount === 1 ? '' : 's'}`}
-        </span>
+        <span className='vp-review-bar__count'>{feedbackSummary(commentCount, answerCount)}</span>
       </div>
       <div className='vp-review-bar__actions'>
         <button

--- a/packages/runtime/components/review/ReviewAnswers.tsx
+++ b/packages/runtime/components/review/ReviewAnswers.tsx
@@ -1,0 +1,33 @@
+import { createContext, type ReactNode, useContext, useMemo, useState } from 'react'
+
+/** Answers the reviewer typed into the plan's `Questions`, keyed by the question text. */
+interface ReviewAnswersValue {
+  answers: Map<string, string>
+  setAnswer: (question: string, answer: string) => void
+}
+
+/**
+ * Shared answer state lifted above both the inline `Questions` (which write answers) and the
+ * `ReviewSession` (which folds them into the feedback payload). A leaf module with no dependency on
+ * `ReviewLayer`, so importing it from `Questions` cannot create a cycle and adds ~nothing to a
+ * normal render. Outside review mode it simply holds an empty map nobody reads.
+ */
+const ReviewAnswersContext = createContext<ReviewAnswersValue | null>(null)
+
+export function ReviewAnswersProvider({ children }: { children: ReactNode }) {
+  const [answers, setAnswers] = useState<Map<string, string>>(() => new Map())
+  // A fresh Map per write so reference-based effect deps in ReviewSession fire on every keystroke.
+  const value = useMemo<ReviewAnswersValue>(
+    () => ({
+      answers,
+      setAnswer: (question, answer) => setAnswers(prev => new Map(prev).set(question, answer)),
+    }),
+    [answers],
+  )
+  return <ReviewAnswersContext.Provider value={value}>{children}</ReviewAnswersContext.Provider>
+}
+
+/** Read the shared answer state. Returns null when no provider is mounted (e.g. a unit test). */
+export function useQuestionAnswers(): ReviewAnswersValue | null {
+  return useContext(ReviewAnswersContext)
+}

--- a/packages/runtime/components/review/ReviewLayer.tsx
+++ b/packages/runtime/components/review/ReviewLayer.tsx
@@ -1,10 +1,11 @@
-import type { Feedback, ReviewComment, ReviewDecision } from '@visualplan/core'
+import type { Feedback, ReviewAnswer, ReviewComment, ReviewDecision } from '@visualplan/core'
 import { IconCheck, IconMessagePlus } from '@tabler/icons-react'
 import { useEffect, useRef, useState } from 'react'
 import { CommentModal } from './CommentModal.js'
 import { CommentsPopover } from './CommentsPopover.js'
 import { DecisionBar } from './DecisionBar.js'
 import { isReviewMode, openKeepalive, postDraft, postFeedback } from './feedback.js'
+import { useQuestionAnswers } from './ReviewAnswers.js'
 import {
   type Section,
   sectionAt,
@@ -32,6 +33,17 @@ interface CommentTarget {
   range?: Range
 }
 
+/** Turn the answer map into the feedback payload, dropping questions left blank. */
+function collectAnswers(answers: Map<string, string> | undefined): ReviewAnswer[] {
+  if (!answers) return []
+  const result: ReviewAnswer[] = []
+  for (const [question, answer] of answers) {
+    const trimmed = answer.trim()
+    if (trimmed) result.push({ question, answer: trimmed })
+  }
+  return result
+}
+
 /** Mounts the interactive review UI, but only when the CLI started the page in review mode. */
 export function ReviewLayer() {
   if (!isReviewMode()) return null
@@ -53,6 +65,7 @@ function ReviewSession() {
 
   const { sections, hoveredIndex } = useReviewSections(submitted === null)
   const { selection, clear: clearSelection } = useTextSelection(submitted === null)
+  const questionAnswers = useQuestionAnswers()
 
   // A selection comment is sent under its quote so the agent can locate the exact text; a section
   // comment is sent under the section label.
@@ -60,6 +73,9 @@ function ReviewSession() {
     section: c.quote ?? c.label,
     body: c.body,
   }))
+  // Answered questions (those with non-blank text) ride the distinct `answers` channel, keyed by the
+  // question so the agent maps each back to the plan's `Questions`.
+  const payloadAnswers: ReviewAnswer[] = collectAnswers(questionAnswers?.answers)
   const commentCounts = new Map<number, number>()
   for (const comment of comments) {
     commentCounts.set(comment.sectionIndex, (commentCounts.get(comment.sectionIndex) ?? 0) + 1)
@@ -72,14 +88,20 @@ function ReviewSession() {
     return () => connection.abort()
   }, [])
 
-  // Keep the server's Deny-on-close payload current, so a tab-close Deny still carries the comments.
-  // Build the payload from `comments` inside the effect so it runs only when the state actually changes.
+  // Keep the server's Deny-on-close payload current, so a tab-close Deny still carries the comments
+  // and answers. Build the payload inside the effect so it runs only when the state actually changes.
+  const answersMap = questionAnswers?.answers
   useEffect(() => {
     if (!submitted) {
       const draft = comments.map(c => ({ section: c.quote ?? c.label, body: c.body }))
-      postDraft({ decision: 'deny', comments: draft, note: note.trim() || undefined })
+      postDraft({
+        decision: 'deny',
+        comments: draft,
+        answers: collectAnswers(answersMap),
+        note: note.trim() || undefined,
+      })
     }
-  }, [comments, note, submitted])
+  }, [comments, note, answersMap, submitted])
 
   // Warn before leaving while undecided; the actual Deny is handled server-side via the dropped
   // keepalive, so this prompt is purely a courtesy. It reads the latest `submitted` via a ref.
@@ -136,6 +158,7 @@ function ReviewSession() {
     const feedback: Feedback = {
       decision,
       comments: payloadComments,
+      answers: payloadAnswers,
       note: note.trim() || undefined,
     }
     setBusy(true)
@@ -252,6 +275,7 @@ function ReviewSession() {
       )}
       <DecisionBar
         commentCount={comments.length}
+        answerCount={payloadAnswers.length}
         note={note}
         onNote={setNote}
         onDecide={decide}

--- a/packages/runtime/components/review/SectionComments.tsx
+++ b/packages/runtime/components/review/SectionComments.tsx
@@ -1,33 +1,62 @@
 import { IconMessage2, IconMessagePlus } from '@tabler/icons-react'
 import { Fragment, useEffect, useState } from 'react'
 
-/** A major section the reviewer can comment on: a `Phase` or a top-level `# / ## heading`. */
+/** A section the reviewer can comment on: a `Phase`, a heading, or a standalone block. */
 export interface Section {
   /** Document-order index, the stable key for comments (labels can repeat). */
   index: number
   label: string
-  /** The section's anchor (the phase or heading element). */
+  /** The section's anchor (the phase, heading, or block element). */
   element: Element
   /** The last top-level element this section owns (the one before the next section), so the
    * highlight can wrap the actual content rather than the empty space up to the next section. */
   lastElement: Element
 }
 
-/** Derive a human label the agent can map back to the MDX: a Phase's title or the heading's text. */
+/** What starts a commentable section: a phase, any heading, or a standalone block component. Only
+ * direct children of `.vp-main` are tested, so a block nested inside a `<Phase>` stays part of that
+ * phase; this splits up the loose top-level content (intro prose, a diagram, a callout) that would
+ * otherwise collapse into one oversized first section. `.vp-matrix-wrap` is the Matrix's scroll
+ * wrapper (its real top-level element). */
+const SECTION_START_SELECTOR =
+  '.vp-phase, h1, h2, h3, .vp-callout, .vp-mermaid, .vp-chart, .vp-filetree, .vp-matrix-wrap, .vp-compare, .vp-checklist, .vp-stat, .vp-questions'
+
+/** Friendly labels for blocks with no heading text of their own, by the class that identifies each. */
+const BLOCK_LABELS: ReadonlyArray<[string, string]> = [
+  ['.vp-mermaid', 'Diagram'],
+  ['.vp-filetree', 'File changes'],
+  ['.vp-matrix-wrap', 'Comparison'],
+  ['.vp-compare', 'Comparison'],
+]
+
+/** Derive a human label the agent can map back to the MDX: a Phase/heading's text, a block's own
+ * title, a friendly block name, or a short snippet of its content as a last resort. */
 function sectionLabel(element: Element): string {
   if (element.classList.contains('vp-phase')) {
     return element.querySelector('.vp-phase__title')?.textContent?.trim() || 'Phase'
   }
-  return element.textContent?.trim() || 'Section'
+  if (/^H[1-6]$/.test(element.tagName)) {
+    return element.textContent?.trim() || 'Section'
+  }
+  // A block that carries its own title/label reads best by that.
+  const titled = element.querySelector(
+    '.vp-callout__label, .vp-questions__title, .vp-checklist__title, .vp-stat__title, .vp-chart__title',
+  )
+  if (titled?.textContent?.trim()) return titled.textContent.trim()
+  for (const [selector, label] of BLOCK_LABELS) {
+    if (element.matches(selector)) return label
+  }
+  const text = element.textContent?.trim() ?? ''
+  return text ? (text.length > 60 ? `${text.slice(0, 60).trim()}…` : text) : 'Section'
 }
 
-/** Enumerate the plan's major sections in document order, each owning the elements up to the next
+/** Enumerate the plan's sections in document order, each owning the elements up to the next
  * section. Called once: the plan is a frozen snapshot. */
 export function collectSections(): Section[] {
   const main = document.querySelector('.vp-main')
   if (!main) return []
   const children = Array.from(main.children)
-  const starts = children.filter(el => el.matches('.vp-phase, h1, h2'))
+  const starts = children.filter(el => el.matches(SECTION_START_SELECTOR))
   return starts.map((element, index) => {
     const next = starts[index + 1]
     const nextIdx = next ? children.indexOf(next) : children.length

--- a/packages/runtime/tests/components.test.tsx
+++ b/packages/runtime/tests/components.test.tsx
@@ -9,6 +9,7 @@ import { MathBlock } from '../components/Math.js'
 import { Matrix } from '../components/Matrix.js'
 import { Phase } from '../components/Phase.js'
 import { Questions } from '../components/Questions.js'
+import { ReviewAnswersProvider } from '../components/review/ReviewAnswers.js'
 import { copyText, ShareButton } from '../components/ShareButton.js'
 import { Stat } from '../components/Stat.js'
 import { ThemeToggle } from '../components/ThemeToggle.js'
@@ -246,6 +247,34 @@ describe('Questions', () => {
   it('renders a single question (edge)', () => {
     const html = renderToStaticMarkup(<Questions items={['Only one?']} />)
     expect(html).toContain('Only one?')
+  })
+})
+
+describe('Questions in review mode', () => {
+  function setReviewMode(on: boolean): void {
+    ;(globalThis as { __VP_REVIEW__?: boolean }).__VP_REVIEW__ = on || undefined
+  }
+  afterEach(() => setReviewMode(false))
+
+  it('renders an inline answer field per question in review mode (golden)', () => {
+    setReviewMode(true)
+    const html = renderToStaticMarkup(
+      <ReviewAnswersProvider>
+        <Questions items={['Fail open or closed?', 'TTL ok?']} />
+      </ReviewAnswersProvider>,
+    )
+    expect((html.match(/vp-questions__answer/g) || []).length).toBe(2)
+    expect(html).toContain('Fail open or closed?')
+  })
+
+  it('stays a static list with no answer field outside review mode (edge)', () => {
+    setReviewMode(false)
+    const html = renderToStaticMarkup(
+      <ReviewAnswersProvider>
+        <Questions items={['Fail open or closed?']} />
+      </ReviewAnswersProvider>,
+    )
+    expect(html).not.toContain('vp-questions__answer')
   })
 })
 

--- a/packages/runtime/tests/review.test.tsx
+++ b/packages/runtime/tests/review.test.tsx
@@ -38,9 +38,16 @@ describe('isReviewMode', () => {
 describe('DecisionBar Iterate gating', () => {
   const noop = () => {}
 
-  it('disables Iterate with no comments and no note (edge)', () => {
+  it('disables Iterate with no comments, answers, or note (edge)', () => {
     const html = renderToStaticMarkup(
-      <DecisionBar commentCount={0} note='' onNote={noop} onDecide={noop} busy={false} />,
+      <DecisionBar
+        commentCount={0}
+        answerCount={0}
+        note=''
+        onNote={noop}
+        onDecide={noop}
+        busy={false}
+      />,
     )
     // Only the Iterate button is disabled; Deny and Approve are always actionable when not busy.
     expect((html.match(/disabled=""/g) || []).length).toBe(1)
@@ -48,7 +55,28 @@ describe('DecisionBar Iterate gating', () => {
 
   it('enables Iterate once a comment exists (golden)', () => {
     const html = renderToStaticMarkup(
-      <DecisionBar commentCount={1} note='' onNote={noop} onDecide={noop} busy={false} />,
+      <DecisionBar
+        commentCount={1}
+        answerCount={0}
+        note=''
+        onNote={noop}
+        onDecide={noop}
+        busy={false}
+      />,
+    )
+    expect((html.match(/disabled=""/g) || []).length).toBe(0)
+  })
+
+  it('enables Iterate when only an answer exists (golden)', () => {
+    const html = renderToStaticMarkup(
+      <DecisionBar
+        commentCount={0}
+        answerCount={1}
+        note=''
+        onNote={noop}
+        onDecide={noop}
+        busy={false}
+      />,
     )
     expect((html.match(/disabled=""/g) || []).length).toBe(0)
   })

--- a/packages/runtime/tests/section-comments.test.ts
+++ b/packages/runtime/tests/section-comments.test.ts
@@ -1,0 +1,42 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { collectSections } from '../components/review/SectionComments.js'
+
+afterEach(() => {
+  document.body.innerHTML = ''
+})
+
+/** Build a `.vp-main` from a list of child element HTML strings, as the rendered plan would have. */
+function setMain(...children: string[]): void {
+  document.body.innerHTML = `<main class="vp-main">${children.join('')}</main>`
+}
+
+describe('collectSections', () => {
+  it('splits loose top-level blocks into their own sections instead of one giant intro (golden)', () => {
+    // The exact case from the review note: a title, intro prose, a diagram, and a callout all
+    // before the first phase must not collapse into a single oversized section.
+    setMain(
+      '<h1>Plan</h1>',
+      '<p>intro prose</p>',
+      '<div class="vp-mermaid"><svg></svg></div>',
+      '<aside class="vp-callout"><div class="vp-callout__label">Decision</div></aside>',
+      '<div class="vp-phase"><div class="vp-phase__title">Build it</div></div>',
+    )
+    const sections = collectSections()
+    // h1, diagram, callout, phase each start a section (the bare <p> joins the heading above it).
+    expect(sections.map(s => s.label)).toEqual(['Plan', 'Diagram', 'Decision', 'Build it'])
+  })
+
+  it('keeps a block nested inside a phase part of that phase, not its own section (edge)', () => {
+    setMain(
+      '<div class="vp-phase"><div class="vp-phase__title">Build</div><div class="vp-mermaid"></div></div>',
+    )
+    const sections = collectSections()
+    expect(sections).toHaveLength(1)
+    expect(sections[0]?.label).toBe('Build')
+  })
+
+  it('returns no sections when there is no plan column (error)', () => {
+    document.body.innerHTML = '<div>no main here</div>'
+    expect(collectSections()).toEqual([])
+  })
+})

--- a/packages/runtime/theme.css
+++ b/packages/runtime/theme.css
@@ -23,6 +23,7 @@
   --vp-question: #2f6fed;
   --vp-question-tint: #eef3fe;
   --vp-question-border: #d4e0fb;
+  --vp-question-glow: rgb(47 111 237 / 28%);
   --vp-note: #2f6fed;
   --vp-note-tint: #eef3fe;
   --vp-note-border: #d4e0fb;
@@ -67,6 +68,7 @@
   --vp-question: #7aa2ff;
   --vp-question-tint: #161d2e;
   --vp-question-border: #2b3a5e;
+  --vp-question-glow: rgb(122 162 255 / 34%);
   --vp-note: #7aa2ff;
   --vp-note-tint: #161d2e;
   --vp-note-border: #2b3a5e;
@@ -600,14 +602,35 @@ body {
   font-variant-numeric: tabular-nums;
 }
 
-/* Questions: open questions for the reader. Neutral card like the other list cards,
-   with blue kept only as the accent on the item numbers. */
+/* Questions: open questions for the reader, deliberately called out with a blue tint and an
+   always-on humming glow so the panel reads as the place to act (especially in a review session,
+   where each row becomes directly answerable). Intentionally NOT neutral; see runtime AGENTS.md. */
 .vp-questions {
-  border: 1px solid var(--vp-border);
-  background: var(--vp-surface);
+  border: 1px solid var(--vp-question-border);
+  background: var(--vp-question-tint);
   border-radius: 10px;
   padding: 0.85rem 1.1rem;
   margin: 1.4rem 0;
+  animation: vp-questions-hum 3.2s var(--vp-ease) infinite;
+}
+
+/* The "hum": a soft blue halo that swells and settles. */
+@keyframes vp-questions-hum {
+  0%,
+  100% {
+    box-shadow: 0 0 7px -2px var(--vp-question-glow);
+  }
+  50% {
+    box-shadow: 0 0 18px 1px var(--vp-question-glow);
+  }
+}
+
+/* Reduced motion: keep the call-out glow, but hold it steady instead of pulsing. */
+@media (prefers-reduced-motion: reduce) {
+  .vp-questions {
+    animation: none;
+    box-shadow: 0 0 12px -2px var(--vp-question-glow);
+  }
 }
 
 /* Small uppercase label, identical to the Checklist title. */
@@ -645,8 +668,42 @@ body {
   font-variant-numeric: tabular-nums;
 }
 
+/* Holds the question text and, in review mode, its answer field stacked beneath it. */
+.vp-questions__body {
+  flex: 1 1 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  min-width: 0;
+}
+
 .vp-questions__text {
   color: var(--vp-text);
+}
+
+/* The review-mode answer field: a plain surface inset on the tinted card, focus ring in the
+   question blue. Grows with `rows`, but stays a single line by default. */
+.vp-questions__answer {
+  width: 100%;
+  box-sizing: border-box;
+  font: inherit;
+  font-size: 0.9rem;
+  color: var(--vp-text);
+  background: var(--vp-bg);
+  border: 1px solid var(--vp-question-border);
+  border-radius: 7px;
+  padding: 0.4rem 0.55rem;
+  resize: vertical;
+}
+
+.vp-questions__answer::placeholder {
+  color: var(--vp-faint);
+}
+
+.vp-questions__answer:focus-visible {
+  outline: none;
+  border-color: var(--vp-question);
+  box-shadow: 0 0 0 2px var(--vp-question-glow);
 }
 
 /* Compare */

--- a/skills/visual-plan/SKILL.md
+++ b/skills/visual-plan/SKILL.md
@@ -37,10 +37,12 @@ and tables, with prose only connecting the visuals, not carrying the plan itself
    run); a plan being generated for the user to read is never that case.
 4. **To get the user's decision on the plan** (a sign-off, not just a viewing), render with
    `vplan render --review <file>.mdx`. It opens the plan with a feedback layer where the user comments
-   on whole sections or on selected text, then clicks Approve / Deny / Iterate. It **blocks** until
-   they submit, prints the decision and comments to stdout, and exits: approve 0, deny 1, iterate 2,
-   timeout 3 (`--timeout`, default 15m; closing the tab counts as deny). It is a long-running
-   foreground server, so run it in the background. Then act on the printed feedback:
+   on whole sections or on selected text, **answers any `<Questions>` directly** (each question
+   becomes an inline answer field, printed back as `Answer to "<question>":`), then clicks
+   Approve / Deny / Iterate. It **blocks** until they submit, prints the decision, comments, and
+   answers to stdout, and exits: approve 0, deny 1, iterate 2, timeout 3 (`--timeout`, default 15m;
+   closing the tab counts as deny). It is a long-running foreground server, so run it in the
+   background. Then act on the printed feedback:
    - **Approve** -> proceed with the plan as written.
    - **Iterate** -> revise the plan addressing each comment, then review again with `-i N`
      (`--iteration N`) incremented so the bar shows the round; repeat until Approve or Deny.
@@ -160,7 +162,8 @@ brace errors that break a render.
   ```
 - `<Questions>` — open questions you want the reader to resolve before building, one per bullet.
   Use this instead of burying uncertainties in prose. The title defaults to "Open questions";
-  override with `title="..."`.
+  override with `title="..."`. In a `--review` session each question is directly answerable, so
+  prefer a `<Questions>` block over prose when you want the reviewer to answer specific questions.
 
   ```mdx
   <Questions>


### PR DESCRIPTION
## What

Make a plan's `Questions` panel directly answerable in `--review` mode (each question gets an inline answer field), give the panel an always-on blue humming glow so it reads as the place to act, and split oversized review sections so loose top-level content is individually commentable.

## How

- Answers flow from the inline fields through a shared `ReviewAnswers` React context (provided in `Layout`, shared by `Questions` and `ReviewSession`) into a **distinct `answers` channel** on the feedback payload, printed to the agent as `Answer to "<question>":`. No new transport: they ride the existing `/__vp_feedback` POST path, and `answers` defaults to `[]` so older payloads still validate.
- Always-on glow via a new `--vp-question-glow` token (all three palettes) and a `vp-questions-hum` keyframes pulse, held steady under `prefers-reduced-motion`. This intentionally overrides the prior "Questions is a neutral card" design rule, recorded in `packages/runtime/AGENTS.md`.
- `collectSections` now starts a commentable section at any `.vp-phase`, heading (`h1`-`h3`), or top-level standalone block; matching only direct children of `.vp-main` keeps blocks nested in a `<Phase>` part of that phase.

## Verification

- [x] `pnpm lint` passes (no errors; 7 pre-existing warnings in untouched CSS)
- [x] `pnpm format` reports no changes (`biome format .`)
- [x] `pnpm typecheck` passes
- [x] `pnpm build` succeeds
- [x] `pnpm test` passes (276 tests)

Also drove the built CLI end-to-end: a `--review` POST carrying `answers` is accepted, the CLI exits 2 (iterate), and stdout prints the `Answer to "..."` blocks in order (comments, answers, note).

## Notes

- No breaking changes.
- Visual check via Playwright (light + dark) confirmed the answer fields render in review mode and the glow reads on both themes with the question numbers correctly aligned.