### PR TITLE
feat(diff): section-level iteration diffing with inline review diffs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,11 @@ polished, self-contained HTML page, so an AI agent can present plans as scannabl
   until then, prints the feedback to stdout, and exits (approve 0, deny 1, iterate 2, timeout 3).
   `--timeout` (default 15m) bounds the wait; a closed tab resolves as Deny. `-i/--iteration N` shows
   the revision number in the review bar (the agent increments it each re-review).
+- Iteration diffing: a render of a plan *file* snapshots its source (`~/.vplan/snapshots`, keyed by
+  the absolute path), and the next render of that path diffs the new source against the snapshot,
+  injecting `__VP_DIFF__` so the runtime marks added/edited sections git-gutter style. `--diff <path>`
+  forces an explicit baseline (no cache touch); `--no-diff` opts out. Works on render, `--watch`, and
+  `--review`; a `--stdout` render never auto-diffs (it stays deterministic for pipelines).
 - `vplan components` prints the component vocabulary cheat-sheet.
 - A programmatic API (`import { renderPlan, checkPlan } from 'vplan'`) renders/validates a plan from
   an in-memory MDX string, with a named export per catalog entry. See `packages/cli/src/api.ts`.
@@ -131,6 +136,12 @@ A release is cut by creating a GitHub release; the tag is the published version 
 
 ## Key Decisions
 
+- 2026-06-24: Iteration diffing is section-level and maps a status onto a DOM section by
+  **document-order index**, so `splitSections` (mdast, `@visualplan/compile`) and the runtime's
+  `collectSections` (DOM) MUST enumerate the same sections in the same order; two parity goldens
+  (compile + runtime) pin this. Why: index mapping avoids cross-boundary label/hash matching, and a
+  count mismatch degrades to "no cue" rather than a mislabeled one. Renames are detected by content
+  similarity (no authored section IDs) per the approved plan.
 - 2026-06-22: CLI config persists to `~/.vplan/config.json` (literal path via `homedir()`, NOT
   `env-paths`); the only setting is the default `theme`. The in-page theme cog overrides per-view via
   `localStorage` and never writes the file. Why: a static `file://` plan cannot reach the disk, so

--- a/packages/cli/AGENTS.md
+++ b/packages/cli/AGENTS.md
@@ -29,6 +29,16 @@ programmatic Node API at `dist/api.js` (the package's `import` entry, `exports["
   are added), and `GET /__vp_alive` (a connection the page holds open; its drop resolves Deny with the
   latest draft). Detecting that socket close server-side is what makes a real tab close reliable,
   where an unload-time `sendBeacon` is not (verified: the beacon survives navigation but not a close).
+- `src/build/snapshots.ts` — the per-plan snapshot cache (`~/.vplan/snapshots`, keyed by a hash of
+  the plan's absolute path) powering automatic iteration diffing. `render` reads a plan path's
+  snapshot as the diff baseline, then overwrites it with the current source ("changes since you last
+  looked"). Best-effort: a read miss or write failure just means no diff, never a broken render.
+  Baseline resolution (`render.ts resolveBaseline`): explicit `--diff <path>` wins and does NOT touch
+  the cache; `--no-diff` (`diff === false`) disables both read and write; otherwise a file render
+  auto-diffs against (and refreshes) the snapshot. stdin (no path key) and `--stdout` (kept
+  deterministic) never auto-diff. The diff itself is injected by `compile.ts planDiffPlugin`
+  (`__VP_DIFF__`, mirroring `planSharePlugin`) when `BuildOptions.baseline` is set, shared by the
+  one-shot build, `--watch`, and `--review`.
 - `src/config.ts` — the persistent CLI config at `~/.vplan/config.json` (literal path via
   `homedir()`, deliberately NOT `env-paths`). Only setting today is `theme` (`light`|`dark`|
   `system`). `readConfig` is tolerant (missing/malformed/unknown-theme -> `{ theme: 'system' }`) so a

--- a/packages/cli/src/build/compile.ts
+++ b/packages/cli/src/build/compile.ts
@@ -5,7 +5,7 @@ import { tmpdir } from 'node:os'
 import { dirname, join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { compile, type CompileOptions } from '@mdx-js/mdx'
-import { baseExpressiveCodeOptions, remarkPlugins } from '@visualplan/compile'
+import { baseExpressiveCodeOptions, diffSections, remarkPlugins } from '@visualplan/compile'
 import { pluginFileIcons } from '@visualplan/compile/file-icons'
 import { remarkFileTreeIcons } from '@visualplan/compile/filetree-icons'
 import { type Feedback, feedbackSchema } from '@visualplan/core'
@@ -209,6 +209,36 @@ function planSharePlugin(readSource: () => string): Plugin {
   }
 }
 
+/**
+ * Inject the section diff against a baseline onto `globalThis.__VP_DIFF__` so the runtime can mark
+ * added/edited sections (git-gutter style). The current source is read fresh on each call, so the
+ * `--watch` dev server re-diffs the live file against the session's baseline on every reload. A diff
+ * failure is swallowed: a diffing problem must never break the render (the page just shows no cues).
+ */
+function planDiffPlugin(readSource: () => string, baseline: string): Plugin {
+  return {
+    name: 'visualplan:diff',
+    transformIndexHtml: {
+      order: 'pre',
+      handler() {
+        let diff: ReturnType<typeof diffSections>
+        try {
+          diff = diffSections(baseline, readSource())
+        } catch {
+          return []
+        }
+        return [
+          {
+            tag: 'script',
+            injectTo: 'head',
+            children: `globalThis.__VP_DIFF__=${JSON.stringify(diff)}`,
+          },
+        ]
+      },
+    },
+  }
+}
+
 /** How a plan is rendered, beyond its source. Defaults match the CLI (cog + share both on). */
 export interface BuildOptions {
   /** Default color scheme baked into the page. Default `system`. */
@@ -218,6 +248,9 @@ export interface BuildOptions {
   lockTheme?: boolean
   /** Inject the share button's data. The CLI shares; the programmatic API defaults this off. Default true. */
   enableSharing?: boolean
+  /** A previous version of the plan's MDX source. When set, the section diff against it is injected
+   * as `__VP_DIFF__` so the runtime marks added/edited sections. Omitted = no diff (the default). */
+  baseline?: string
 }
 
 /**
@@ -262,6 +295,8 @@ function baseConfig(paths: RuntimePaths, input: PlanInput, options: BuildOptions
   ]
   // The share button renders only when its data is injected, so omitting the plugin hides it.
   if (enableSharing) plugins.push(planSharePlugin(readSource))
+  // Diff cues render only when a baseline is given, so omitting the plugin leaves a plain render.
+  if (options.baseline !== undefined) plugins.push(planDiffPlugin(readSource, options.baseline))
   return {
     root: paths.runtimeDir,
     configFile: false,
@@ -336,9 +371,10 @@ export async function startDevServer(
   mdxPath: string,
   theme: Theme = 'system',
   port: number = DEFAULT_DEV_PORT,
+  baseline?: string,
 ): Promise<DevServer> {
   const paths = findRuntimePaths()
-  const config = baseConfig(paths, { path: resolve(mdxPath) }, { theme })
+  const config = baseConfig(paths, { path: resolve(mdxPath) }, { theme, baseline })
   const server = await createServer({ ...config, server: { ...config.server, port } })
   await server.listen()
   const url =
@@ -474,6 +510,7 @@ export async function startReviewServer(
   source: string,
   theme: Theme = 'system',
   iteration?: number,
+  baseline?: string,
 ): Promise<ReviewServer> {
   const paths = findRuntimePaths()
   let settled = false
@@ -488,7 +525,7 @@ export async function startReviewServer(
     resolveFeedback(value)
   }
   const state: ReviewState = { draft: { decision: 'deny', comments: [], answers: [] } }
-  const config = baseConfig(paths, source, { theme })
+  const config = baseConfig(paths, source, { theme, baseline })
   // Use the same default port as the `--watch` dev server (Vite auto-increments if it is taken).
   const server = await createServer({
     ...config,

--- a/packages/cli/src/build/snapshots.ts
+++ b/packages/cli/src/build/snapshots.ts
@@ -1,0 +1,59 @@
+/**
+ * The per-plan snapshot cache that powers automatic iteration diffing. Each render of a plan *file*
+ * stores its source keyed by the file's absolute path; the next render of that same path diffs the
+ * new source against the stored snapshot (see `diffSections`) and then overwrites it. So the agent's
+ * normal loop (edit the `.mdx` in place, re-present) shows "what changed since you last looked" with
+ * no flag to remember. Piped stdin has no stable path key, so it never auto-snapshots.
+ *
+ * The store lives under `~/.vplan/snapshots/` (alongside the config), is keyed by a hash of the
+ * absolute path so the filename is filesystem-safe, and is best-effort: a read miss or a write
+ * failure simply means no diff, never a broken render.
+ */
+import { mkdir, readFile, writeFile } from 'node:fs/promises'
+import { join } from 'node:path'
+import { configDir } from '../config.js'
+
+/** `~/.vplan/snapshots` — where the last-presented source of each plan file is cached. */
+export const snapshotsDir = join(configDir, 'snapshots')
+
+/** FNV-1a 32-bit hash as hex; a stable, filesystem-safe key for an absolute plan path. */
+function hashPath(absPath: string): string {
+  let h = 0x811c9dc5
+  for (let i = 0; i < absPath.length; i++) {
+    h ^= absPath.charCodeAt(i)
+    h = Math.imul(h, 0x01000193)
+  }
+  return (h >>> 0).toString(16)
+}
+
+/** The snapshot file path for a plan's absolute path within `dir` (defaults to `~/.vplan/snapshots`). */
+export function snapshotPath(absPath: string, dir: string = snapshotsDir): string {
+  return join(dir, `${hashPath(absPath)}.mdx`)
+}
+
+/** The cached previous source for a plan path, or undefined if none is cached (or the read fails). */
+export async function readSnapshot(
+  absPath: string,
+  dir: string = snapshotsDir,
+): Promise<string | undefined> {
+  try {
+    return await readFile(snapshotPath(absPath, dir), 'utf8')
+  } catch {
+    return undefined
+  }
+}
+
+/** Cache `source` as the last-presented version of a plan path. Best-effort: a write failure is
+ * swallowed, since a missing snapshot only costs a diff, never a render. */
+export async function writeSnapshot(
+  absPath: string,
+  source: string,
+  dir: string = snapshotsDir,
+): Promise<void> {
+  try {
+    await mkdir(dir, { recursive: true })
+    await writeFile(snapshotPath(absPath, dir), source)
+  } catch {
+    // A cache write failure must never fail the render that triggered it.
+  }
+}

--- a/packages/cli/src/commands/render.ts
+++ b/packages/cli/src/commands/render.ts
@@ -1,10 +1,11 @@
-import { writeFile } from 'node:fs/promises'
+import { readFile, writeFile } from 'node:fs/promises'
 import { basename, dirname, extname, join, resolve } from 'node:path'
 import { InvalidArgumentError } from 'commander'
 import ms from 'ms'
 import open from 'open'
 import { checkPlan, checkSource } from '../build/check.js'
 import { buildHtml, startDevServer } from '../build/compile.js'
+import { readSnapshot, writeSnapshot } from '../build/snapshots.js'
 import { readConfig } from '../config.js'
 import { runReview } from '../review/session.js'
 import { printIssues, resolvePlanFile } from './check.js'
@@ -27,6 +28,36 @@ export interface RenderOptions {
   timeout?: number
   /** Iteration number shown in the review bar (the agent sets it as it revises the plan). */
   iteration?: number
+  /** Diff baseline. A string path is an explicit baseline (bypasses the cache); `false` is
+   * `--no-diff` (disable diffing); `undefined` auto-diffs a file render against its snapshot. */
+  diff?: string | false
+}
+
+/**
+ * Resolve the diff baseline for a render and refresh the snapshot cache. Explicit `--diff <path>`
+ * wins and does not touch the cache; `--no-diff` (`diff === false`) disables diffing entirely;
+ * otherwise a file render auto-diffs against its path-keyed snapshot and then overwrites it with the
+ * current source ("changes since you last looked"). Piped stdin (`absPath` undefined) has no stable
+ * key, so it only diffs via an explicit `--diff`.
+ */
+async function resolveBaseline(
+  options: RenderOptions,
+  currentSource: string,
+  absPath: string | undefined,
+): Promise<string | undefined> {
+  if (options.diff === false) return undefined
+  if (typeof options.diff === 'string') {
+    return (await readFile(resolve(options.diff), 'utf8')).replace(/^﻿/, '')
+  }
+  if (absPath === undefined) return undefined
+  const baseline = await readSnapshot(absPath)
+  await writeSnapshot(absPath, currentSource)
+  return baseline
+}
+
+/** The absolute path that keys a plan's snapshot, or undefined for stdin (no stable key). */
+function snapshotKey(file: string | undefined, fromStdin: boolean): string | undefined {
+  return !fromStdin && file && file !== '-' ? resolve(file) : undefined
 }
 
 /** Parse the `--iteration` value as a positive integer (the plan revision number shown in review). */
@@ -86,19 +117,21 @@ export async function runRender(file: string | undefined, options: RenderOptions
   // Review is a one-shot server that blocks on human feedback; it accepts a file or piped stdin
   // because it serves a snapshot read once (no watching), unlike --watch.
   if (options.review) {
-    const { source, label } = await readPlanSource(file)
+    const { source, label, fromStdin } = await readPlanSource(file)
     const issues = await checkSource(source)
     if (issues.length > 0) {
       printIssues(label, issues)
       process.exitCode = 1
       return
     }
+    const baseline = await resolveBaseline(options, source, snapshotKey(file, fromStdin))
     await runReview(
       source,
       theme,
       options.timeout ?? DEFAULT_REVIEW_TIMEOUT_MS,
       options.open !== false,
       options.iteration,
+      baseline,
     )
     return
   }
@@ -115,7 +148,8 @@ export async function runRender(file: string | undefined, options: RenderOptions
       process.exitCode = 1
       return
     }
-    const server = await startDevServer(absMdx, theme, options.port)
+    const baseline = await resolveBaseline(options, await readFile(absMdx, 'utf8'), absMdx)
+    const server = await startDevServer(absMdx, theme, options.port, baseline)
     process.stdout.write(
       `Visual Plan watching ${file}\n  ${server.url}\n  (edit the file to hot-reload; Ctrl+C to stop)\n`,
     )
@@ -131,10 +165,18 @@ export async function runRender(file: string | undefined, options: RenderOptions
     return
   }
 
-  const html = await buildHtml(source, { theme })
+  // A stdout render must stay deterministic (CI / pipelines), so it never auto-diffs against the
+  // home-dir snapshot cache; only an explicit --diff applies. A file render auto-diffs as usual.
+  const goingToStdout = options.stdout || (fromStdin && !options.out)
+  const baseline = await resolveBaseline(
+    options,
+    source,
+    goingToStdout ? undefined : snapshotKey(file, fromStdin),
+  )
+  const html = await buildHtml(source, { theme, baseline })
 
   // Piped stdin with no explicit destination defaults to stdout, so the tool composes in a pipeline.
-  if (options.stdout || (fromStdin && !options.out)) {
+  if (goingToStdout) {
     process.stdout.write(html)
     return
   }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -38,6 +38,11 @@ program
     parseTimeout,
     DEFAULT_REVIEW_TIMEOUT_MS,
   )
+  .option(
+    '--diff <path>',
+    'diff this render against a baseline plan .mdx (overrides the snapshot cache)',
+  )
+  .option('--no-diff', 'skip iteration diffing (do not read or write the snapshot cache)')
   .option('--no-open', 'do not open the result in a browser')
   .action((file: string | undefined, options: RenderOptions) => runRender(file, options))
 

--- a/packages/cli/src/review/session.ts
+++ b/packages/cli/src/review/session.ts
@@ -19,8 +19,9 @@ export async function runReview(
   timeoutMs: number,
   openBrowser: boolean,
   iteration?: number,
+  baseline?: string,
 ): Promise<void> {
-  const server = await startReviewServer(source, theme, iteration)
+  const server = await startReviewServer(source, theme, iteration, baseline)
   process.stderr.write(
     `Visual Plan review at\n  ${server.url}\n  (comment on sections, then Approve / Deny / Iterate; Ctrl+C to cancel)\n`,
   )

--- a/packages/cli/tests/snapshots.test.ts
+++ b/packages/cli/tests/snapshots.test.ts
@@ -1,0 +1,46 @@
+// @vitest-environment node
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { readSnapshot, snapshotPath, writeSnapshot } from '../src/build/snapshots.js'
+
+describe('snapshot cache', () => {
+  let dir: string
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), 'vplan-snap-'))
+  })
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true })
+  })
+
+  it('round-trips the cached source for a plan path', async () => {
+    await writeSnapshot('/plans/feature.mdx', '# Feature\n', dir)
+    expect(await readSnapshot('/plans/feature.mdx', dir)).toBe('# Feature\n')
+  })
+
+  it('returns undefined for a path with no snapshot (a first look)', async () => {
+    expect(await readSnapshot('/plans/never-seen.mdx', dir)).toBeUndefined()
+  })
+
+  it('keys distinct paths to distinct files but is stable for one path', async () => {
+    expect(snapshotPath('/a/one.mdx', dir)).toBe(snapshotPath('/a/one.mdx', dir))
+    expect(snapshotPath('/a/one.mdx', dir)).not.toBe(snapshotPath('/a/two.mdx', dir))
+  })
+
+  it('overwrites a prior snapshot so the diff means "since you last looked"', async () => {
+    await writeSnapshot('/plans/p.mdx', 'v1', dir)
+    await writeSnapshot('/plans/p.mdx', 'v2', dir)
+    expect(await readSnapshot('/plans/p.mdx', dir)).toBe('v2')
+  })
+
+  it('does not throw when the cache directory cannot be created (best-effort write)', async () => {
+    // Point the store at a path under a regular file, so mkdir fails; the write must swallow it.
+    const file = join(dir, 'not-a-dir')
+    await writeFile(file, 'x')
+    await expect(
+      writeSnapshot('/plans/p.mdx', 'data', join(file, 'snapshots')),
+    ).resolves.toBeUndefined()
+  })
+})

--- a/packages/compile/AGENTS.md
+++ b/packages/compile/AGENTS.md
@@ -54,6 +54,15 @@ through the workspace.
   cog / CLI config, not just the OS. `useDarkModeMediaQuery` stays on as the pre-`data-theme`
   fallback. Both consumers set `<html data-theme>` (the CLI's inline bootstrap; the runtime `mount`),
   so do not drop the attribute or the syntax theme stops following an explicit light/dark choice.
+- `src/sections.ts` — section-level plan diffing for iteration cues. `splitSections(source)` parses
+  MDX to mdast and enumerates the section-start blocks (top-level heading depth<=3, mermaid fence, or
+  block component), mirroring the runtime's DOM `collectSections` set; `diffSections(baseline,
+  current)` aligns two versions by key via LCS, then a similarity (token-Jaccard, `RENAME_THRESHOLD`)
+  pass so a reworded title or edited title-less block reads as `edited` not remove+add. Output is one
+  status per current section in document order (so the runtime maps it by index) plus removed ones.
+  Pure/isomorphic (no fs/DOM). **The section set + order MUST match the runtime's `collectSections`**;
+  paired parity goldens here and in the runtime pin it (see the runtime AGENTS.md). A behavioral
+  corpus (`tests/fixtures/diff-corpus.json`, `tests/diff-corpus.test.ts`) calibrates the threshold.
 - `src/icon-resolution.ts` — the **isomorphic** Material-icon resolution core
   (`@visualplan/compile/icon-resolution` subpath): a pure `resolveIconName(manifest, ...)` over a
   passed-in manifest, no fs. Single-sources the resolution order for the Node `file-icons.ts` AND

--- a/packages/compile/AGENTS.md
+++ b/packages/compile/AGENTS.md
@@ -61,7 +61,8 @@ through the workspace.
   pass so a reworded title or edited title-less block reads as `edited` not remove+add. Output is one
   status per current section in document order (so the runtime maps it by index) plus removed ones;
   an `edited` section also carries `prev` (the baseline `prose` = paragraph/list text only, no
-  title/attributes) so the runtime can word-highlight what changed against the rendered `p`/`li`.
+  title/attributes) and, when renamed, `prevLabel` (the baseline title) so the runtime can word-diff
+  the body and the title respectively (a rename has no body diff).
   Pure/isomorphic (no fs/DOM). **The section set + order MUST match the runtime's `collectSections`**;
   paired parity goldens here and in the runtime pin it (see the runtime AGENTS.md). A behavioral
   corpus (`tests/fixtures/diff-corpus.json`, `tests/diff-corpus.test.ts`) calibrates the threshold.

--- a/packages/compile/AGENTS.md
+++ b/packages/compile/AGENTS.md
@@ -59,7 +59,9 @@ through the workspace.
   block component), mirroring the runtime's DOM `collectSections` set; `diffSections(baseline,
   current)` aligns two versions by key via LCS, then a similarity (token-Jaccard, `RENAME_THRESHOLD`)
   pass so a reworded title or edited title-less block reads as `edited` not remove+add. Output is one
-  status per current section in document order (so the runtime maps it by index) plus removed ones.
+  status per current section in document order (so the runtime maps it by index) plus removed ones;
+  an `edited` section also carries `prev` (the baseline `prose` = paragraph/list text only, no
+  title/attributes) so the runtime can word-highlight what changed against the rendered `p`/`li`.
   Pure/isomorphic (no fs/DOM). **The section set + order MUST match the runtime's `collectSections`**;
   paired parity goldens here and in the runtime pin it (see the runtime AGENTS.md). A behavioral
   corpus (`tests/fixtures/diff-corpus.json`, `tests/diff-corpus.test.ts`) calibrates the threshold.

--- a/packages/compile/src/index.ts
+++ b/packages/compile/src/index.ts
@@ -17,3 +17,11 @@ export { remarkMath } from './remark-math.js'
 export { remarkMermaid } from './remark-mermaid.js'
 export { remarkPlanBlocks } from './remark-plan-blocks.js'
 export { assertPlanIsSafe, UnsafePlanError } from './safety-gate.js'
+export {
+  diffSections,
+  type PlanSection,
+  RENAME_THRESHOLD,
+  type SectionDiff,
+  type SectionStatus,
+  splitSections,
+} from './sections.js'

--- a/packages/compile/src/sections.ts
+++ b/packages/compile/src/sections.ts
@@ -47,6 +47,9 @@ export interface SectionDiff {
     /** The baseline section's prose, present only on `edited` sections, so the runtime can highlight
      * the words that changed against the rendered body. */
     prev?: string
+    /** The baseline section's label, present only when an `edited` section was renamed, so the runtime
+     * can show the title change (a rename has no body diff). */
+    prevLabel?: string
   }[]
   removed: { label: string; type: string }[]
 }
@@ -362,9 +365,19 @@ export function diffSections(baseline: string, current: string): SectionDiff {
     sections: cur.map((s, ci) => {
       const sectionStatus = status[ci] as SectionStatus
       const bi = matchedBase[ci]
+      const baseSection = sectionStatus === 'edited' && bi !== undefined ? base[bi] : undefined
       // Carry the baseline prose only on edited sections, so the runtime can highlight what changed.
-      const prev = sectionStatus === 'edited' && bi !== undefined ? base[bi]?.prose : undefined
-      return { status: sectionStatus, label: s.label, type: s.type, ...(prev ? { prev } : {}) }
+      const prev = baseSection?.prose
+      // Carry the baseline label only when the title actually changed (a rename), so the runtime can
+      // show that even when the body is unchanged.
+      const prevLabel = baseSection && baseSection.label !== s.label ? baseSection.label : undefined
+      return {
+        status: sectionStatus,
+        label: s.label,
+        type: s.type,
+        ...(prev ? { prev } : {}),
+        ...(prevLabel ? { prevLabel } : {}),
+      }
     }),
     removed,
   }

--- a/packages/compile/src/sections.ts
+++ b/packages/compile/src/sections.ts
@@ -31,13 +31,23 @@ export interface PlanSection {
   titled: boolean
   /** Normalized text of the section's span, for edit detection and rename similarity. */
   text: string
+  /** Normalized prose (paragraph + list text only, no title/heading/attributes), so the runtime can
+   * word-diff a section's body against its rendered `p`/`li` text without title/chrome false hits. */
+  prose: string
 }
 
 /** The diff of a current plan against a baseline. `sections` is one entry per current section in
  * document order (so it maps onto the runtime's DOM sections by index); `removed` lists baseline
  * sections with no current match, for the summary. */
 export interface SectionDiff {
-  sections: { status: SectionStatus; label: string; type: string }[]
+  sections: {
+    status: SectionStatus
+    label: string
+    type: string
+    /** The baseline section's prose, present only on `edited` sections, so the runtime can highlight
+     * the words that changed against the rendered body. */
+    prev?: string
+  }[]
   removed: { label: string; type: string }[]
 }
 
@@ -107,6 +117,21 @@ function textContent(node: MdastNode): string {
   }
   if (node.children) for (const child of node.children) out += textContent(child)
   return out
+}
+
+/** The prose text of a node: text within `paragraph`/`listItem` nodes only (no headings, titles, or
+ * attributes), recursively. Mirrors the runtime's `p`/`li` DOM extraction so the two token streams
+ * align for word-level highlighting. `inProse` becomes true once inside a paragraph or list item. */
+function proseText(node: MdastNode, inProse: boolean, out: string[]): void {
+  const within = inProse || node.type === 'paragraph' || node.type === 'listItem'
+  if (
+    within &&
+    typeof node.value === 'string' &&
+    (node.type === 'text' || node.type === 'inlineCode')
+  ) {
+    out.push(node.value)
+  }
+  if (node.children) for (const child of node.children) proseText(child, within, out)
 }
 
 /** All text of a section's span: node values plus JSX string-attribute values (so a title or a
@@ -192,10 +217,14 @@ export function splitSections(source: string): PlanSection[] {
 
   return starts.map(({ index, descriptor }, position) => {
     const end = starts[position + 1]?.index ?? children.length
-    const text = normalizeWhitespace(children.slice(index, end).map(spanText).join(' '))
+    const span = children.slice(index, end)
+    const text = normalizeWhitespace(span.map(spanText).join(' '))
+    const proseParts: string[] = []
+    for (const node of span) proseText(node, false, proseParts)
+    const prose = normalizeWhitespace(proseParts.join(' '))
     const { type, label, titled } = descriptor
     const key = titled ? `${type}:${label}` : `${type}:#${hash(text)}`
-    return { type, label, key, titled, text }
+    return { type, label, key, titled, text, prose }
   })
 }
 
@@ -263,6 +292,9 @@ export function diffSections(baseline: string, current: string): SectionDiff {
   const baseMatched = new Array(base.length).fill(false)
   const curMatched = new Array(cur.length).fill(false)
   const status: (SectionStatus | undefined)[] = new Array(cur.length)
+  // The baseline section each current section matched, so an edited section can carry its previous
+  // prose for word-level highlighting.
+  const matchedBase: (number | undefined)[] = new Array(cur.length)
 
   for (const [bi, ci] of lcsPairs(
     base.map(s => s.key),
@@ -270,6 +302,7 @@ export function diffSections(baseline: string, current: string): SectionDiff {
   )) {
     baseMatched[bi] = true
     curMatched[ci] = true
+    matchedBase[ci] = bi
     // A titleless key embeds the content hash, so a matched key implies identical text (unchanged);
     // a titled key is stable under body edits, so compare the text to tell unchanged from edited.
     status[ci] =
@@ -295,6 +328,7 @@ export function diffSections(baseline: string, current: string): SectionDiff {
     if (best >= 0) {
       baseMatched[best] = true
       curMatched[ci] = true
+      matchedBase[ci] = best
       status[ci] = 'edited'
     }
   }
@@ -308,11 +342,13 @@ export function diffSections(baseline: string, current: string): SectionDiff {
     .map(s => ({ label: s.label, type: s.type }))
 
   return {
-    sections: cur.map((s, ci) => ({
-      status: status[ci] as SectionStatus,
-      label: s.label,
-      type: s.type,
-    })),
+    sections: cur.map((s, ci) => {
+      const sectionStatus = status[ci] as SectionStatus
+      const bi = matchedBase[ci]
+      // Carry the baseline prose only on edited sections, so the runtime can highlight what changed.
+      const prev = sectionStatus === 'edited' && bi !== undefined ? base[bi]?.prose : undefined
+      return { status: sectionStatus, label: s.label, type: s.type, ...(prev ? { prev } : {}) }
+    }),
     removed,
   }
 }

--- a/packages/compile/src/sections.ts
+++ b/packages/compile/src/sections.ts
@@ -1,0 +1,318 @@
+/**
+ * Section-level diffing of a plan across iterations. Splits an MDX plan into the same ordered
+ * sections the runtime's `collectSections` derives from the rendered DOM, then aligns two versions
+ * to classify each current section as unchanged / edited / added (and lists removed ones).
+ *
+ * Isomorphic: pure mdast parsing, no fs/React/DOM, so it is safe in the browser bundle. The
+ * load-bearing invariant is that this split and the runtime's DOM split produce the **same count and
+ * order** of sections, so the runtime can map a status onto a DOM section by document-order index.
+ * Labels are display-only (the removed-section summary); they need not match the DOM's labels.
+ */
+import remarkFrontmatter from 'remark-frontmatter'
+import remarkGfm from 'remark-gfm'
+import remarkMdx from 'remark-mdx'
+import remarkParse from 'remark-parse'
+import { unified } from 'unified'
+
+/** A diff status for a section present in the current plan. `removed` rides a separate list. */
+export type SectionStatus = 'unchanged' | 'edited' | 'added'
+
+/** One section of a single plan version, in document order. */
+export interface PlanSection {
+  /** Section kind: `h1`/`h2`/`h3`, `phase`, `callout`, `chart`, `filetree`, `matrix`, `compare`,
+   * `checklist`, `stat`, `questions`, or `mermaid`. Mirrors the runtime's section-start set. */
+  type: string
+  /** Human label for the summary (heading/title text, or a friendly block name). */
+  label: string
+  /** Matching key: a titled section keys by `type:label` (stable under body edits); a titleless one
+   * keys by `type:#contentHash` (identical content matches; an edit falls to the similarity pass). */
+  key: string
+  /** Whether the section carries an authored title/heading, which drives the matching strategy. */
+  titled: boolean
+  /** Normalized text of the section's span, for edit detection and rename similarity. */
+  text: string
+}
+
+/** The diff of a current plan against a baseline. `sections` is one entry per current section in
+ * document order (so it maps onto the runtime's DOM sections by index); `removed` lists baseline
+ * sections with no current match, for the summary. */
+export interface SectionDiff {
+  sections: { status: SectionStatus; label: string; type: string }[]
+  removed: { label: string; type: string }[]
+}
+
+/** Two unmatched same-type sections whose token overlap is at least this are treated as a rename
+ * (an edit), not a remove + add. Calibrated by the Phase 5 simulation corpus; start permissive. */
+export const RENAME_THRESHOLD = 0.5
+
+/** The JSX block components that begin a section, mapped to their section type token. Mirrors the
+ * runtime `SECTION_START_SELECTOR` (minus headings and mermaid, handled separately). */
+const JSX_SECTION_TYPES: Record<string, string> = {
+  Phase: 'phase',
+  Callout: 'callout',
+  FileTree: 'filetree',
+  Chart: 'chart',
+  Matrix: 'matrix',
+  Compare: 'compare',
+  Checklist: 'checklist',
+  Stat: 'stat',
+  Questions: 'questions',
+}
+
+interface MdastNode {
+  type: string
+  depth?: number
+  lang?: string | null
+  value?: string
+  name?: string | null
+  attributes?: { type: string; name?: string; value?: unknown }[]
+  children?: MdastNode[]
+}
+
+interface StartDescriptor {
+  type: string
+  label: string
+  titled: boolean
+}
+
+function parse(source: string): MdastNode {
+  return unified()
+    .use(remarkParse)
+    .use(remarkFrontmatter)
+    .use(remarkGfm)
+    .use(remarkMdx)
+    .parse(source) as unknown as MdastNode
+}
+
+/** The string value of a JSX attribute, or undefined for an absent / non-string (expression) one. */
+function attr(node: MdastNode, name: string): string | undefined {
+  const found = node.attributes?.find(a => a.type === 'mdxJsxAttribute' && a.name === name)
+  return typeof found?.value === 'string' ? found.value : undefined
+}
+
+function capitalize(text: string): string {
+  return text ? text.charAt(0).toUpperCase() + text.slice(1) : text
+}
+
+/** Collapse runs of whitespace and trim, so formatting-only changes are not read as edits. */
+function normalizeWhitespace(text: string): string {
+  return text.replace(/\s+/g, ' ').trim()
+}
+
+/** The rendered text of a node (text/inlineCode leaves only), for deriving a heading/section label. */
+function textContent(node: MdastNode): string {
+  let out = ''
+  if (typeof node.value === 'string' && (node.type === 'text' || node.type === 'inlineCode')) {
+    out += node.value
+  }
+  if (node.children) for (const child of node.children) out += textContent(child)
+  return out
+}
+
+/** All text of a section's span: node values plus JSX string-attribute values (so a title or a
+ * callout type is part of the content fingerprint), recursively. Used for hashing and similarity. */
+function spanText(node: MdastNode): string {
+  let out = ''
+  if (typeof node.value === 'string') out += ` ${node.value} `
+  if (node.attributes) {
+    for (const a of node.attributes) if (typeof a.value === 'string') out += ` ${a.value} `
+  }
+  if (node.children) for (const child of node.children) out += spanText(child)
+  return out
+}
+
+/** FNV-1a 32-bit hash as hex; deterministic and dependency-free (no crypto needed for a cache key). */
+function hash(text: string): string {
+  let h = 0x811c9dc5
+  for (let i = 0; i < text.length; i++) {
+    h ^= text.charCodeAt(i)
+    h = Math.imul(h, 0x01000193)
+  }
+  return (h >>> 0).toString(16)
+}
+
+/** Describe a section-starting node, or null if the node does not begin a section. Only the section
+ * START set matters here; following non-start siblings are folded into the preceding section. */
+function startDescriptor(node: MdastNode): StartDescriptor | null {
+  if (node.type === 'heading' && (node.depth ?? 0) <= 3) {
+    return { type: `h${node.depth}`, label: normalizeWhitespace(textContent(node)), titled: true }
+  }
+  if (node.type === 'code' && node.lang === 'mermaid') {
+    return { type: 'mermaid', label: 'Diagram', titled: false }
+  }
+  if (node.type === 'mdxJsxFlowElement' && node.name) {
+    const sectionType = JSX_SECTION_TYPES[node.name]
+    if (sectionType) return describeJsxSection(node, sectionType)
+  }
+  return null
+}
+
+function describeJsxSection(node: MdastNode, type: string): StartDescriptor {
+  const titleAttr = (fallback: string): StartDescriptor => {
+    const title = attr(node, 'title')
+    return { type, label: title ?? fallback, titled: title !== undefined }
+  }
+  switch (type) {
+    case 'phase':
+      return titleAttr('Phase')
+    case 'chart':
+      return titleAttr('Chart')
+    case 'checklist':
+      return titleAttr('Checklist')
+    case 'stat':
+      return titleAttr('Stat')
+    case 'questions':
+      return titleAttr('Open questions')
+    case 'callout': {
+      // A callout has no title; its rendered label is the type word (Risk/Decision/...). It keys by
+      // content (titleless) so two same-type callouts stay distinct and an edited body is a rename.
+      const calloutType = attr(node, 'type')
+      return { type, label: calloutType ? capitalize(calloutType) : 'Note', titled: false }
+    }
+    case 'filetree':
+      return { type, label: 'File changes', titled: false }
+    default:
+      // matrix, compare, and any other titleless block.
+      return { type, label: 'Comparison', titled: false }
+  }
+}
+
+/**
+ * Split a plan's MDX source into its ordered sections, mirroring the runtime's DOM section split:
+ * each top-level heading (depth <= 3), mermaid fence, or block component begins a section that owns
+ * the following non-start siblings up to the next start.
+ */
+export function splitSections(source: string): PlanSection[] {
+  const children = parse(source).children ?? []
+  const starts: { index: number; descriptor: StartDescriptor }[] = []
+  children.forEach((node, index) => {
+    const descriptor = startDescriptor(node)
+    if (descriptor) starts.push({ index, descriptor })
+  })
+
+  return starts.map(({ index, descriptor }, position) => {
+    const end = starts[position + 1]?.index ?? children.length
+    const text = normalizeWhitespace(children.slice(index, end).map(spanText).join(' '))
+    const { type, label, titled } = descriptor
+    const key = titled ? `${type}:${label}` : `${type}:#${hash(text)}`
+    return { type, label, key, titled, text }
+  })
+}
+
+/** Tokenize into a lowercase word set for Jaccard similarity. */
+function tokenSet(text: string): Set<string> {
+  return new Set(text.toLowerCase().match(/[a-z0-9]+/g) ?? [])
+}
+
+/** Token Jaccard similarity in [0, 1]; 1 when both are empty (two empty blocks are "the same"). */
+function similarity(a: string, b: string): number {
+  const setA = tokenSet(a)
+  const setB = tokenSet(b)
+  if (setA.size === 0 && setB.size === 0) return 1
+  let intersection = 0
+  for (const token of setA) if (setB.has(token)) intersection++
+  const union = setA.size + setB.size - intersection
+  return union === 0 ? 0 : intersection / union
+}
+
+/** Longest common subsequence over two key arrays, returned as matched `[baseIndex, currentIndex]`
+ * pairs in order. Duplicate keys are handled (it is a sequence alignment, not a set match). */
+function lcsPairs(base: string[], current: string[]): [number, number][] {
+  const n = base.length
+  const m = current.length
+  const dp: number[][] = Array.from({ length: n + 1 }, () => new Array(m + 1).fill(0))
+  for (let i = n - 1; i >= 0; i--) {
+    const row = dp[i] as number[]
+    const nextRow = dp[i + 1] as number[]
+    for (let j = m - 1; j >= 0; j--) {
+      row[j] =
+        base[i] === current[j]
+          ? (nextRow[j + 1] ?? 0) + 1
+          : Math.max(nextRow[j] ?? 0, row[j + 1] ?? 0)
+    }
+  }
+  const pairs: [number, number][] = []
+  let i = 0
+  let j = 0
+  while (i < n && j < m) {
+    const row = dp[i] as number[]
+    const nextRow = dp[i + 1] as number[]
+    if (base[i] === current[j]) {
+      pairs.push([i, j])
+      i++
+      j++
+    } else if ((nextRow[j] ?? 0) >= (row[j + 1] ?? 0)) {
+      i++
+    } else {
+      j++
+    }
+  }
+  return pairs
+}
+
+/**
+ * Diff a current plan against a baseline at the section level. Aligns by key via LCS (so order is
+ * respected and inserts/deletes are localized), marks key-matched pairs unchanged or edited by their
+ * text, then runs a similarity pass over the leftovers so a reworded title or an edited titleless
+ * block reads as an edit rather than a remove + add. Whatever stays unmatched is added / removed.
+ */
+export function diffSections(baseline: string, current: string): SectionDiff {
+  const base = splitSections(baseline)
+  const cur = splitSections(current)
+
+  const baseMatched = new Array(base.length).fill(false)
+  const curMatched = new Array(cur.length).fill(false)
+  const status: (SectionStatus | undefined)[] = new Array(cur.length)
+
+  for (const [bi, ci] of lcsPairs(
+    base.map(s => s.key),
+    cur.map(s => s.key),
+  )) {
+    baseMatched[bi] = true
+    curMatched[ci] = true
+    // A titleless key embeds the content hash, so a matched key implies identical text (unchanged);
+    // a titled key is stable under body edits, so compare the text to tell unchanged from edited.
+    status[ci] =
+      (base[bi] as PlanSection).text === (cur[ci] as PlanSection).text ? 'unchanged' : 'edited'
+  }
+
+  // Rename / edit-of-titleless pass: pair each leftover current section with the most similar
+  // leftover baseline section of the same type, above the threshold.
+  for (let ci = 0; ci < cur.length; ci++) {
+    if (curMatched[ci]) continue
+    const target = cur[ci] as PlanSection
+    let best = -1
+    let bestScore = RENAME_THRESHOLD
+    for (let bi = 0; bi < base.length; bi++) {
+      const candidate = base[bi] as PlanSection
+      if (baseMatched[bi] || candidate.type !== target.type) continue
+      const score = similarity(candidate.text, target.text)
+      if (score >= bestScore) {
+        bestScore = score
+        best = bi
+      }
+    }
+    if (best >= 0) {
+      baseMatched[best] = true
+      curMatched[ci] = true
+      status[ci] = 'edited'
+    }
+  }
+
+  for (let ci = 0; ci < cur.length; ci++) {
+    if (status[ci] === undefined) status[ci] = 'added'
+  }
+
+  const removed = base
+    .filter((_, bi) => !baseMatched[bi])
+    .map(s => ({ label: s.label, type: s.type }))
+
+  return {
+    sections: cur.map((s, ci) => ({
+      status: status[ci] as SectionStatus,
+      label: s.label,
+      type: s.type,
+    })),
+    removed,
+  }
+}

--- a/packages/compile/src/sections.ts
+++ b/packages/compile/src/sections.ts
@@ -119,10 +119,27 @@ function textContent(node: MdastNode): string {
   return out
 }
 
+/** Data components whose markdown children are structured DATA, not authored prose; their rendered
+ * text (file paths, table cells, task items) tokenizes differently from the source, so they are
+ * excluded from prose word-highlighting on both sides (here and the runtime's DOM extraction). */
+const PROSE_OPAQUE_COMPONENTS = new Set([
+  'FileTree',
+  'Chart',
+  'Matrix',
+  'Compare',
+  'Checklist',
+  'Stat',
+  'Questions',
+])
+
 /** The prose text of a node: text within `paragraph`/`listItem` nodes only (no headings, titles, or
- * attributes), recursively. Mirrors the runtime's `p`/`li` DOM extraction so the two token streams
- * align for word-level highlighting. `inProse` becomes true once inside a paragraph or list item. */
+ * attributes), recursively, skipping data-component subtrees. Mirrors the runtime's `p`/`li` DOM
+ * extraction so the two token streams align for word-level highlighting. `inProse` becomes true once
+ * inside a paragraph or list item. */
 function proseText(node: MdastNode, inProse: boolean, out: string[]): void {
+  if (node.type === 'mdxJsxFlowElement' && node.name && PROSE_OPAQUE_COMPONENTS.has(node.name)) {
+    return
+  }
   const within = inProse || node.type === 'paragraph' || node.type === 'listItem'
   if (
     within &&

--- a/packages/compile/tests/diff-corpus.test.ts
+++ b/packages/compile/tests/diff-corpus.test.ts
@@ -1,0 +1,55 @@
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+import { diffSections } from '../src/sections.js'
+
+/**
+ * A subagent-generated corpus of realistic plan-iteration edits (see the approved plan's "subagent
+ * simulations"), each with a human-intent expected classification. It validates `diffSections` and
+ * calibrates the rename threshold. Cases are tagged `core` (unambiguous: a strict assertion) or
+ * `stretch` (threshold-boundary: a reworded rename near the similarity cutoff, or a reorder of
+ * identically-titled sections — where add+remove vs edited is acceptable, so we assert only the
+ * safety property that the change is surfaced at all, never silently dropped).
+ */
+interface DiffCase {
+  name: string
+  category: string
+  baseline: string
+  current: string
+  expectedStatuses: ('unchanged' | 'edited' | 'added')[]
+  expectedRemovedTypes: string[]
+  confidence: 'core' | 'stretch'
+}
+
+const corpusPath = fileURLToPath(new URL('./fixtures/diff-corpus.json', import.meta.url))
+const corpus: DiffCase[] = JSON.parse(readFileSync(corpusPath, 'utf8'))
+
+const core = corpus.filter(c => c.confidence === 'core')
+const stretch = corpus.filter(c => c.confidence === 'stretch')
+
+describe('diffSections corpus (core: must match the intended classification)', () => {
+  it.each(core.map(c => [c.name, c] as const))('%s', (_name, testCase) => {
+    const diff = diffSections(testCase.baseline, testCase.current)
+    expect(diff.sections.map(s => s.status)).toEqual(testCase.expectedStatuses)
+    expect(diff.removed.map(r => r.type)).toEqual(testCase.expectedRemovedTypes)
+  })
+})
+
+describe('diffSections corpus (stretch: boundary cases must still surface the change)', () => {
+  it.each(stretch.map(c => [c.name, c] as const))('%s', (_name, testCase) => {
+    const diff = diffSections(testCase.baseline, testCase.current)
+    // The mapping must stay sound: one status per current section, in order.
+    expect(diff.sections).toHaveLength(testCase.current ? countCurrentSections(testCase) : 0)
+    // A boundary case may classify a rename as edited OR as add+remove, but it must never silently
+    // report the edited plan as fully unchanged: the reviewer would miss a real change.
+    const surfaced =
+      diff.sections.filter(s => s.status !== 'unchanged').length + diff.removed.length
+    expect(surfaced).toBeGreaterThan(0)
+  })
+})
+
+/** The expected current-section count for a case, taken from its oracle (its length is verified
+ * correct by construction in the fixture). */
+function countCurrentSections(testCase: DiffCase): number {
+  return testCase.expectedStatuses.length
+}

--- a/packages/compile/tests/fixtures/diff-corpus.json
+++ b/packages/compile/tests/fixtures/diff-corpus.json
@@ -1,0 +1,191 @@
+[
+  {
+    "name": "no-op-identical-plan",
+    "category": "no-op",
+    "baseline": "# Checkout redesign\n\nA short plan to redesign the checkout flow.\n\n<Phase title=\"Audit current funnel\">\nMap each step and where users drop off.\n</Phase>\n\n<Phase title=\"Rebuild the payment step\">\nReplace the legacy form with the new component.\n</Phase>\n",
+    "current": "# Checkout redesign\n\nA short plan to redesign the checkout flow.\n\n<Phase title=\"Audit current funnel\">\nMap each step and where users drop off.\n</Phase>\n\n<Phase title=\"Rebuild the payment step\">\nReplace the legacy form with the new component.\n</Phase>\n",
+    "expectedStatuses": ["unchanged", "unchanged", "unchanged"],
+    "expectedRemovedTypes": [],
+    "confidence": "core"
+  },
+  {
+    "name": "whitespace-only-indentation-and-blanks",
+    "category": "whitespace-only",
+    "baseline": "# Search relevance tuning\n\nImprove ranking quality for the product search index.\n\n<Phase title=\"Collect judgments\">\nGather labeled query/result pairs from the analytics team.\n</Phase>\n\n<Callout type=\"note\">\nUse the existing eval harness rather than building a new one.\n</Callout>\n",
+    "current": "# Search relevance tuning\n\n\nImprove ranking quality for the product search index.\n\n\n<Phase title=\"Collect judgments\">\nGather labeled query/result pairs from the analytics team.\n</Phase>\n\n\n<Callout type=\"note\">\nUse the existing eval harness rather than building a new one.\n</Callout>\n",
+    "expectedStatuses": ["unchanged", "unchanged", "unchanged"],
+    "expectedRemovedTypes": [],
+    "confidence": "core"
+  },
+  {
+    "name": "edit-phase-body-under-same-title",
+    "category": "edit-body",
+    "baseline": "# Notifications service\n\nStand up a service that fans out user notifications.\n\n<Phase title=\"Define the event schema\">\nAgree on a JSON envelope for every notification event.\n</Phase>\n\n<Phase title=\"Wire the delivery workers\">\nWorkers pull from the queue and call the email provider.\n</Phase>\n",
+    "current": "# Notifications service\n\nStand up a service that fans out user notifications.\n\n<Phase title=\"Define the event schema\">\nAgree on a versioned JSON envelope for every notification event, with a required type discriminator.\n</Phase>\n\n<Phase title=\"Wire the delivery workers\">\nWorkers pull from the queue and call the email provider.\n</Phase>\n",
+    "expectedStatuses": ["unchanged", "edited", "unchanged"],
+    "expectedRemovedTypes": [],
+    "confidence": "core"
+  },
+  {
+    "name": "edit-h2-body-under-same-heading",
+    "category": "edit-body",
+    "baseline": "# Q3 mobile launch\n\n## Goals\n\nShip the redesigned home screen to all iOS users.\n\n## Risks\n\nApp Store review can take up to a week.\n",
+    "current": "# Q3 mobile launch\n\n## Goals\n\nShip the redesigned home screen to all iOS users and start a 10 percent Android rollout.\n\n## Risks\n\nApp Store review can take up to a week.\n",
+    "expectedStatuses": ["unchanged", "edited", "unchanged"],
+    "expectedRemovedTypes": [],
+    "confidence": "core"
+  },
+  {
+    "name": "edit-chart-body-under-same-title",
+    "category": "edit-body",
+    "baseline": "# Capacity plan\n\nProject infrastructure spend for the next two quarters.\n\n<Chart type=\"bar\" title=\"Projected monthly cost\">\nQ1: 12000\nQ2: 14000\n</Chart>\n\n<Phase title=\"Reserve instances\">\nBuy one-year reserved instances for the steady-state baseline.\n</Phase>\n",
+    "current": "# Capacity plan\n\nProject infrastructure spend for the next two quarters.\n\n<Chart type=\"bar\" title=\"Projected monthly cost\">\nQ1: 12000\nQ2: 14000\nQ3: 15500\n</Chart>\n\n<Phase title=\"Reserve instances\">\nBuy one-year reserved instances for the steady-state baseline.\n</Phase>\n",
+    "expectedStatuses": ["unchanged", "edited", "unchanged"],
+    "expectedRemovedTypes": [],
+    "confidence": "core"
+  },
+  {
+    "name": "add-phase-in-middle",
+    "category": "add-section",
+    "baseline": "# Data warehouse migration\n\nMove reporting from the legacy MySQL replica to Snowflake.\n\n<Phase title=\"Stand up Snowflake\">\nCreate the account, warehouses, and role hierarchy.\n</Phase>\n\n<Phase title=\"Cut over dashboards\">\nRepoint the BI tool at the new warehouse.\n</Phase>\n",
+    "current": "# Data warehouse migration\n\nMove reporting from the legacy MySQL replica to Snowflake.\n\n<Phase title=\"Stand up Snowflake\">\nCreate the account, warehouses, and role hierarchy.\n</Phase>\n\n<Phase title=\"Backfill historical data\">\nLoad the last two years of fact tables and validate row counts.\n</Phase>\n\n<Phase title=\"Cut over dashboards\">\nRepoint the BI tool at the new warehouse.\n</Phase>\n",
+    "expectedStatuses": ["unchanged", "unchanged", "added", "unchanged"],
+    "expectedRemovedTypes": [],
+    "confidence": "core"
+  },
+  {
+    "name": "add-callout-and-checklist-at-end",
+    "category": "add-section",
+    "baseline": "# Feature flag cleanup\n\nRemove stale flags that have been fully rolled out.\n\n<Phase title=\"Inventory flags\">\nList every flag and its current rollout percentage.\n</Phase>\n",
+    "current": "# Feature flag cleanup\n\nRemove stale flags that have been fully rolled out.\n\n<Phase title=\"Inventory flags\">\nList every flag and its current rollout percentage.\n</Phase>\n\n<Callout type=\"risk\">\nDeleting a flag still referenced in code will break the build.\n</Callout>\n\n<Checklist title=\"Removal steps\">\n- Remove the flag check\n- Delete the flag definition\n- Drop the analytics event\n</Checklist>\n",
+    "expectedStatuses": ["unchanged", "unchanged", "added", "added"],
+    "expectedRemovedTypes": [],
+    "confidence": "core"
+  },
+  {
+    "name": "remove-callout-section",
+    "category": "remove-section",
+    "baseline": "# Password reset flow\n\nRebuild the forgotten-password experience.\n\n<Phase title=\"Token generation\">\nGenerate a single-use, time-boxed reset token.\n</Phase>\n\n<Callout type=\"warn\">\nNever log the reset token in plaintext.\n</Callout>\n\n<Phase title=\"Reset page\">\nServe the form that consumes the token and sets a new password.\n</Phase>\n",
+    "current": "# Password reset flow\n\nRebuild the forgotten-password experience.\n\n<Phase title=\"Token generation\">\nGenerate a single-use, time-boxed reset token.\n</Phase>\n\n<Phase title=\"Reset page\">\nServe the form that consumes the token and sets a new password.\n</Phase>\n",
+    "expectedStatuses": ["unchanged", "unchanged", "unchanged"],
+    "expectedRemovedTypes": ["callout"],
+    "confidence": "core"
+  },
+  {
+    "name": "remove-trailing-phase-and-stat",
+    "category": "remove-section",
+    "baseline": "# Onboarding revamp\n\nReduce time-to-first-value for new signups.\n\n<Phase title=\"Welcome tour\">\nAdd a dismissible three-step product tour.\n</Phase>\n\n<Stat title=\"Target activation\">\n45 percent within seven days\n</Stat>\n\n<Phase title=\"Sample data seeding\">\nSeed each new account with example projects.\n</Phase>\n",
+    "current": "# Onboarding revamp\n\nReduce time-to-first-value for new signups.\n\n<Phase title=\"Welcome tour\">\nAdd a dismissible three-step product tour.\n</Phase>\n",
+    "expectedStatuses": ["unchanged", "unchanged"],
+    "expectedRemovedTypes": ["stat", "phase"],
+    "confidence": "core"
+  },
+  {
+    "name": "rename-phase-title-body-unchanged",
+    "category": "rename-title",
+    "baseline": "# Billing integration\n\nIntegrate the Stripe billing API.\n\n<Phase title=\"Build the limiter\">\nImplement the per-customer rate limiter using a Redis sliding window and a fail-open fallback when Redis is unavailable.\n</Phase>\n\n<Phase title=\"Invoice sync\">\nMirror Stripe invoices into our database on webhook receipt.\n</Phase>\n",
+    "current": "# Billing integration\n\nIntegrate the Stripe billing API.\n\n<Phase title=\"Build the rate limiter\">\nImplement the per-customer rate limiter using a Redis sliding window and a fail-open fallback when Redis is unavailable.\n</Phase>\n\n<Phase title=\"Invoice sync\">\nMirror Stripe invoices into our database on webhook receipt.\n</Phase>\n",
+    "expectedStatuses": ["unchanged", "edited", "unchanged"],
+    "expectedRemovedTypes": [],
+    "confidence": "core"
+  },
+  {
+    "name": "rename-heading-body-mostly-unchanged",
+    "category": "rename-title",
+    "baseline": "# Incident runbook\n\n## Detection\n\nAlerts fire from the latency SLO burn-rate monitor and page the on-call engineer through PagerDuty within two minutes.\n\n## Mitigation\n\nDrain the unhealthy region and shift traffic to the standby.\n",
+    "current": "# Incident runbook\n\n## Detect the incident\n\nAlerts fire from the latency SLO burn-rate monitor and page the on-call engineer through PagerDuty within two minutes.\n\n## Mitigation\n\nDrain the unhealthy region and shift traffic to the standby.\n",
+    "expectedStatuses": ["unchanged", "edited", "unchanged"],
+    "expectedRemovedTypes": [],
+    "confidence": "core"
+  },
+  {
+    "name": "rename-checklist-title-body-unchanged",
+    "category": "rename-title",
+    "baseline": "# Release process\n\nStandardize how we cut a production release.\n\n<Checklist title=\"Pre-flight\">\n- Freeze the release branch\n- Run the full e2e suite\n- Verify migrations are reversible\n- Post the changelog to the channel\n</Checklist>\n",
+    "current": "# Release process\n\nStandardize how we cut a production release.\n\n<Checklist title=\"Pre-flight checks\">\n- Freeze the release branch\n- Run the full e2e suite\n- Verify migrations are reversible\n- Post the changelog to the channel\n</Checklist>\n",
+    "expectedStatuses": ["unchanged", "edited"],
+    "expectedRemovedTypes": [],
+    "confidence": "core"
+  },
+  {
+    "name": "rename-phase-title-borderline-half-rewrite",
+    "category": "rename-title",
+    "baseline": "# API gateway rollout\n\nPut every public endpoint behind a managed gateway.\n\n<Phase title=\"Pilot one service\">\nRoute the read-only catalog service through the gateway and watch p99 latency for a week before expanding.\n</Phase>\n\n<Phase title=\"Document the contract\">\nPublish the OpenAPI spec for partners.\n</Phase>\n",
+    "current": "# API gateway rollout\n\nPut every public endpoint behind a managed gateway.\n\n<Phase title=\"Initial limited rollout\">\nRoute the read-only catalog service through the gateway first, enable request logging and per-route quotas, then review error budgets before onboarding the write services.\n</Phase>\n\n<Phase title=\"Document the contract\">\nPublish the OpenAPI spec for partners.\n</Phase>\n",
+    "expectedStatuses": ["unchanged", "edited", "unchanged"],
+    "expectedRemovedTypes": [],
+    "confidence": "stretch"
+  },
+  {
+    "name": "rename-heading-borderline-heavy-reword",
+    "category": "rename-title",
+    "baseline": "# Cache layer\n\n## Eviction policy\n\nUse an LRU policy with a fixed memory ceiling and a sixty second TTL on every entry to bound staleness.\n",
+    "current": "# Cache layer\n\n## Memory management\n\nApply LRU eviction, cap the heap at a fixed ceiling, and expire keys after sixty seconds so reads never serve badly stale data while keeping the hit rate high.\n",
+    "expectedStatuses": ["unchanged", "edited"],
+    "expectedRemovedTypes": [],
+    "confidence": "stretch"
+  },
+  {
+    "name": "edit-callout-body-titleless",
+    "category": "edit-titleless",
+    "baseline": "# Webhook hardening\n\nMake inbound webhook handling resilient.\n\n<Callout type=\"risk\">\nUnsigned webhook payloads can be spoofed by anyone who knows the URL.\n</Callout>\n\n<Phase title=\"Verify signatures\">\nReject any request whose HMAC signature does not match.\n</Phase>\n",
+    "current": "# Webhook hardening\n\nMake inbound webhook handling resilient.\n\n<Callout type=\"risk\">\nUnsigned webhook payloads can be spoofed by anyone who knows the URL, and replayed payloads can double-charge customers.\n</Callout>\n\n<Phase title=\"Verify signatures\">\nReject any request whose HMAC signature does not match.\n</Phase>\n",
+    "expectedStatuses": ["unchanged", "edited", "unchanged"],
+    "expectedRemovedTypes": [],
+    "confidence": "core"
+  },
+  {
+    "name": "edit-filetree-entry-titleless",
+    "category": "edit-titleless",
+    "baseline": "# Module reorg\n\nSplit the monolithic utils file into focused modules.\n\n<FileTree>\n- src/\n  - utils.ts\n  - index.ts\n</FileTree>\n\n<Phase title=\"Move helpers\">\nRelocate each helper to its new home and update imports.\n</Phase>\n",
+    "current": "# Module reorg\n\nSplit the monolithic utils file into focused modules.\n\n<FileTree>\n- src/\n  - format.ts\n  - validate.ts\n  - index.ts\n</FileTree>\n\n<Phase title=\"Move helpers\">\nRelocate each helper to its new home and update imports.\n</Phase>\n",
+    "expectedStatuses": ["unchanged", "edited", "unchanged"],
+    "expectedRemovedTypes": [],
+    "confidence": "stretch"
+  },
+  {
+    "name": "edit-mermaid-diagram-titleless",
+    "category": "edit-titleless",
+    "baseline": "# Auth flow\n\nDocument the OAuth handshake.\n\n```mermaid\nflowchart LR\n  User --> App\n  App --> Provider\n```\n\n<Phase title=\"Implement callback\">\nExchange the code for tokens on the callback route.\n</Phase>\n",
+    "current": "# Auth flow\n\nDocument the OAuth handshake.\n\n```mermaid\nflowchart LR\n  User --> App\n  App --> Provider\n  Provider --> App\n```\n\n<Phase title=\"Implement callback\">\nExchange the code for tokens on the callback route.\n</Phase>\n",
+    "expectedStatuses": ["unchanged", "edited", "unchanged"],
+    "expectedRemovedTypes": [],
+    "confidence": "core"
+  },
+  {
+    "name": "reorder-two-phases",
+    "category": "reorder",
+    "baseline": "# Deploy pipeline\n\nFormalize the continuous deployment pipeline.\n\n<Phase title=\"Build and test\">\nCompile the project and run the unit and integration suites.\n</Phase>\n\n<Phase title=\"Deploy to staging\">\nPromote the artifact to the staging environment automatically.\n</Phase>\n",
+    "current": "# Deploy pipeline\n\nFormalize the continuous deployment pipeline.\n\n<Phase title=\"Deploy to staging\">\nPromote the artifact to the staging environment automatically.\n</Phase>\n\n<Phase title=\"Build and test\">\nCompile the project and run the unit and integration suites.\n</Phase>\n",
+    "expectedStatuses": ["unchanged", "unchanged", "unchanged"],
+    "expectedRemovedTypes": [],
+    "confidence": "stretch"
+  },
+  {
+    "name": "mixed-edit-add-remove",
+    "category": "mixed",
+    "baseline": "# Customer export feature\n\nLet customers download all their data on demand.\n\n<Phase title=\"Gather data\">\nQuery every table that holds customer-owned records.\n</Phase>\n\n<Callout type=\"note\">\nExports must complete within the request timeout.\n</Callout>\n\n<Phase title=\"Package the archive\">\nZip the JSON files and store them in a bucket.\n</Phase>\n",
+    "current": "# Customer export feature\n\nLet customers download all their data on demand.\n\n<Phase title=\"Gather data\">\nQuery every table that holds customer-owned records, including soft-deleted rows that the customer can still recover.\n</Phase>\n\n<Phase title=\"Package the archive\">\nZip the JSON files and store them in a bucket.\n</Phase>\n\n<Phase title=\"Email the download link\">\nSend a signed, expiring URL once the archive is ready.\n</Phase>\n",
+    "expectedStatuses": ["unchanged", "edited", "unchanged", "added"],
+    "expectedRemovedTypes": ["callout"],
+    "confidence": "core"
+  },
+  {
+    "name": "mixed-rename-edit-titleless-add",
+    "category": "mixed",
+    "baseline": "# Fraud detection rollout\n\nDeploy the real-time fraud scoring model.\n\n<Phase title=\"Shadow mode\">\nScore live transactions without acting on the result and compare against the current rules engine.\n</Phase>\n\n<Compare>\nRules engine vs ML model on the holdout set.\n</Compare>\n",
+    "current": "# Fraud detection rollout\n\nDeploy the real-time fraud scoring model.\n\n<Phase title=\"Run in shadow mode\">\nScore live transactions without acting on the result and compare against the current rules engine.\n</Phase>\n\n<Compare>\nRules engine vs ML model on the holdout set, broken down by transaction size band.\n</Compare>\n\n<Phase title=\"Enforce blocks\">\nStart declining transactions above the score threshold.\n</Phase>\n",
+    "expectedStatuses": ["unchanged", "edited", "edited", "added"],
+    "expectedRemovedTypes": [],
+    "confidence": "core"
+  },
+  {
+    "name": "edit-questions-body-under-same-title",
+    "category": "edit-body",
+    "baseline": "# Pricing experiment\n\nTest a usage-based pricing tier.\n\n<Questions title=\"Open questions\">\n- What is the unit of metering?\n- How do we handle overage?\n</Questions>\n\n<Phase title=\"Instrument usage\">\nEmit a metering event on every billable action.\n</Phase>\n",
+    "current": "# Pricing experiment\n\nTest a usage-based pricing tier.\n\n<Questions title=\"Open questions\">\n- What is the unit of metering?\n- How do we handle overage?\n- Do existing customers get grandfathered onto the old plan?\n</Questions>\n\n<Phase title=\"Instrument usage\">\nEmit a metering event on every billable action.\n</Phase>\n",
+    "expectedStatuses": ["unchanged", "edited", "unchanged"],
+    "expectedRemovedTypes": [],
+    "confidence": "core"
+  }
+]

--- a/packages/compile/tests/sections.test.ts
+++ b/packages/compile/tests/sections.test.ts
@@ -137,6 +137,22 @@ Watch out.
     ])
   })
 
+  it('excludes data-component children from a section prose (so word-diff stays clean)', () => {
+    const source = `# Title
+
+<Phase title="Build">
+Wrap the SDK.
+
+<FileTree>
+- add src/x.ts
+</FileTree>
+</Phase>
+`
+    const phase = splitSections(source)[1]
+    // Prose carries the paragraph but not the FileTree entry text (which tokenizes unlike its source).
+    expect(phase?.prose).toBe('Wrap the SDK.')
+  })
+
   it('gives titled sections a label-based key and titleless ones a content-based key', () => {
     const sections = splitSections(BASE)
     const phase = sections[1]

--- a/packages/compile/tests/sections.test.ts
+++ b/packages/compile/tests/sections.test.ts
@@ -226,6 +226,13 @@ describe('diffSections', () => {
     expect(callout?.prev).toBeUndefined()
   })
 
+  it('carries the baseline label as prevLabel on a renamed section', () => {
+    const current = BASE.replace('title="Build the limiter"', 'title="Build the rate limiter"')
+    const phase = diffSections(BASE, current).sections[1]
+    expect(phase?.status).toBe('edited')
+    expect(phase?.prevLabel).toBe('Build the limiter')
+  })
+
   it('detects a reworded title as an edit (rename), not a remove + add', () => {
     const current = BASE.replace('title="Build the limiter"', 'title="Build the rate limiter"')
     const diff = diffSections(BASE, current)

--- a/packages/compile/tests/sections.test.ts
+++ b/packages/compile/tests/sections.test.ts
@@ -196,6 +196,20 @@ describe('diffSections', () => {
     expect(diff.removed.map(r => r.type)).toEqual(['callout'])
   })
 
+  it('carries the baseline prose as prev on an edited section, not on others', () => {
+    const current = BASE.replace(
+      'Implement the Redis window.',
+      'Implement the sliding window in Redis.',
+    )
+    const diff = diffSections(BASE, current)
+    const [title, phase, callout] = diff.sections
+    expect(phase?.status).toBe('edited')
+    expect(phase?.prev).toBe('Implement the Redis window.')
+    // Unchanged sections (and added ones) carry no prev.
+    expect(title?.prev).toBeUndefined()
+    expect(callout?.prev).toBeUndefined()
+  })
+
   it('detects a reworded title as an edit (rename), not a remove + add', () => {
     const current = BASE.replace('title="Build the limiter"', 'title="Build the rate limiter"')
     const diff = diffSections(BASE, current)

--- a/packages/compile/tests/sections.test.ts
+++ b/packages/compile/tests/sections.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it } from 'vitest'
+import { diffSections, splitSections } from '../src/sections.js'
+
+/** A small well-formed plan used as the unchanged baseline across the diff cases. */
+const BASE = `# Rate limiting
+
+Intro prose before the first phase.
+
+<Phase title="Build the limiter">
+Implement the Redis window.
+</Phase>
+
+<Callout type="risk">
+A Redis outage must fail open.
+</Callout>
+
+<Phase title="Ship it">
+Roll out behind a flag.
+</Phase>
+`
+
+describe('splitSections', () => {
+  it('enumerates the section-start blocks in document order', () => {
+    const sections = splitSections(BASE)
+    expect(sections.map(s => s.type)).toEqual(['h1', 'phase', 'callout', 'phase'])
+    expect(sections.map(s => s.label)).toEqual([
+      'Rate limiting',
+      'Build the limiter',
+      'Risk',
+      'Ship it',
+    ])
+  })
+
+  it('does not treat nested blocks or non-section blocks as starts', () => {
+    const source = `# Title
+
+<Phase title="Outer">
+Some text.
+
+<Callout type="note">
+Nested callout, not a top-level section.
+</Callout>
+</Phase>
+
+\`\`\`math
+T(n) = O(n)
+\`\`\`
+`
+    // h1 + the one top-level Phase only; the nested Callout and the math fence are not starts.
+    expect(splitSections(source).map(s => s.type)).toEqual(['h1', 'phase'])
+  })
+
+  it('treats a mermaid fence as a section start but not a regular code fence', () => {
+    const source = `# Title
+
+\`\`\`mermaid
+flowchart LR
+  A --> B
+\`\`\`
+
+\`\`\`ts
+const x = 1
+\`\`\`
+`
+    expect(splitSections(source).map(s => s.type)).toEqual(['h1', 'mermaid'])
+  })
+
+  it('gives titled sections a label-based key and titleless ones a content-based key', () => {
+    const sections = splitSections(BASE)
+    const phase = sections[1]
+    const callout = sections[2]
+    expect(phase?.titled).toBe(true)
+    expect(phase?.key).toBe('phase:Build the limiter')
+    expect(callout?.titled).toBe(false)
+    expect(callout?.key).toMatch(/^callout:#/)
+  })
+})
+
+describe('diffSections', () => {
+  it('reports every section unchanged when the source is identical', () => {
+    const diff = diffSections(BASE, BASE)
+    expect(diff.sections.map(s => s.status)).toEqual([
+      'unchanged',
+      'unchanged',
+      'unchanged',
+      'unchanged',
+    ])
+    expect(diff.removed).toEqual([])
+  })
+
+  it('marks an edited phase body as edited and leaves its siblings unchanged', () => {
+    const current = BASE.replace(
+      'Implement the Redis window.',
+      'Implement the sliding window in Redis.',
+    )
+    const diff = diffSections(BASE, current)
+    expect(diff.sections.map(s => s.status)).toEqual([
+      'unchanged',
+      'edited',
+      'unchanged',
+      'unchanged',
+    ])
+  })
+
+  it('marks a newly inserted section as added and keeps the rest stable', () => {
+    const current = BASE.replace(
+      '<Phase title="Ship it">',
+      '<Phase title="Test it">\nWrite the tests.\n</Phase>\n\n<Phase title="Ship it">',
+    )
+    const diff = diffSections(BASE, current)
+    expect(diff.sections.map(s => s.status)).toEqual([
+      'unchanged',
+      'unchanged',
+      'unchanged',
+      'added',
+      'unchanged',
+    ])
+  })
+
+  it('reports a deleted section under removed, not in the current sections', () => {
+    const current = BASE.replace(/<Callout type="risk">[\s\S]*?<\/Callout>\n\n/, '')
+    const diff = diffSections(BASE, current)
+    expect(diff.sections.map(s => s.status)).toEqual(['unchanged', 'unchanged', 'unchanged'])
+    expect(diff.removed.map(r => r.type)).toEqual(['callout'])
+  })
+
+  it('detects a reworded title as an edit (rename), not a remove + add', () => {
+    const current = BASE.replace('title="Build the limiter"', 'title="Build the rate limiter"')
+    const diff = diffSections(BASE, current)
+    expect(diff.sections.map(s => s.status)).toEqual([
+      'unchanged',
+      'edited',
+      'unchanged',
+      'unchanged',
+    ])
+    expect(diff.removed).toEqual([])
+  })
+})

--- a/packages/compile/tests/sections.test.ts
+++ b/packages/compile/tests/sections.test.ts
@@ -65,6 +65,78 @@ const x = 1
     expect(splitSections(source).map(s => s.type)).toEqual(['h1', 'mermaid'])
   })
 
+  // PARITY GOLDEN: this exact ordered type sequence is also asserted against the runtime's DOM-based
+  // `collectSections` in packages/runtime/tests/section-comments.test.ts ("full vocabulary parity").
+  // The two must agree, because the runtime maps a diff status onto a DOM section by document-order
+  // index. If you add or remove a section-starting component, update BOTH goldens together.
+  it('covers the full section-start vocabulary in order (parity golden)', () => {
+    const source = `# Title
+
+## Section two
+
+### Section three
+
+\`\`\`mermaid
+flowchart LR
+  A --> B
+\`\`\`
+
+<Phase title="Build">
+Do the thing.
+</Phase>
+
+<Callout type="risk">
+Watch out.
+</Callout>
+
+<FileTree>
+- add src/x.ts
+</FileTree>
+
+<Chart type="bar" title="Effort">
+- A: 1
+</Chart>
+
+<Matrix>
+| Dim | A | B |
+|-----|---|---|
+| x   | 1 | 2 |
+</Matrix>
+
+<Compare>
+## Option A
+- pro: fast
+</Compare>
+
+<Checklist title="Done when">
+- [ ] works
+</Checklist>
+
+<Stat>
+- Files: 3
+</Stat>
+
+<Questions>
+- Is it ready?
+</Questions>
+`
+    expect(splitSections(source).map(s => s.type)).toEqual([
+      'h1',
+      'h2',
+      'h3',
+      'mermaid',
+      'phase',
+      'callout',
+      'filetree',
+      'chart',
+      'matrix',
+      'compare',
+      'checklist',
+      'stat',
+      'questions',
+    ])
+  })
+
   it('gives titled sections a label-based key and titleless ones a content-based key', () => {
     const sections = splitSections(BASE)
     const phase = sections[1]

--- a/packages/runtime/AGENTS.md
+++ b/packages/runtime/AGENTS.md
@@ -39,21 +39,23 @@ the root AGENTS.md for why Vite is configured without `@vitejs/plugin-react`.
   while undecided is now just a courtesy, the actual Deny no longer depends on the page sending
   anything during unload.
 - `components/DiffCues.tsx` renders iteration diff cues when the CLI injected `__VP_DIFF__` (any
-  render/watch/review with a baseline, NOT review-gated). All fixed-position overlay (plan DOM
-  untouched): a git-gutter left edge-accent bar beside each added (`--vp-done`) / edited
-  (`--vp-modify`) section, a bottom-left summary chip, and an "only changes" toggle that scrims
-  unchanged sections. Each edited section **also shows a true inline word diff by default** (not
-  behind the toggle, so it is not missed): `applyInlineWordDiff` word-diffs the section's `<p>` prose
-  against its injected baseline prose (`prev`) and re-renders the first prose paragraph as the diff,
-  deletions in `<del class="vp-diff-del">` (struck red) and insertions in `<ins class="vp-diff-ins">`
-  (green). This **mutates the plan DOM** (a deletion is not otherwise in the page) but only the prose,
-  and reversibly (the effect's cleanup restores it). It scopes to authored prose (`<p>` not inside a
-  data component), so file paths / table cells / task items never produce false diffs, and scans a
-  section's full owned sibling span (a heading plus its intro paragraph). `components/review/diff.ts`
-  holds the **pure**, jsdom-tested helpers (`diffOverlays`, `wordDiffOps`, `applyInlineWordDiff`,
-  `sectionOwnedElements`). Known limit: inline formatting (bold/links) in an edited paragraph is
-  flattened to text while the diff is shown, and word-level granularity re-marks a word on a
-  punctuation-only change. **Parity contract:** the injected `__VP_DIFF__.sections` is one entry
+  render/watch/review with a baseline, NOT review-gated). Always on: a change bar **flush to the left
+  edge of the viewport** (`left: 0`, a dedicated lane clear of the content gutter so it never piles up
+  with the phase timeline or review comment badges) for each added (`--vp-done`) / edited
+  (`--vp-modify`) section, plus a bottom-left summary chip. The **"Show changes"** toggle reveals the
+  inline word diff and scrims unchanged sections. The inline diff (`applyInlineWordDiff` for the
+  body prose, `applyTitleDiff` for a renamed title) word-diffs each edited section against its injected
+  baseline (`prev` = body prose, `prevLabel` = old title) and re-renders it as `<del class="vp-diff-del">`
+  (red strikethrough) / `<ins class="vp-diff-ins">` (green-tinted), keeping the text its normal color so
+  it stays readable. `prevLabel` is what surfaces a rename whose body is unchanged (else the section is
+  "marked changed but nothing differs"). This **mutates the plan DOM** (a deletion is not otherwise in
+  the page) but only the prose/title, reversibly (the effect cleanup restores it). It scopes to authored
+  prose (`<p>` not inside a data component), so file paths / table cells never produce false diffs, and
+  scans a section's full owned sibling span (a heading plus its intro paragraph). `wordDiffOps` compares
+  on a punctuation-stripped, lowercased word core, so a trailing-comma or capitalization change is not
+  noise. `components/review/diff.ts` holds the **pure**, jsdom-tested helpers (`diffOverlays`,
+  `wordDiffOps`, `applyInlineWordDiff`, `applyTitleDiff`, `sectionOwnedElements`). Known limit: inline
+  formatting (bold/links) in an edited paragraph is flattened to text while the diff is shown. **Parity contract:** the injected `__VP_DIFF__.sections` is one entry
   per current section in document order, mapped onto `collectSections()` output BY INDEX, so the
   counts must agree; `diffOverlays` returns nothing on a mismatch (degrade, never mislabel). This DOM
   split and `@visualplan/compile`'s mdast `splitSections` are kept aligned by paired parity goldens

--- a/packages/runtime/AGENTS.md
+++ b/packages/runtime/AGENTS.md
@@ -38,6 +38,17 @@ the root AGENTS.md for why Vite is configured without `@vitejs/plugin-react`.
   `sendBeacon`, which is dropped on a real close (it only survived navigation). A `beforeunload` prompt
   while undecided is now just a courtesy, the actual Deny no longer depends on the page sending
   anything during unload.
+- `components/DiffCues.tsx` renders iteration diff cues when the CLI injected `__VP_DIFF__` (any
+  render/watch/review with a baseline, NOT review-gated). All fixed-position overlay (plan DOM
+  untouched): a git-gutter left edge-accent bar beside each added (`--vp-done`) / edited
+  (`--vp-modify`) section, a bottom-left summary chip, and an "only changes" toggle that scrims
+  unchanged sections. `components/review/diff.ts` reads the global and holds `diffOverlays`, a **pure**
+  helper (unit-tested in jsdom). **Parity contract:** the injected `__VP_DIFF__.sections` is one entry
+  per current section in document order, mapped onto `collectSections()` output BY INDEX, so the
+  counts must agree; `diffOverlays` returns nothing on a mismatch (degrade, never mislabel). This DOM
+  split and `@visualplan/compile`'s mdast `splitSections` are kept aligned by paired parity goldens
+  (`tests/section-comments.test.ts` here + `packages/compile/tests/sections.test.ts`); update both
+  when the section-start vocabulary changes.
 - `components/ThemeToggle.tsx` is the fixed top-right cog, just left of the share button. Its menu
   picks `system` / `light` / `dark`; choosing one recolors the page live (all colors are CSS vars,
   so flipping `<html data-theme>` repaints with no React re-render) and persists the choice in

--- a/packages/runtime/AGENTS.md
+++ b/packages/runtime/AGENTS.md
@@ -42,13 +42,18 @@ the root AGENTS.md for why Vite is configured without `@vitejs/plugin-react`.
   render/watch/review with a baseline, NOT review-gated). All fixed-position overlay (plan DOM
   untouched): a git-gutter left edge-accent bar beside each added (`--vp-done`) / edited
   (`--vp-modify`) section, a bottom-left summary chip, and an "only changes" toggle that scrims
-  unchanged sections AND reveals the exact changed words inside edited ones. The word reveal
-  word-diffs each edited section's `p`/`li` prose against its injected baseline prose (`prev`) and
-  registers the inserted words as a **CSS Custom Highlight** (`::highlight(vp-diff-ins)`) — no DOM
-  mutation, feature-detected (degrades to bars-only on older browsers). It scopes to prose so titles
-  and chrome never false-hit, and scans a section's full owned sibling span (a heading plus its intro
-  paragraph), not just the start element. `components/review/diff.ts` reads the global and holds the
-  **pure**, jsdom-tested helpers (`diffOverlays`, `insertedWordRanges`, `sectionOwnedElements`). **Parity contract:** the injected `__VP_DIFF__.sections` is one entry
+  unchanged sections. Each edited section **also shows a true inline word diff by default** (not
+  behind the toggle, so it is not missed): `applyInlineWordDiff` word-diffs the section's `<p>` prose
+  against its injected baseline prose (`prev`) and re-renders the first prose paragraph as the diff,
+  deletions in `<del class="vp-diff-del">` (struck red) and insertions in `<ins class="vp-diff-ins">`
+  (green). This **mutates the plan DOM** (a deletion is not otherwise in the page) but only the prose,
+  and reversibly (the effect's cleanup restores it). It scopes to authored prose (`<p>` not inside a
+  data component), so file paths / table cells / task items never produce false diffs, and scans a
+  section's full owned sibling span (a heading plus its intro paragraph). `components/review/diff.ts`
+  holds the **pure**, jsdom-tested helpers (`diffOverlays`, `wordDiffOps`, `applyInlineWordDiff`,
+  `sectionOwnedElements`). Known limit: inline formatting (bold/links) in an edited paragraph is
+  flattened to text while the diff is shown, and word-level granularity re-marks a word on a
+  punctuation-only change. **Parity contract:** the injected `__VP_DIFF__.sections` is one entry
   per current section in document order, mapped onto `collectSections()` output BY INDEX, so the
   counts must agree; `diffOverlays` returns nothing on a mismatch (degrade, never mislabel). This DOM
   split and `@visualplan/compile`'s mdast `splitSections` are kept aligned by paired parity goldens

--- a/packages/runtime/AGENTS.md
+++ b/packages/runtime/AGENTS.md
@@ -42,8 +42,13 @@ the root AGENTS.md for why Vite is configured without `@vitejs/plugin-react`.
   render/watch/review with a baseline, NOT review-gated). All fixed-position overlay (plan DOM
   untouched): a git-gutter left edge-accent bar beside each added (`--vp-done`) / edited
   (`--vp-modify`) section, a bottom-left summary chip, and an "only changes" toggle that scrims
-  unchanged sections. `components/review/diff.ts` reads the global and holds `diffOverlays`, a **pure**
-  helper (unit-tested in jsdom). **Parity contract:** the injected `__VP_DIFF__.sections` is one entry
+  unchanged sections AND reveals the exact changed words inside edited ones. The word reveal
+  word-diffs each edited section's `p`/`li` prose against its injected baseline prose (`prev`) and
+  registers the inserted words as a **CSS Custom Highlight** (`::highlight(vp-diff-ins)`) — no DOM
+  mutation, feature-detected (degrades to bars-only on older browsers). It scopes to prose so titles
+  and chrome never false-hit, and scans a section's full owned sibling span (a heading plus its intro
+  paragraph), not just the start element. `components/review/diff.ts` reads the global and holds the
+  **pure**, jsdom-tested helpers (`diffOverlays`, `insertedWordRanges`, `sectionOwnedElements`). **Parity contract:** the injected `__VP_DIFF__.sections` is one entry
   per current section in document order, mapped onto `collectSections()` output BY INDEX, so the
   counts must agree; `diffOverlays` returns nothing on a mismatch (degrade, never mislabel). This DOM
   split and `@visualplan/compile`'s mdast `splitSections` are kept aligned by paired parity goldens

--- a/packages/runtime/Layout.tsx
+++ b/packages/runtime/Layout.tsx
@@ -1,4 +1,5 @@
 import { type ReactNode, useEffect } from 'react'
+import { DiffCues } from './components/DiffCues.js'
 import { ReviewAnswersProvider } from './components/review/ReviewAnswers.js'
 import { ReviewLayer } from './components/review/ReviewLayer.js'
 import { ShareButton } from './components/ShareButton.js'
@@ -23,6 +24,7 @@ export function Layout({ children }: { children: ReactNode }) {
         <ShareButton />
         {!isThemeLocked() && <ThemeToggle />}
         <main className='vp-main'>{children}</main>
+        <DiffCues />
         <ReviewLayer />
       </div>
     </ReviewAnswersProvider>

--- a/packages/runtime/components/DiffCues.tsx
+++ b/packages/runtime/components/DiffCues.tsx
@@ -32,7 +32,9 @@ export function DiffCues() {
 
 function DiffOverlay({ diff }: { diff: NonNullable<ReturnType<typeof readDiff>> }) {
   const [sections, setSections] = useState<Section[]>([])
-  const [onlyChanges, setOnlyChanges] = useState(false)
+  // The gutter bars are always on; "Show changes" reveals the inline word diffs and fades unchanged
+  // sections to focus on the deltas.
+  const [showChanges, setShowChanges] = useState(false)
   // Overlays read live rects, so a scroll/resize must re-render them to stay pinned to the content.
   const [, setTick] = useState(0)
 
@@ -48,11 +50,11 @@ function DiffOverlay({ diff }: { diff: NonNullable<ReturnType<typeof readDiff>> 
     }
   }, [])
 
-  // Render the word-level changes inline on every diff render (not behind the toggle, so they are
-  // not missed): re-render each edited section's prose as a diff, deletions struck through and
-  // insertions marked. Restored on cleanup (deps change / unmount).
+  // Reveal the word-level changes inline only while "Show changes" is active: re-render each edited
+  // section's prose as a diff, deletions struck through and insertions marked. The cleanup restores
+  // the prose when the toggle goes off (or on unmount).
   useEffect(() => {
-    if (sections.length !== diff.sections.length) return
+    if (!showChanges || sections.length !== diff.sections.length) return
     const restores = sections.flatMap((section, index) => {
       const entry = diff.sections[index]
       return entry?.status === 'edited' && entry.prev
@@ -62,14 +64,14 @@ function DiffOverlay({ diff }: { diff: NonNullable<ReturnType<typeof readDiff>> 
     return () => {
       for (const restore of restores) restore()
     }
-  }, [sections, diff])
+  }, [showChanges, sections, diff])
 
   const changedCount = diff.sections.filter(s => isChanged(s.status)).length
   const removedCount = diff.removed.length
   // A re-render of an identical plan has nothing to surface, so show no chrome at all.
   if (changedCount === 0 && removedCount === 0) return null
 
-  const overlays = diffOverlays(sections, diff, onlyChanges)
+  const overlays = diffOverlays(sections, diff, showChanges)
   // The toggle only does something when the bars are mapped (the diff and DOM section counts agree).
   const mapped = sections.length === diff.sections.length
 
@@ -104,10 +106,10 @@ function DiffOverlay({ diff }: { diff: NonNullable<ReturnType<typeof readDiff>> 
           <button
             type='button'
             className='vp-diff-toggle'
-            data-active={onlyChanges}
-            onClick={() => setOnlyChanges(value => !value)}
+            data-active={showChanges}
+            onClick={() => setShowChanges(value => !value)}
           >
-            Only changes
+            Show changes
           </button>
         )}
       </div>

--- a/packages/runtime/components/DiffCues.tsx
+++ b/packages/runtime/components/DiffCues.tsx
@@ -2,6 +2,7 @@ import { IconGitCommit } from '@tabler/icons-react'
 import { useEffect, useState } from 'react'
 import {
   applyInlineWordDiff,
+  applyTitleDiff,
   type DiffStatus,
   diffOverlays,
   isChanged,
@@ -58,9 +59,13 @@ function DiffOverlay({ diff }: { diff: NonNullable<ReturnType<typeof readDiff>> 
     if (!showChanges || sections.length !== diff.sections.length) return
     const restores = sections.flatMap((section, index) => {
       const entry = diff.sections[index]
-      return entry?.status === 'edited' && entry.prev
-        ? [applyInlineWordDiff(sectionOwnedElements(section), entry.prev)]
-        : []
+      if (entry?.status !== 'edited') return []
+      const sectionRestores: (() => void)[] = []
+      // A rename (prevLabel) shows in the title; a body edit (prev) shows in the prose. Either or both.
+      if (entry.prevLabel) sectionRestores.push(applyTitleDiff(section, entry.prevLabel))
+      if (entry.prev)
+        sectionRestores.push(applyInlineWordDiff(sectionOwnedElements(section), entry.prev))
+      return sectionRestores
     })
     return () => {
       for (const restore of restores) restore()

--- a/packages/runtime/components/DiffCues.tsx
+++ b/packages/runtime/components/DiffCues.tsx
@@ -1,0 +1,101 @@
+import { IconGitCommit } from '@tabler/icons-react'
+import { useEffect, useState } from 'react'
+import { type DiffStatus, diffOverlays, isChanged, readDiff } from './review/diff.js'
+import { collectSections, type Section } from './review/SectionComments.js'
+import './diff.css'
+
+/** The status color token for a changed section's gutter bar (added = done-green, edited = amber). */
+const STATUS_COLOR: Record<DiffStatus, string> = {
+  added: 'var(--vp-done)',
+  edited: 'var(--vp-modify)',
+  unchanged: 'transparent',
+}
+
+/**
+ * Iteration diff cues: a git-gutter-style left edge-accent bar beside each added/edited section, a
+ * summary chip with the change counts, and an "only changes" toggle that fades unchanged sections.
+ * Renders whenever the CLI injected `__VP_DIFF__` (a render/watch/review with a baseline), not just in
+ * review mode. Everything is fixed-position overlay; the plan DOM is never touched.
+ */
+export function DiffCues() {
+  const diff = readDiff()
+  if (!diff) return null
+  return <DiffOverlay diff={diff} />
+}
+
+function DiffOverlay({ diff }: { diff: NonNullable<ReturnType<typeof readDiff>> }) {
+  const [sections, setSections] = useState<Section[]>([])
+  const [onlyChanges, setOnlyChanges] = useState(false)
+  // Overlays read live rects, so a scroll/resize must re-render them to stay pinned to the content.
+  const [, setTick] = useState(0)
+
+  useEffect(() => setSections(collectSections()), [])
+
+  useEffect(() => {
+    const onReflow = () => setTick(tick => tick + 1)
+    window.addEventListener('scroll', onReflow, { passive: true })
+    window.addEventListener('resize', onReflow)
+    return () => {
+      window.removeEventListener('scroll', onReflow)
+      window.removeEventListener('resize', onReflow)
+    }
+  }, [])
+
+  const changedCount = diff.sections.filter(s => isChanged(s.status)).length
+  const removedCount = diff.removed.length
+  // A re-render of an identical plan has nothing to surface, so show no chrome at all.
+  if (changedCount === 0 && removedCount === 0) return null
+
+  const overlays = diffOverlays(sections, diff, onlyChanges)
+  // The toggle only does something when the bars are mapped (the diff and DOM section counts agree).
+  const mapped = sections.length === diff.sections.length
+
+  return (
+    <>
+      {overlays.map(overlay =>
+        overlay.kind === 'bar' ? (
+          <div
+            key={overlay.sectionIndex}
+            className='vp-diff-bar'
+            data-status={overlay.status}
+            style={{
+              top: overlay.rect.top,
+              left: overlay.rect.left,
+              height: overlay.rect.height,
+              background: STATUS_COLOR[overlay.status],
+            }}
+          />
+        ) : (
+          // Fade an unchanged section so the changed ones stand out; an overlay scrim, never a DOM edit.
+          <div
+            key={overlay.sectionIndex}
+            className='vp-diff-scrim'
+            style={{ top: overlay.rect.top, left: 10, right: 10, height: overlay.rect.height }}
+          />
+        ),
+      )}
+      <div className='vp-diff-summary'>
+        <IconGitCommit size={14} />
+        <span>{summaryText(changedCount, removedCount)}</span>
+        {mapped && changedCount > 0 && (
+          <button
+            type='button'
+            className='vp-diff-toggle'
+            data-active={onlyChanges}
+            onClick={() => setOnlyChanges(value => !value)}
+          >
+            Only changes
+          </button>
+        )}
+      </div>
+    </>
+  )
+}
+
+/** "3 changed since last view" plus removed count, pluralized; the chip's text. */
+function summaryText(changed: number, removed: number): string {
+  const parts: string[] = []
+  if (changed > 0) parts.push(`${changed} changed`)
+  if (removed > 0) parts.push(`${removed} removed`)
+  return `${parts.join(', ')} since last view`
+}

--- a/packages/runtime/components/DiffCues.tsx
+++ b/packages/runtime/components/DiffCues.tsx
@@ -72,7 +72,11 @@ function DiffOverlay({ diff }: { diff: NonNullable<ReturnType<typeof readDiff>> 
   // A re-render of an identical plan has nothing to surface, so show no chrome at all.
   if (changedCount === 0 && removedCount === 0) return null
 
-  const overlays = diffOverlays(sections, diff, showChanges)
+  const allOverlays = diffOverlays(sections, diff, showChanges)
+  // In review mode the left gutter belongs to the phase timeline and the comment affordances, so the
+  // diff bars would pile up there; drop them and let the summary count + "Show changes" inline diff
+  // convey what changed. The scrims (which fade unchanged sections) stay.
+  const overlays = isReviewMode() ? allOverlays.filter(o => o.kind !== 'bar') : allOverlays
   // The toggle only does something when the bars are mapped (the diff and DOM section counts agree).
   const mapped = sections.length === diff.sections.length
 

--- a/packages/runtime/components/DiffCues.tsx
+++ b/packages/runtime/components/DiffCues.tsx
@@ -1,10 +1,9 @@
 import { IconGitCommit } from '@tabler/icons-react'
 import { useEffect, useState } from 'react'
 import {
-  applyWordHighlights,
+  applyInlineWordDiff,
   type DiffStatus,
   diffOverlays,
-  insertedWordRanges,
   isChanged,
   readDiff,
   sectionOwnedElements,
@@ -49,19 +48,21 @@ function DiffOverlay({ diff }: { diff: NonNullable<ReturnType<typeof readDiff>> 
     }
   }, [])
 
-  // "Only changes" also reveals the exact words that changed: word-diff each edited section's body
-  // against its baseline prose and register the inserted words as a CSS Custom Highlight (no DOM
-  // mutation). Cleared whenever the toggle is off, the counts mismatch, or the component unmounts.
+  // Render the word-level changes inline on every diff render (not behind the toggle, so they are
+  // not missed): re-render each edited section's prose as a diff, deletions struck through and
+  // insertions marked. Restored on cleanup (deps change / unmount).
   useEffect(() => {
-    if (!onlyChanges || sections.length !== diff.sections.length) return applyWordHighlights([])
-    const ranges = sections.flatMap((section, index) => {
+    if (sections.length !== diff.sections.length) return
+    const restores = sections.flatMap((section, index) => {
       const entry = diff.sections[index]
       return entry?.status === 'edited' && entry.prev
-        ? insertedWordRanges(sectionOwnedElements(section), entry.prev)
+        ? [applyInlineWordDiff(sectionOwnedElements(section), entry.prev)]
         : []
     })
-    return applyWordHighlights(ranges)
-  }, [onlyChanges, sections, diff])
+    return () => {
+      for (const restore of restores) restore()
+    }
+  }, [sections, diff])
 
   const changedCount = diff.sections.filter(s => isChanged(s.status)).length
   const removedCount = diff.removed.length

--- a/packages/runtime/components/DiffCues.tsx
+++ b/packages/runtime/components/DiffCues.tsx
@@ -1,6 +1,14 @@
 import { IconGitCommit } from '@tabler/icons-react'
 import { useEffect, useState } from 'react'
-import { type DiffStatus, diffOverlays, isChanged, readDiff } from './review/diff.js'
+import {
+  applyWordHighlights,
+  type DiffStatus,
+  diffOverlays,
+  insertedWordRanges,
+  isChanged,
+  readDiff,
+  sectionOwnedElements,
+} from './review/diff.js'
 import { collectSections, type Section } from './review/SectionComments.js'
 import './diff.css'
 
@@ -40,6 +48,20 @@ function DiffOverlay({ diff }: { diff: NonNullable<ReturnType<typeof readDiff>> 
       window.removeEventListener('resize', onReflow)
     }
   }, [])
+
+  // "Only changes" also reveals the exact words that changed: word-diff each edited section's body
+  // against its baseline prose and register the inserted words as a CSS Custom Highlight (no DOM
+  // mutation). Cleared whenever the toggle is off, the counts mismatch, or the component unmounts.
+  useEffect(() => {
+    if (!onlyChanges || sections.length !== diff.sections.length) return applyWordHighlights([])
+    const ranges = sections.flatMap((section, index) => {
+      const entry = diff.sections[index]
+      return entry?.status === 'edited' && entry.prev
+        ? insertedWordRanges(sectionOwnedElements(section), entry.prev)
+        : []
+    })
+    return applyWordHighlights(ranges)
+  }, [onlyChanges, sections, diff])
 
   const changedCount = diff.sections.filter(s => isChanged(s.status)).length
   const removedCount = diff.removed.length

--- a/packages/runtime/components/DiffCues.tsx
+++ b/packages/runtime/components/DiffCues.tsx
@@ -8,6 +8,7 @@ import {
   readDiff,
   sectionOwnedElements,
 } from './review/diff.js'
+import { isReviewMode } from './review/feedback.js'
 import { collectSections, type Section } from './review/SectionComments.js'
 import './diff.css'
 
@@ -99,7 +100,8 @@ function DiffOverlay({ diff }: { diff: NonNullable<ReturnType<typeof readDiff>> 
           />
         ),
       )}
-      <div className='vp-diff-summary'>
+      {/* In review mode the bottom is occupied by the review DecisionBar, so lift the chip above it. */}
+      <div className='vp-diff-summary' data-review={isReviewMode() || undefined}>
         <IconGitCommit size={14} />
         <span>{summaryText(changedCount, removedCount)}</span>
         {mapped && changedCount > 0 && (

--- a/packages/runtime/components/DiffCues.tsx
+++ b/packages/runtime/components/DiffCues.tsx
@@ -21,10 +21,11 @@ const STATUS_COLOR: Record<DiffStatus, string> = {
 }
 
 /**
- * Iteration diff cues: a git-gutter-style left edge-accent bar beside each added/edited section, a
- * summary chip with the change counts, and an "only changes" toggle that fades unchanged sections.
- * Renders whenever the CLI injected `__VP_DIFF__` (a render/watch/review with a baseline), not just in
- * review mode. Everything is fixed-position overlay; the plan DOM is never touched.
+ * Iteration diff cues, shown whenever the CLI injected `__VP_DIFF__` (a render/watch/review with a
+ * baseline). Always on: a change bar flush to the left edge of the viewport for each added/edited
+ * section, plus a summary chip. The "Show changes" toggle reveals the inline word diff (each edited
+ * section's prose and renamed title re-rendered as del/ins) and fades unchanged sections. The bars,
+ * scrims, and chip are fixed-position overlay; the inline diff alone mutates the prose DOM, reversibly.
  */
 export function DiffCues() {
   const diff = readDiff()

--- a/packages/runtime/components/DiffCues.tsx
+++ b/packages/runtime/components/DiffCues.tsx
@@ -72,9 +72,7 @@ function DiffOverlay({ diff }: { diff: NonNullable<ReturnType<typeof readDiff>> 
   // A re-render of an identical plan has nothing to surface, so show no chrome at all.
   if (changedCount === 0 && removedCount === 0) return null
 
-  // In review mode the outer gutter holds comment badges, so hug the content edge (offset 4) to avoid
-  // clipping them; otherwise sit out in the gutter (offset 18) for the git-gutter look.
-  const overlays = diffOverlays(sections, diff, showChanges, isReviewMode() ? 4 : 18)
+  const overlays = diffOverlays(sections, diff, showChanges)
   // The toggle only does something when the bars are mapped (the diff and DOM section counts agree).
   const mapped = sections.length === diff.sections.length
 

--- a/packages/runtime/components/DiffCues.tsx
+++ b/packages/runtime/components/DiffCues.tsx
@@ -72,7 +72,9 @@ function DiffOverlay({ diff }: { diff: NonNullable<ReturnType<typeof readDiff>> 
   // A re-render of an identical plan has nothing to surface, so show no chrome at all.
   if (changedCount === 0 && removedCount === 0) return null
 
-  const overlays = diffOverlays(sections, diff, showChanges)
+  // In review mode the outer gutter holds comment badges, so hug the content edge (offset 4) to avoid
+  // clipping them; otherwise sit out in the gutter (offset 18) for the git-gutter look.
+  const overlays = diffOverlays(sections, diff, showChanges, isReviewMode() ? 4 : 18)
   // The toggle only does something when the bars are mapped (the diff and DOM section counts agree).
   const mapped = sections.length === diff.sections.length
 

--- a/packages/runtime/components/DiffCues.tsx
+++ b/packages/runtime/components/DiffCues.tsx
@@ -72,11 +72,7 @@ function DiffOverlay({ diff }: { diff: NonNullable<ReturnType<typeof readDiff>> 
   // A re-render of an identical plan has nothing to surface, so show no chrome at all.
   if (changedCount === 0 && removedCount === 0) return null
 
-  const allOverlays = diffOverlays(sections, diff, showChanges)
-  // In review mode the left gutter belongs to the phase timeline and the comment affordances, so the
-  // diff bars would pile up there; drop them and let the summary count + "Show changes" inline diff
-  // convey what changed. The scrims (which fade unchanged sections) stay.
-  const overlays = isReviewMode() ? allOverlays.filter(o => o.kind !== 'bar') : allOverlays
+  const overlays = diffOverlays(sections, diff, showChanges)
   // The toggle only does something when the bars are mapped (the diff and DOM section counts agree).
   const mapped = sections.length === diff.sections.length
 

--- a/packages/runtime/components/Questions.tsx
+++ b/packages/runtime/components/Questions.tsx
@@ -9,6 +9,9 @@ import { decodeJson, validateProps } from './validate.js'
  * before paint to avoid a flash at the wrong height. Pairs with `resize: none` in the CSS. */
 function AutoGrowTextarea(props: ComponentProps<'textarea'>) {
   const ref = useRef<HTMLTextAreaElement>(null)
+  // Re-measure whenever the value changes; the effect reads it via the DOM (scrollHeight), not
+  // directly, so the dependency is intentional even though biome cannot see the use.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: resize on every value change
   useLayoutEffect(() => {
     const el = ref.current
     if (!el) return

--- a/packages/runtime/components/Questions.tsx
+++ b/packages/runtime/components/Questions.tsx
@@ -1,7 +1,22 @@
 import { questionsSchema } from '@visualplan/core'
+import { type ComponentProps, useLayoutEffect, useRef } from 'react'
 import { isReviewMode } from './review/feedback.js'
 import { useQuestionAnswers } from './review/ReviewAnswers.js'
 import { decodeJson, validateProps } from './validate.js'
+
+/** A textarea that grows to fit its content, so a long answer is never cramped into one scrolling
+ * line. Resets to `auto` before measuring so it shrinks as well as grows; `useLayoutEffect` sizes it
+ * before paint to avoid a flash at the wrong height. Pairs with `resize: none` in the CSS. */
+function AutoGrowTextarea(props: ComponentProps<'textarea'>) {
+  const ref = useRef<HTMLTextAreaElement>(null)
+  useLayoutEffect(() => {
+    const el = ref.current
+    if (!el) return
+    el.style.height = 'auto'
+    el.style.height = `${el.scrollHeight}px`
+  }, [props.value])
+  return <textarea ref={ref} {...props} />
+}
 
 interface QuestionsProps {
   title?: unknown
@@ -29,7 +44,7 @@ export function Questions(props: QuestionsProps) {
             <div className='vp-questions__body'>
               <span className='vp-questions__text'>{item}</span>
               {interactive && (
-                <textarea
+                <AutoGrowTextarea
                   className='vp-questions__answer'
                   rows={1}
                   placeholder='Answer this question…'

--- a/packages/runtime/components/diff.css
+++ b/packages/runtime/components/diff.css
@@ -11,31 +11,35 @@
   }
 }
 
-/* The git-gutter-style accent bar beside a changed section. Thin, low-key, color set inline from the
-   section's status (added = done-green, edited = modify-amber). */
+/* A change-indicator bar flush to the left edge of the viewport (left: 0 set inline), a dedicated
+   lane clear of the content gutter. Color set inline from the status (added = green, edited = amber). */
 .vp-diff-bar {
   position: fixed;
   z-index: 52;
-  width: 2px;
-  border-radius: 2px;
+  width: 4px;
+  border-radius: 0 2px 2px 0;
   pointer-events: none;
-  opacity: 0.5;
+  opacity: 0.75;
   animation: vp-diff-fade-in 0.12s var(--vp-ease);
 }
 
-/* Inline word-level diff inside an edited section's prose: insertions in green, deletions muted and
-   struck through, so the before -> after change is readable in place without shouting. */
+/* Inline word-level diff inside an edited section's prose: insertions green, deletions red and struck
+   through, each on a light tinted background so the before -> after change is clearly visible. */
 .vp-main ins.vp-diff-ins {
   color: var(--vp-done);
   text-decoration: none;
-  box-shadow: inset 0 -1px 0 color-mix(in srgb, var(--vp-done) 40%, transparent);
+  background: color-mix(in srgb, var(--vp-done) 16%, transparent);
+  border-radius: 2px;
+  padding: 0 0.1em;
 }
 
 .vp-main del.vp-diff-del {
-  color: var(--vp-muted);
+  color: var(--vp-risk);
   text-decoration: line-through;
   text-decoration-thickness: 1px;
-  text-decoration-color: color-mix(in srgb, var(--vp-risk) 60%, transparent);
+  background: color-mix(in srgb, var(--vp-risk) 13%, transparent);
+  border-radius: 2px;
+  padding: 0 0.1em;
 }
 
 /* Fades an unchanged section when "only changes" is on, so the changed ones stand out. */

--- a/packages/runtime/components/diff.css
+++ b/packages/runtime/components/diff.css
@@ -16,11 +16,20 @@
 .vp-diff-bar {
   position: fixed;
   z-index: 52;
-  width: 3px;
+  width: 2px;
   border-radius: 2px;
   pointer-events: none;
-  opacity: 0.85;
+  opacity: 0.5;
   animation: vp-diff-fade-in 0.12s var(--vp-ease);
+}
+
+/* Inserted/changed words inside an edited section, revealed while "only changes" is on. A soft amber
+   wash + underline (the edited color), non-destructive via the CSS Custom Highlight API. */
+::highlight(vp-diff-ins) {
+  background-color: color-mix(in srgb, var(--vp-modify) 18%, transparent);
+  text-decoration: underline;
+  text-decoration-color: color-mix(in srgb, var(--vp-modify) 55%, transparent);
+  text-underline-offset: 2px;
 }
 
 /* Fades an unchanged section when "only changes" is on, so the changed ones stand out. */

--- a/packages/runtime/components/diff.css
+++ b/packages/runtime/components/diff.css
@@ -23,21 +23,22 @@
   animation: vp-diff-fade-in 0.12s var(--vp-ease);
 }
 
-/* Inline word-level diff inside an edited section's prose: insertions green, deletions red and struck
-   through, each on a light tinted background so the before -> after change is clearly visible. */
+/* Inline word-level diff inside an edited section's prose: the background tint signals add (green) vs
+   remove (red), while the text keeps its normal color so the words stay readable (green-on-green is
+   not). Deletions are struck through. */
 .vp-main ins.vp-diff-ins {
-  color: var(--vp-done);
+  color: var(--vp-text);
   text-decoration: none;
-  background: color-mix(in srgb, var(--vp-done) 16%, transparent);
+  background: color-mix(in srgb, var(--vp-done) 24%, transparent);
   border-radius: 2px;
   padding: 0 0.1em;
 }
 
 .vp-main del.vp-diff-del {
-  color: var(--vp-risk);
+  color: var(--vp-muted);
   text-decoration: line-through;
   text-decoration-thickness: 1px;
-  background: color-mix(in srgb, var(--vp-risk) 13%, transparent);
+  background: color-mix(in srgb, var(--vp-risk) 16%, transparent);
   border-radius: 2px;
   padding: 0 0.1em;
 }

--- a/packages/runtime/components/diff.css
+++ b/packages/runtime/components/diff.css
@@ -1,0 +1,78 @@
+/* Iteration diff cues. All fixed-position overlay (the plan DOM is never touched) and all colors are
+   theme.css CSS vars, so the cues track light/dark. Subtle by design: a quiet gutter bar and a small
+   chip that draw the eye to what changed without the page screaming. */
+
+@keyframes vp-diff-fade-in {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+/* The git-gutter-style accent bar beside a changed section. Thin, low-key, color set inline from the
+   section's status (added = done-green, edited = modify-amber). */
+.vp-diff-bar {
+  position: fixed;
+  z-index: 52;
+  width: 3px;
+  border-radius: 2px;
+  pointer-events: none;
+  opacity: 0.85;
+  animation: vp-diff-fade-in 0.12s var(--vp-ease);
+}
+
+/* Fades an unchanged section when "only changes" is on, so the changed ones stand out. */
+.vp-diff-scrim {
+  position: fixed;
+  z-index: 40;
+  pointer-events: none;
+  border-radius: 10px;
+  background: color-mix(in srgb, var(--vp-bg) 72%, transparent);
+  animation: vp-diff-fade-in 0.12s var(--vp-ease);
+}
+
+/* The summary chip, bottom-left, clear of the top-right cog/share and the centered review bar. */
+.vp-diff-summary {
+  position: fixed;
+  z-index: 59;
+  bottom: 1rem;
+  left: 1rem;
+  display: inline-flex;
+  gap: 0.4rem;
+  align-items: center;
+  padding: 0.32rem 0.6rem;
+  font-size: 0.78rem;
+  font-weight: 500;
+  color: var(--vp-muted);
+  background: var(--vp-surface-2);
+  border: 1px solid var(--vp-border);
+  border-radius: 999px;
+  box-shadow: 0 2px 8px rgb(0 0 0 / 12%);
+}
+
+.vp-diff-toggle {
+  padding: 0.15rem 0.5rem;
+  font: inherit;
+  font-size: 0.74rem;
+  font-weight: 600;
+  color: var(--vp-muted);
+  background: transparent;
+  border: 1px solid var(--vp-border);
+  border-radius: 999px;
+  cursor: pointer;
+  transition:
+    color 0.12s var(--vp-ease),
+    background 0.12s var(--vp-ease);
+}
+
+.vp-diff-toggle:hover {
+  color: var(--vp-text);
+}
+
+.vp-diff-toggle[data-active="true"] {
+  color: var(--vp-on-accent);
+  background: var(--vp-accent);
+  border-color: var(--vp-accent);
+}

--- a/packages/runtime/components/diff.css
+++ b/packages/runtime/components/diff.css
@@ -23,20 +23,19 @@
   animation: vp-diff-fade-in 0.12s var(--vp-ease);
 }
 
-/* Inline word-level diff inside an edited section's prose: insertions marked green, deletions struck
-   through in red, so the before -> after change is readable in place. */
+/* Inline word-level diff inside an edited section's prose: insertions in green, deletions muted and
+   struck through, so the before -> after change is readable in place without shouting. */
 .vp-main ins.vp-diff-ins {
+  color: var(--vp-done);
   text-decoration: none;
-  background: color-mix(in srgb, var(--vp-done) 16%, transparent);
-  box-shadow: inset 0 -1.5px 0 color-mix(in srgb, var(--vp-done) 60%, transparent);
-  border-radius: 2px;
+  box-shadow: inset 0 -1px 0 color-mix(in srgb, var(--vp-done) 40%, transparent);
 }
 
 .vp-main del.vp-diff-del {
-  color: var(--vp-risk);
+  color: var(--vp-muted);
   text-decoration: line-through;
   text-decoration-thickness: 1px;
-  opacity: 0.7;
+  text-decoration-color: color-mix(in srgb, var(--vp-risk) 60%, transparent);
 }
 
 /* Fades an unchanged section when "only changes" is on, so the changed ones stand out. */

--- a/packages/runtime/components/diff.css
+++ b/packages/runtime/components/diff.css
@@ -23,13 +23,20 @@
   animation: vp-diff-fade-in 0.12s var(--vp-ease);
 }
 
-/* Inserted/changed words inside an edited section, revealed while "only changes" is on. A soft amber
-   wash + underline (the edited color), non-destructive via the CSS Custom Highlight API. */
-::highlight(vp-diff-ins) {
-  background-color: color-mix(in srgb, var(--vp-modify) 18%, transparent);
-  text-decoration: underline;
-  text-decoration-color: color-mix(in srgb, var(--vp-modify) 55%, transparent);
-  text-underline-offset: 2px;
+/* Inline word-level diff inside an edited section's prose: insertions marked green, deletions struck
+   through in red, so the before -> after change is readable in place. */
+.vp-main ins.vp-diff-ins {
+  text-decoration: none;
+  background: color-mix(in srgb, var(--vp-done) 16%, transparent);
+  box-shadow: inset 0 -1.5px 0 color-mix(in srgb, var(--vp-done) 60%, transparent);
+  border-radius: 2px;
+}
+
+.vp-main del.vp-diff-del {
+  color: var(--vp-risk);
+  text-decoration: line-through;
+  text-decoration-thickness: 1px;
+  opacity: 0.7;
 }
 
 /* Fades an unchanged section when "only changes" is on, so the changed ones stand out. */

--- a/packages/runtime/components/diff.css
+++ b/packages/runtime/components/diff.css
@@ -35,10 +35,13 @@
 }
 
 .vp-main del.vp-diff-del {
-  color: var(--vp-muted);
+  /* Keep the text readable (not red-on-red), but make the removal unmistakably red via a thick red
+     strike and a red tint. */
+  color: var(--vp-text);
   text-decoration: line-through;
-  text-decoration-thickness: 1px;
-  background: color-mix(in srgb, var(--vp-risk) 16%, transparent);
+  text-decoration-color: var(--vp-risk);
+  text-decoration-thickness: 2px;
+  background: color-mix(in srgb, var(--vp-risk) 18%, transparent);
   border-radius: 2px;
   padding: 0 0.1em;
 }

--- a/packages/runtime/components/diff.css
+++ b/packages/runtime/components/diff.css
@@ -49,7 +49,7 @@
   animation: vp-diff-fade-in 0.12s var(--vp-ease);
 }
 
-/* The summary chip, bottom-left, clear of the top-right cog/share and the centered review bar. */
+/* The summary chip, bottom-left, clear of the top-right cog/share. */
 .vp-diff-summary {
   position: fixed;
   z-index: 59;
@@ -66,6 +66,13 @@
   border: 1px solid var(--vp-border);
   border-radius: 999px;
   box-shadow: 0 2px 8px rgb(0 0 0 / 12%);
+}
+
+/* In review mode the review DecisionBar owns the bottom edge, so lift the chip clear of it and
+   above its z-index. */
+.vp-diff-summary[data-review="true"] {
+  bottom: 4.75rem;
+  z-index: 71;
 }
 
 .vp-diff-toggle {

--- a/packages/runtime/components/review/SectionComments.tsx
+++ b/packages/runtime/components/review/SectionComments.tsx
@@ -234,16 +234,16 @@ export function SectionOverlays({
         return (
           <Fragment key={section.index}>
             {hovered && (
-              // A wide band hugging the section's content (heading + its elements), not the empty
-              // space up to the next section. Side-inset for breathing space; overlay only, so it
-              // never shifts the page layout.
+              // A wide band around the section's content (heading + its elements), not the empty
+              // space up to the next section. Padded ~8px beyond the content so the bordered frame
+              // reads as breathing room around it; overlay only, so it never shifts the page layout.
               <div
                 className='vp-review-highlight'
                 style={{
-                  top: content.top,
+                  top: content.top - 8,
                   left: 10,
                   right: 10,
-                  height: Math.max(content.bottom - content.top, 0),
+                  height: Math.max(content.bottom - content.top, 0) + 16,
                 }}
               />
             )}

--- a/packages/runtime/components/review/SectionComments.tsx
+++ b/packages/runtime/components/review/SectionComments.tsx
@@ -264,8 +264,9 @@ export function SectionOverlays({
               <button
                 type='button'
                 className='vp-review-badge'
-                // Out in the left gutter with breathing room from the content, clamped on-screen.
-                style={{ top: controlTop, left: Math.max(rect.left - 46, 10) }}
+                // Out in the left gutter, past the diff gutter bar (which sits at rect.left - 18) so
+                // the two never overlap; clamped on-screen.
+                style={{ top: controlTop, left: Math.max(rect.left - 64, 8) }}
                 onClick={() => onView(section)}
                 aria-label={`${count} comment${count === 1 ? '' : 's'} on "${section.label}"`}
                 title={`View ${count} comment${count === 1 ? '' : 's'}`}

--- a/packages/runtime/components/review/SectionComments.tsx
+++ b/packages/runtime/components/review/SectionComments.tsx
@@ -264,9 +264,8 @@ export function SectionOverlays({
               <button
                 type='button'
                 className='vp-review-badge'
-                // Out in the left gutter, past the diff gutter bar (which sits at rect.left - 18) so
-                // the two never overlap; clamped on-screen.
-                style={{ top: controlTop, left: Math.max(rect.left - 64, 8) }}
+                // Out in the left gutter with breathing room from the content, clamped on-screen.
+                style={{ top: controlTop, left: Math.max(rect.left - 46, 10) }}
                 onClick={() => onView(section)}
                 aria-label={`${count} comment${count === 1 ? '' : 's'} on "${section.label}"`}
                 title={`View ${count} comment${count === 1 ? '' : 's'}`}

--- a/packages/runtime/components/review/diff.ts
+++ b/packages/runtime/components/review/diff.ts
@@ -113,6 +113,12 @@ interface ProseToken {
   text: string
 }
 
+/** Data-component containers whose rendered text is structured data, not authored prose. Their text
+ * tokenizes differently from the MDX source (file paths split by separators, table cells, task
+ * items), so it is excluded from word-highlighting, matching the source-side `PROSE_OPAQUE_COMPONENTS`. */
+const DATA_COMPONENT_SELECTOR =
+  '.vp-filetree, .vp-chart, .vp-matrix-wrap, .vp-compare, .vp-checklist, .vp-stat, .vp-questions'
+
 /** Lowercase word tokens, for whitespace-insensitive, case-insensitive matching. */
 function tokenize(text: string): string[] {
   return text.toLowerCase().match(/\S+/g) ?? []
@@ -129,7 +135,7 @@ function proseTokens(roots: Element[]): ProseToken[] {
     let node = walker.nextNode()
     while (node) {
       const block = node.parentElement?.closest('p, li')
-      if (block && root.contains(block)) {
+      if (block && root.contains(block) && !block.closest(DATA_COMPONENT_SELECTOR)) {
         const text = node.textContent ?? ''
         for (const match of text.matchAll(/\S+/g)) {
           if (match.index !== undefined) {

--- a/packages/runtime/components/review/diff.ts
+++ b/packages/runtime/components/review/diff.ts
@@ -15,9 +15,9 @@ export type DiffStatus = 'unchanged' | 'edited' | 'added'
 
 /** The diff payload injected by the CLI build's `planDiffPlugin`. */
 export interface InjectedDiff {
-  /** One per current section, in document order. `prev` is the baseline prose, present only on
-   * `edited` sections, for word-level highlighting. */
-  sections: { status: DiffStatus; label: string; type: string; prev?: string }[]
+  /** One per current section, in document order. `prev` is the baseline prose and `prevLabel` the
+   * baseline title (only on `edited` sections; `prevLabel` only on a rename), for word-level diffing. */
+  sections: { status: DiffStatus; label: string; type: string; prev?: string; prevLabel?: string }[]
   /** Baseline sections with no current match. */
   removed: { label: string; type: string }[]
 }
@@ -221,4 +221,31 @@ export function applyInlineWordDiff(roots: Element[], prevProse: string): () => 
     target.replaceChildren(...originalTarget)
     for (const { p, display } of collapsed) p.style.display = display
   }
+}
+
+/** A section's title/label element, whose text the rename diff targets: the heading itself for a
+ * heading section, otherwise the block's title/label element. */
+const TITLE_SELECTOR =
+  '.vp-phase__title, .vp-chart__title, .vp-checklist__title, .vp-stat__title, .vp-questions__title, .vp-callout__label'
+
+function titleElement(section: Section): Element | null {
+  const el = section.element
+  if (/^H[1-6]$/.test(el.tagName)) return el
+  return el.querySelector(TITLE_SELECTOR)
+}
+
+/**
+ * Show a renamed section's title change inline: diff the rendered title against the baseline label
+ * (`prevLabel`) and re-render it as the diff. This is what surfaces a rename whose body is otherwise
+ * unchanged (so the section is not "marked changed but nothing differs"). Reversible; returns a
+ * cleanup that restores the title.
+ */
+export function applyTitleDiff(section: Section, prevLabel: string): () => void {
+  const el = titleElement(section)
+  if (!el) return () => {}
+  const ops = wordDiffOps(words(prevLabel), words(el.textContent ?? ''))
+  if (!ops.some(op => op.type !== 'eq')) return () => {}
+  const original = Array.from(el.childNodes)
+  el.replaceChildren(renderDiff(ops))
+  return () => el.replaceChildren(...original)
 }

--- a/packages/runtime/components/review/diff.ts
+++ b/packages/runtime/components/review/diff.ts
@@ -80,121 +80,12 @@ export function diffOverlays(
   return overlays
 }
 
-/** The CSS Custom Highlight registered for inserted/changed words inside an edited section. */
-export const DIFF_HIGHLIGHT_NAME = 'vp-diff-ins'
-
-interface HighlightRegistry {
-  set(name: string, highlight: unknown): void
-  delete(name: string): void
-}
-
-/** Register `ranges` as a non-destructive CSS Custom Highlight (no DOM mutation) and return a cleanup
- * that removes it. Where the Custom Highlight API is unavailable (older browsers) or there is nothing
- * to mark, it clears any prior highlight and degrades to no inline cue; the gutter bars still show. */
-export function applyWordHighlights(ranges: Range[]): () => void {
-  const registry = (CSS as unknown as { highlights?: HighlightRegistry }).highlights
-  const HighlightConstructor = (
-    globalThis as unknown as { Highlight?: new (...r: Range[]) => unknown }
-  ).Highlight
-  const clear = () => registry?.delete(DIFF_HIGHLIGHT_NAME)
-  if (!registry || !HighlightConstructor || ranges.length === 0) {
-    clear()
-    return clear
-  }
-  registry.set(DIFF_HIGHLIGHT_NAME, new HighlightConstructor(...ranges))
-  return clear
-}
-
-/** A prose word in the rendered section, with the text node and offsets that locate it for a Range. */
-interface ProseToken {
-  node: Text
-  start: number
-  end: number
-  text: string
-}
-
 /** Data-component containers whose rendered text is structured data, not authored prose. Their text
  * tokenizes differently from the MDX source (file paths split by separators, table cells, task
- * items), so it is excluded from word-highlighting, matching the source-side `PROSE_OPAQUE_COMPONENTS`. */
+ * items), so they are excluded from the prose diff, matching the source-side `PROSE_OPAQUE_COMPONENTS`. */
 const DATA_COMPONENT_SELECTOR =
   '.vp-filetree, .vp-chart, .vp-matrix-wrap, .vp-compare, .vp-checklist, .vp-stat, .vp-questions'
 
-/** Lowercase word tokens, for whitespace-insensitive, case-insensitive matching. */
-function tokenize(text: string): string[] {
-  return text.toLowerCase().match(/\S+/g) ?? []
-}
-
-/** Collect the prose word tokens within a set of root elements: text inside `p`/`li` only (so
- * titles, headings, and chrome like a status badge are never matched), each tagged with its text
- * node + offsets. A section owns several sibling blocks (e.g. a heading plus its intro paragraph),
- * so the caller passes all of them, not just the start element. */
-function proseTokens(roots: Element[]): ProseToken[] {
-  const tokens: ProseToken[] = []
-  for (const root of roots) {
-    const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT)
-    let node = walker.nextNode()
-    while (node) {
-      const block = node.parentElement?.closest('p, li')
-      if (block && root.contains(block) && !block.closest(DATA_COMPONENT_SELECTOR)) {
-        const text = node.textContent ?? ''
-        for (const match of text.matchAll(/\S+/g)) {
-          if (match.index !== undefined) {
-            tokens.push({
-              node: node as Text,
-              start: match.index,
-              end: match.index + match[0].length,
-              text: match[0],
-            })
-          }
-        }
-      }
-      node = walker.nextNode()
-    }
-  }
-  return tokens
-}
-
-/** The current-token indices NOT in the LCS with the previous tokens, i.e. the inserted/changed words. */
-function insertedIndices(prev: string[], current: string[]): Set<number> {
-  const n = prev.length
-  const m = current.length
-  const dp: number[][] = Array.from({ length: n + 1 }, () => new Array(m + 1).fill(0))
-  for (let i = n - 1; i >= 0; i--) {
-    const row = dp[i] as number[]
-    const next = dp[i + 1] as number[]
-    for (let j = m - 1; j >= 0; j--) {
-      row[j] =
-        prev[i] === current[j] ? (next[j + 1] ?? 0) + 1 : Math.max(next[j] ?? 0, row[j + 1] ?? 0)
-    }
-  }
-  const matched = new Set<number>()
-  let i = 0
-  let j = 0
-  while (i < n && j < m) {
-    const row = dp[i] as number[]
-    const next = dp[i + 1] as number[]
-    if (prev[i] === current[j]) {
-      matched.add(j)
-      i++
-      j++
-    } else if ((next[j] ?? 0) >= (row[j + 1] ?? 0)) {
-      i++
-    } else {
-      j++
-    }
-  }
-  const inserted = new Set<number>()
-  for (let k = 0; k < m; k++) if (!matched.has(k)) inserted.add(k)
-  return inserted
-}
-
-/**
- * Ranges over the words in a section's prose that are new or changed relative to `prevProse` (the
- * baseline section's prose). `roots` are the sibling blocks the section owns (its start element plus
- * any following blocks up to the next section). A word-level LCS marks the inserted current tokens;
- * each becomes a DOM Range so the caller can register a non-destructive CSS Custom Highlight (no DOM
- * mutation). Pure given the DOM, so it is unit-testable in jsdom.
- */
 /** The sibling blocks a section owns: from its start element through `lastElement`, so prose in a
  * following sibling (a heading's intro paragraph) is included, not just the start element's subtree. */
 export function sectionOwnedElements(section: Section): Element[] {
@@ -207,20 +98,114 @@ export function sectionOwnedElements(section: Section): Element[] {
   return children.slice(start, (last < 0 ? start : last) + 1)
 }
 
-export function insertedWordRanges(roots: Element[], prevProse: string): Range[] {
-  const tokens = proseTokens(roots)
-  if (tokens.length === 0) return []
-  const inserted = insertedIndices(
-    tokenize(prevProse),
-    tokens.map(t => t.text.toLowerCase()),
-  )
-  const ranges: Range[] = []
-  tokens.forEach((token, index) => {
-    if (!inserted.has(index)) return
-    const range = document.createRange()
-    range.setStart(token.node, token.start)
-    range.setEnd(token.node, token.end)
-    ranges.push(range)
-  })
-  return ranges
+/** One step of a word-level diff: text kept (`eq`), removed from the baseline (`del`), or added in
+ * the current version (`ins`). */
+export interface DiffOp {
+  type: 'eq' | 'del' | 'ins'
+  text: string
+}
+
+/** Raw whitespace-split words, keeping original case and punctuation for display. */
+function words(text: string): string[] {
+  return text.match(/\S+/g) ?? []
+}
+
+/**
+ * Word-level diff of `prev` -> `current` via LCS, as an ordered op list (kept / deleted / inserted).
+ * Comparison is case-insensitive so a capitalization change is not noise, but ops carry the original
+ * words for display. Pure, so it is unit-testable.
+ */
+export function wordDiffOps(prev: string[], current: string[]): DiffOp[] {
+  const n = prev.length
+  const m = current.length
+  const same = (a: string, b: string) => a.toLowerCase() === b.toLowerCase()
+  const dp: number[][] = Array.from({ length: n + 1 }, () => new Array(m + 1).fill(0))
+  for (let i = n - 1; i >= 0; i--) {
+    const row = dp[i] as number[]
+    const next = dp[i + 1] as number[]
+    for (let j = m - 1; j >= 0; j--) {
+      row[j] = same(prev[i] as string, current[j] as string)
+        ? (next[j + 1] ?? 0) + 1
+        : Math.max(next[j] ?? 0, row[j + 1] ?? 0)
+    }
+  }
+  const ops: DiffOp[] = []
+  let i = 0
+  let j = 0
+  while (i < n && j < m) {
+    const row = dp[i] as number[]
+    const next = dp[i + 1] as number[]
+    if (same(prev[i] as string, current[j] as string)) {
+      ops.push({ type: 'eq', text: current[j] as string })
+      i++
+      j++
+    } else if ((next[j] ?? 0) >= (row[j + 1] ?? 0)) {
+      ops.push({ type: 'del', text: prev[i] as string })
+      i++
+    } else {
+      ops.push({ type: 'ins', text: current[j] as string })
+      j++
+    }
+  }
+  while (i < n) ops.push({ type: 'del', text: prev[i++] as string })
+  while (j < m) ops.push({ type: 'ins', text: current[j++] as string })
+  return ops
+}
+
+/** The prose paragraphs a section owns: `<p>` elements not inside a data component (whose text is
+ * structured data, not authored prose). Deduped, in document order. */
+function proseParagraphs(roots: Element[]): HTMLParagraphElement[] {
+  const found = new Set<HTMLParagraphElement>()
+  for (const root of roots) {
+    const candidates: Element[] = root.matches('p') ? [root] : []
+    candidates.push(...root.querySelectorAll('p'))
+    for (const el of candidates) {
+      if (!el.closest(DATA_COMPONENT_SELECTOR)) found.add(el as HTMLParagraphElement)
+    }
+  }
+  return [...found]
+}
+
+/** Render a word-diff op list into a fragment: kept words as text, deletions struck through, and
+ * insertions marked, each followed by a space. */
+function renderDiff(ops: DiffOp[]): DocumentFragment {
+  const fragment = document.createDocumentFragment()
+  for (const op of ops) {
+    if (op.type === 'eq') {
+      fragment.append(`${op.text} `)
+    } else {
+      const mark = document.createElement(op.type === 'del' ? 'del' : 'ins')
+      mark.className = op.type === 'del' ? 'vp-diff-del' : 'vp-diff-ins'
+      mark.textContent = op.text
+      fragment.append(mark, ' ')
+    }
+  }
+  return fragment
+}
+
+/**
+ * Show an edited section's word-level changes inline: diff its prose against the baseline
+ * (`prevProse`) and re-render the section's first prose paragraph as the diff (deletions struck
+ * through, insertions marked), collapsing any further prose paragraphs while active. Returns a
+ * cleanup that restores the original DOM exactly. Mutates the plan DOM by necessity (a deletion is
+ * not present in the rendered page), but only the prose, and reversibly.
+ */
+export function applyInlineWordDiff(roots: Element[], prevProse: string): () => void {
+  const paragraphs = proseParagraphs(roots)
+  const target = paragraphs[0]
+  if (!target) return () => {}
+  const current = words(paragraphs.map(p => p.textContent ?? '').join(' '))
+  const ops = wordDiffOps(words(prevProse), current)
+  // Nothing actually differs in the prose (e.g. only a title/attribute changed): leave it untouched.
+  if (!ops.some(op => op.type !== 'eq')) return () => {}
+
+  const originalTarget = Array.from(target.childNodes)
+  const collapsed = paragraphs.slice(1).map(p => ({ p, display: p.style.display }))
+  target.replaceChildren(renderDiff(ops))
+  for (const { p } of collapsed) p.style.display = 'none'
+
+  return () => {
+    target.replaceChildren(...originalTarget)
+    for (const { p, display } of collapsed) p.style.display = display
+  }
 }

--- a/packages/runtime/components/review/diff.ts
+++ b/packages/runtime/components/review/diff.ts
@@ -1,0 +1,80 @@
+/**
+ * Reads the section diff the CLI injects as `globalThis.__VP_DIFF__` when a render has a baseline
+ * (the snapshot cache or an explicit `--diff`). The shape mirrors `@visualplan/compile`'s
+ * `SectionDiff`: one entry per CURRENT section in document order (so it maps onto the runtime's
+ * `collectSections()` output by index), plus the baseline sections that were removed.
+ *
+ * The runtime redefines the type rather than importing `@visualplan/compile` (a Node-side build
+ * dependency the browser bundle does not carry); the two must stay in sync by shape.
+ */
+
+import { type Section, sectionContent } from './SectionComments.js'
+
+/** A diff status for a section present in the current plan. */
+export type DiffStatus = 'unchanged' | 'edited' | 'added'
+
+/** The diff payload injected by the CLI build's `planDiffPlugin`. */
+export interface InjectedDiff {
+  /** One per current section, in document order. */
+  sections: { status: DiffStatus; label: string; type: string }[]
+  /** Baseline sections with no current match. */
+  removed: { label: string; type: string }[]
+}
+
+/** The injected diff, or null on a plain render with no baseline (the common case). */
+export function readDiff(): InjectedDiff | null {
+  const value = (globalThis as { __VP_DIFF__?: InjectedDiff }).__VP_DIFF__
+  return value && Array.isArray(value.sections) ? value : null
+}
+
+/** Whether a status is a visible change (added or edited); unchanged sections get no cue. */
+export function isChanged(status: DiffStatus): boolean {
+  return status === 'added' || status === 'edited'
+}
+
+/** One positioned diff overlay: a gutter `bar` on a changed section, or a `scrim` fading an unchanged
+ * one (only when `only changes` is on). The component turns each into a fixed-position element. */
+export interface DiffOverlay {
+  sectionIndex: number
+  kind: 'bar' | 'scrim'
+  status: DiffStatus
+  rect: { top: number; left: number; height: number }
+}
+
+/**
+ * Map the injected diff onto the DOM sections by document-order index. The diff is one entry per
+ * current section in order, so index alignment is correct ONLY when the counts agree; if they drift
+ * (the mdast split and the DOM split disagreed) the mapping is unsafe, so return no overlays rather
+ * than risk marking the wrong section. A pure function over the section list, so it is unit-testable.
+ */
+export function diffOverlays(
+  sections: Section[],
+  diff: InjectedDiff,
+  onlyChanges: boolean,
+): DiffOverlay[] {
+  if (sections.length !== diff.sections.length) return []
+  const overlays: DiffOverlay[] = []
+  sections.forEach((section, index) => {
+    const status = diff.sections[index]?.status
+    if (!status) return
+    const { top, bottom } = sectionContent(section)
+    const height = Math.max(bottom - top, 0)
+    if (isChanged(status)) {
+      const left = Math.max(section.element.getBoundingClientRect().left - 18, 6)
+      overlays.push({
+        sectionIndex: section.index,
+        kind: 'bar',
+        status,
+        rect: { top, left, height },
+      })
+    } else if (onlyChanges) {
+      overlays.push({
+        sectionIndex: section.index,
+        kind: 'scrim',
+        status,
+        rect: { top, left: 10, height },
+      })
+    }
+  })
+  return overlays
+}

--- a/packages/runtime/components/review/diff.ts
+++ b/packages/runtime/components/review/diff.ts
@@ -15,8 +15,9 @@ export type DiffStatus = 'unchanged' | 'edited' | 'added'
 
 /** The diff payload injected by the CLI build's `planDiffPlugin`. */
 export interface InjectedDiff {
-  /** One per current section, in document order. */
-  sections: { status: DiffStatus; label: string; type: string }[]
+  /** One per current section, in document order. `prev` is the baseline prose, present only on
+   * `edited` sections, for word-level highlighting. */
+  sections: { status: DiffStatus; label: string; type: string; prev?: string }[]
   /** Baseline sections with no current match. */
   removed: { label: string; type: string }[]
 }
@@ -77,4 +78,143 @@ export function diffOverlays(
     }
   })
   return overlays
+}
+
+/** The CSS Custom Highlight registered for inserted/changed words inside an edited section. */
+export const DIFF_HIGHLIGHT_NAME = 'vp-diff-ins'
+
+interface HighlightRegistry {
+  set(name: string, highlight: unknown): void
+  delete(name: string): void
+}
+
+/** Register `ranges` as a non-destructive CSS Custom Highlight (no DOM mutation) and return a cleanup
+ * that removes it. Where the Custom Highlight API is unavailable (older browsers) or there is nothing
+ * to mark, it clears any prior highlight and degrades to no inline cue; the gutter bars still show. */
+export function applyWordHighlights(ranges: Range[]): () => void {
+  const registry = (CSS as unknown as { highlights?: HighlightRegistry }).highlights
+  const HighlightConstructor = (
+    globalThis as unknown as { Highlight?: new (...r: Range[]) => unknown }
+  ).Highlight
+  const clear = () => registry?.delete(DIFF_HIGHLIGHT_NAME)
+  if (!registry || !HighlightConstructor || ranges.length === 0) {
+    clear()
+    return clear
+  }
+  registry.set(DIFF_HIGHLIGHT_NAME, new HighlightConstructor(...ranges))
+  return clear
+}
+
+/** A prose word in the rendered section, with the text node and offsets that locate it for a Range. */
+interface ProseToken {
+  node: Text
+  start: number
+  end: number
+  text: string
+}
+
+/** Lowercase word tokens, for whitespace-insensitive, case-insensitive matching. */
+function tokenize(text: string): string[] {
+  return text.toLowerCase().match(/\S+/g) ?? []
+}
+
+/** Collect the prose word tokens within a set of root elements: text inside `p`/`li` only (so
+ * titles, headings, and chrome like a status badge are never matched), each tagged with its text
+ * node + offsets. A section owns several sibling blocks (e.g. a heading plus its intro paragraph),
+ * so the caller passes all of them, not just the start element. */
+function proseTokens(roots: Element[]): ProseToken[] {
+  const tokens: ProseToken[] = []
+  for (const root of roots) {
+    const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT)
+    let node = walker.nextNode()
+    while (node) {
+      const block = node.parentElement?.closest('p, li')
+      if (block && root.contains(block)) {
+        const text = node.textContent ?? ''
+        for (const match of text.matchAll(/\S+/g)) {
+          if (match.index !== undefined) {
+            tokens.push({
+              node: node as Text,
+              start: match.index,
+              end: match.index + match[0].length,
+              text: match[0],
+            })
+          }
+        }
+      }
+      node = walker.nextNode()
+    }
+  }
+  return tokens
+}
+
+/** The current-token indices NOT in the LCS with the previous tokens, i.e. the inserted/changed words. */
+function insertedIndices(prev: string[], current: string[]): Set<number> {
+  const n = prev.length
+  const m = current.length
+  const dp: number[][] = Array.from({ length: n + 1 }, () => new Array(m + 1).fill(0))
+  for (let i = n - 1; i >= 0; i--) {
+    const row = dp[i] as number[]
+    const next = dp[i + 1] as number[]
+    for (let j = m - 1; j >= 0; j--) {
+      row[j] =
+        prev[i] === current[j] ? (next[j + 1] ?? 0) + 1 : Math.max(next[j] ?? 0, row[j + 1] ?? 0)
+    }
+  }
+  const matched = new Set<number>()
+  let i = 0
+  let j = 0
+  while (i < n && j < m) {
+    const row = dp[i] as number[]
+    const next = dp[i + 1] as number[]
+    if (prev[i] === current[j]) {
+      matched.add(j)
+      i++
+      j++
+    } else if ((next[j] ?? 0) >= (row[j + 1] ?? 0)) {
+      i++
+    } else {
+      j++
+    }
+  }
+  const inserted = new Set<number>()
+  for (let k = 0; k < m; k++) if (!matched.has(k)) inserted.add(k)
+  return inserted
+}
+
+/**
+ * Ranges over the words in a section's prose that are new or changed relative to `prevProse` (the
+ * baseline section's prose). `roots` are the sibling blocks the section owns (its start element plus
+ * any following blocks up to the next section). A word-level LCS marks the inserted current tokens;
+ * each becomes a DOM Range so the caller can register a non-destructive CSS Custom Highlight (no DOM
+ * mutation). Pure given the DOM, so it is unit-testable in jsdom.
+ */
+/** The sibling blocks a section owns: from its start element through `lastElement`, so prose in a
+ * following sibling (a heading's intro paragraph) is included, not just the start element's subtree. */
+export function sectionOwnedElements(section: Section): Element[] {
+  const parent = section.element.parentElement
+  if (!parent) return [section.element]
+  const children = Array.from(parent.children)
+  const start = children.indexOf(section.element)
+  if (start < 0) return [section.element]
+  const last = children.indexOf(section.lastElement)
+  return children.slice(start, (last < 0 ? start : last) + 1)
+}
+
+export function insertedWordRanges(roots: Element[], prevProse: string): Range[] {
+  const tokens = proseTokens(roots)
+  if (tokens.length === 0) return []
+  const inserted = insertedIndices(
+    tokenize(prevProse),
+    tokens.map(t => t.text.toLowerCase()),
+  )
+  const ranges: Range[] = []
+  tokens.forEach((token, index) => {
+    if (!inserted.has(index)) return
+    const range = document.createRange()
+    range.setStart(token.node, token.start)
+    range.setEnd(token.node, token.end)
+    ranges.push(range)
+  })
+  return ranges
 }

--- a/packages/runtime/components/review/diff.ts
+++ b/packages/runtime/components/review/diff.ts
@@ -52,6 +52,7 @@ export function diffOverlays(
   sections: Section[],
   diff: InjectedDiff,
   onlyChanges: boolean,
+  barOffset = 18,
 ): DiffOverlay[] {
   if (sections.length !== diff.sections.length) return []
   const overlays: DiffOverlay[] = []
@@ -61,7 +62,9 @@ export function diffOverlays(
     const { top, bottom } = sectionContent(section)
     const height = Math.max(bottom - top, 0)
     if (isChanged(status)) {
-      const left = Math.max(section.element.getBoundingClientRect().left - 18, 6)
+      // `barOffset` is the distance left of the content; the caller tightens it in review mode so the
+      // bar hugs the content edge and leaves the outer gutter free for the comment badges.
+      const left = Math.max(section.element.getBoundingClientRect().left - barOffset, 4)
       overlays.push({
         sectionIndex: section.index,
         kind: 'bar',

--- a/packages/runtime/components/review/diff.ts
+++ b/packages/runtime/components/review/diff.ts
@@ -61,12 +61,13 @@ export function diffOverlays(
     const { top, bottom } = sectionContent(section)
     const height = Math.max(bottom - top, 0)
     if (isChanged(status)) {
-      const left = Math.max(section.element.getBoundingClientRect().left - 18, 6)
+      // Flush to the left edge of the viewport: a dedicated change-indicator lane, clear of the
+      // content gutter (phase timeline + review comment affordances), so nothing piles up.
       overlays.push({
         sectionIndex: section.index,
         kind: 'bar',
         status,
-        rect: { top, left, height },
+        rect: { top, left: 0, height },
       })
     } else if (onlyChanges) {
       overlays.push({

--- a/packages/runtime/components/review/diff.ts
+++ b/packages/runtime/components/review/diff.ts
@@ -52,7 +52,6 @@ export function diffOverlays(
   sections: Section[],
   diff: InjectedDiff,
   onlyChanges: boolean,
-  barOffset = 18,
 ): DiffOverlay[] {
   if (sections.length !== diff.sections.length) return []
   const overlays: DiffOverlay[] = []
@@ -62,9 +61,7 @@ export function diffOverlays(
     const { top, bottom } = sectionContent(section)
     const height = Math.max(bottom - top, 0)
     if (isChanged(status)) {
-      // `barOffset` is the distance left of the content; the caller tightens it in review mode so the
-      // bar hugs the content edge and leaves the outer gutter free for the comment badges.
-      const left = Math.max(section.element.getBoundingClientRect().left - barOffset, 4)
+      const left = Math.max(section.element.getBoundingClientRect().left - 18, 6)
       overlays.push({
         sectionIndex: section.index,
         kind: 'bar',
@@ -118,10 +115,22 @@ function words(text: string): string[] {
  * Comparison is case-insensitive so a capitalization change is not noise, but ops carry the original
  * words for display. Pure, so it is unit-testable.
  */
+/** A word's comparison core: lowercased, with leading/trailing punctuation stripped, so a change in
+ * only surrounding punctuation (a trailing comma) does not register as an edit. */
+function wordCore(word: string): string {
+  return word.toLowerCase().replace(/^[^a-z0-9]+|[^a-z0-9]+$/g, '')
+}
+
 export function wordDiffOps(prev: string[], current: string[]): DiffOp[] {
   const n = prev.length
   const m = current.length
-  const same = (a: string, b: string) => a.toLowerCase() === b.toLowerCase()
+  // Compare on the punctuation-stripped core (so "scaling." matches "scaling"); fall back to exact
+  // for all-punctuation tokens, which have no core.
+  const same = (a: string, b: string) => {
+    const ca = wordCore(a)
+    const cb = wordCore(b)
+    return ca && cb ? ca === cb : a.toLowerCase() === b.toLowerCase()
+  }
   const dp: number[][] = Array.from({ length: n + 1 }, () => new Array(m + 1).fill(0))
   for (let i = n - 1; i >= 0; i--) {
     const row = dp[i] as number[]

--- a/packages/runtime/components/review/review.css
+++ b/packages/runtime/components/review/review.css
@@ -41,6 +41,8 @@
   pointer-events: none;
   border-radius: 10px;
   background: color-mix(in srgb, var(--vp-accent) 3.5%, transparent);
+  /* A same-hue border so the band reads as a padded frame around the hovered section. */
+  border: 1px solid color-mix(in srgb, var(--vp-accent) 10%, transparent);
   animation: vp-review-fade-in 0.12s var(--vp-ease);
 }
 

--- a/packages/runtime/components/review/review.css
+++ b/packages/runtime/components/review/review.css
@@ -40,7 +40,7 @@
   z-index: 54;
   pointer-events: none;
   border-radius: 10px;
-  background: color-mix(in srgb, var(--vp-accent) 6%, transparent);
+  background: color-mix(in srgb, var(--vp-accent) 3.5%, transparent);
   animation: vp-review-fade-in 0.12s var(--vp-ease);
 }
 

--- a/packages/runtime/tests/diff.test.ts
+++ b/packages/runtime/tests/diff.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it } from 'vitest'
 import {
   applyInlineWordDiff,
+  applyTitleDiff,
   diffOverlays,
   type InjectedDiff,
   isChanged,
@@ -141,5 +142,25 @@ describe('applyInlineWordDiff', () => {
     const filetreeP = el.querySelector('.vp-filetree p') as HTMLElement
     expect(filetreeP.querySelector('del, ins')).toBeNull()
     expect(filetreeP.textContent).toBe('add backfill.ts')
+  })
+})
+
+describe('applyTitleDiff', () => {
+  it('re-renders a renamed phase title as a del/ins diff and restores it (golden + restore)', () => {
+    document.body.innerHTML =
+      '<main class="vp-main"><div class="vp-phase"><div class="vp-phase__title">Switch the write path</div></div></main>'
+    const section = collectSections()[0]
+    const title = document.querySelector('.vp-phase__title') as HTMLElement
+    const original = title.innerHTML
+
+    const restore = applyTitleDiff(
+      section as Parameters<typeof applyTitleDiff>[0],
+      'Switch the upload path',
+    )
+    expect(title.querySelector('del')?.textContent).toBe('upload')
+    expect(title.querySelector('ins')?.textContent).toBe('write')
+
+    restore()
+    expect(title.innerHTML).toBe(original)
   })
 })

--- a/packages/runtime/tests/diff.test.ts
+++ b/packages/runtime/tests/diff.test.ts
@@ -1,0 +1,74 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { diffOverlays, type InjectedDiff, isChanged, readDiff } from '../components/review/diff.js'
+import { collectSections } from '../components/review/SectionComments.js'
+
+afterEach(() => {
+  document.body.innerHTML = ''
+  ;(globalThis as { __VP_DIFF__?: InjectedDiff }).__VP_DIFF__ = undefined
+})
+
+/** Build a `.vp-main` from child element HTML, as the rendered plan would have. */
+function setMain(...children: string[]): void {
+  document.body.innerHTML = `<main class="vp-main">${children.join('')}</main>`
+}
+
+/** A four-section plan (h1, phase, callout, phase) matching the diff fixtures below. */
+function fourSectionPlan(): void {
+  setMain(
+    '<h1>Plan</h1>',
+    '<div class="vp-phase"><div class="vp-phase__title">One</div></div>',
+    '<aside class="vp-callout"><div class="vp-callout__label">Risk</div></aside>',
+    '<div class="vp-phase"><div class="vp-phase__title">Two</div></div>',
+  )
+}
+
+const FOUR: InjectedDiff = {
+  sections: [
+    { status: 'unchanged', label: 'Plan', type: 'h1' },
+    { status: 'edited', label: 'One', type: 'phase' },
+    { status: 'unchanged', label: 'Risk', type: 'callout' },
+    { status: 'added', label: 'Two', type: 'phase' },
+  ],
+  removed: [],
+}
+
+describe('diffOverlays', () => {
+  it('emits a gutter bar only for changed sections, by document-order index (golden)', () => {
+    fourSectionPlan()
+    const overlays = diffOverlays(collectSections(), FOUR, false)
+    expect(overlays.map(o => [o.kind, o.status, o.sectionIndex])).toEqual([
+      ['bar', 'edited', 1],
+      ['bar', 'added', 3],
+    ])
+  })
+
+  it('adds a scrim over each unchanged section when only-changes is on (edge)', () => {
+    fourSectionPlan()
+    const overlays = diffOverlays(collectSections(), FOUR, true)
+    expect(overlays.filter(o => o.kind === 'bar')).toHaveLength(2)
+    const scrims = overlays.filter(o => o.kind === 'scrim')
+    expect(scrims.map(o => o.sectionIndex)).toEqual([0, 2])
+  })
+
+  it('emits nothing when the DOM section count disagrees with the diff (error / parity guard)', () => {
+    // Three DOM sections but a four-entry diff: index alignment is unsafe, so no cues at all.
+    setMain('<h1>Plan</h1>', '<div class="vp-phase"><div class="vp-phase__title">One</div></div>')
+    expect(diffOverlays(collectSections(), FOUR, false)).toEqual([])
+  })
+})
+
+describe('readDiff', () => {
+  it('returns null when no diff was injected, the payload when it was (golden + edge)', () => {
+    expect(readDiff()).toBeNull()
+    ;(globalThis as { __VP_DIFF__?: InjectedDiff }).__VP_DIFF__ = FOUR
+    expect(readDiff()).toBe(FOUR)
+  })
+})
+
+describe('isChanged', () => {
+  it('treats added and edited as changes, unchanged as not (golden)', () => {
+    expect(isChanged('added')).toBe(true)
+    expect(isChanged('edited')).toBe(true)
+    expect(isChanged('unchanged')).toBe(false)
+  })
+})

--- a/packages/runtime/tests/diff.test.ts
+++ b/packages/runtime/tests/diff.test.ts
@@ -100,6 +100,12 @@ describe('wordDiffOps', () => {
   it('treats a capitalization-only change as unchanged (edge)', () => {
     expect(wordDiffOps('done'.split(' '), 'Done'.split(' ')).every(o => o.type === 'eq')).toBe(true)
   })
+
+  it('does not mark a punctuation-only change, only the real insertion (edge)', () => {
+    // "scaling." -> "scaling" is just a comma move; only "and" is genuinely inserted.
+    const ops = wordDiffOps('scaling. We move'.split(' '), 'scaling and we move'.split(' '))
+    expect(compact(ops)).toEqual(['scaling', '+and', 'we', 'move'])
+  })
 })
 
 describe('applyInlineWordDiff', () => {

--- a/packages/runtime/tests/diff.test.ts
+++ b/packages/runtime/tests/diff.test.ts
@@ -1,10 +1,11 @@
 import { afterEach, describe, expect, it } from 'vitest'
 import {
+  applyInlineWordDiff,
   diffOverlays,
   type InjectedDiff,
-  insertedWordRanges,
   isChanged,
   readDiff,
+  wordDiffOps,
 } from '../components/review/diff.js'
 import { collectSections } from '../components/review/SectionComments.js'
 
@@ -79,49 +80,60 @@ describe('isChanged', () => {
   })
 })
 
-describe('insertedWordRanges', () => {
-  const section = (html: string): Element => {
-    document.body.innerHTML = `<div class="vp-phase">${html}</div>`
-    return document.querySelector('.vp-phase') as Element
-  }
+describe('wordDiffOps', () => {
+  const compact = (ops: { type: string; text: string }[]) =>
+    ops.map(o => (o.type === 'eq' ? o.text : `${o.type === 'del' ? '-' : '+'}${o.text}`))
 
-  it('ranges cover only the inserted words in the body prose (golden)', () => {
-    // The title is in a non-prose element, so it is never matched even though it changed.
-    const el = section(
-      '<div class="vp-phase__title">Ship it now</div><p>Roll out behind a staged feature flag with metrics</p>',
+  it('marks kept, inserted, and deleted words in order (golden)', () => {
+    const ops = wordDiffOps('the old slow path'.split(' '), 'the new path'.split(' '))
+    expect(compact(ops)).toEqual(['the', '-old', '-slow', '+new', 'path'])
+  })
+
+  it('reports an append as all insertions after the kept words (edge)', () => {
+    const ops = wordDiffOps(
+      'Roll out the flag'.split(' '),
+      'Roll out the flag behind a guard'.split(' '),
     )
-    const ranges = insertedWordRanges([el], 'Roll out behind a feature flag')
-    expect(ranges.map(r => r.toString())).toEqual(['staged', 'with', 'metrics'])
+    expect(compact(ops)).toEqual(['Roll', 'out', 'the', 'flag', '+behind', '+a', '+guard'])
   })
 
-  it('scans prose across all owned sibling blocks, not just the start element (edge)', () => {
-    // A heading section owns a following intro paragraph that is its sibling, not its child.
+  it('treats a capitalization-only change as unchanged (edge)', () => {
+    expect(wordDiffOps('done'.split(' '), 'Done'.split(' ')).every(o => o.type === 'eq')).toBe(true)
+  })
+})
+
+describe('applyInlineWordDiff', () => {
+  it('re-renders an edited paragraph as a del/ins diff and restores it (golden + restore)', () => {
     document.body.innerHTML =
-      '<main class="vp-main"><h1>Title</h1><p>Intro text now with extra words</p></main>'
-    const main = document.querySelector('.vp-main') as Element
-    const ranges = insertedWordRanges(Array.from(main.children), 'Intro text')
-    expect(ranges.map(r => r.toString())).toEqual(['now', 'with', 'extra', 'words'])
-  })
-
-  it('returns no ranges when the body prose is unchanged (edge)', () => {
-    const el = section('<p>Stand up the Redis client</p>')
-    expect(insertedWordRanges([el], 'Stand up the Redis client')).toEqual([])
-  })
-
-  it('excludes data-component li (FileTree etc.) from word highlighting (edge)', () => {
-    document.body.innerHTML =
-      '<div class="vp-phase"><p>Wrap the SDK with retries</p><div class="vp-filetree"><ul><li>add backfill.ts</li></ul></div></div>'
+      '<div class="vp-phase"><div class="vp-phase__title">Build</div><p>Wrap the SDK</p></div>'
     const el = document.querySelector('.vp-phase') as Element
-    // Only the paragraph's new words highlight; the FileTree entry is excluded despite being "new".
-    expect(insertedWordRanges([el], 'Wrap the SDK').map(r => r.toString())).toEqual([
-      'with',
-      'retries',
-    ])
+    const p = el.querySelector('p') as HTMLElement
+    const original = p.innerHTML
+
+    const restore = applyInlineWordDiff([el], 'Wrap the old SDK')
+    expect(p.querySelector('del.vp-diff-del')?.textContent).toBe('old')
+    expect(p.textContent).toContain('Wrap the')
+
+    restore()
+    expect(p.innerHTML).toBe(original)
   })
 
-  it('returns no ranges when the section has no p/li prose (error / non-prose block)', () => {
-    document.body.innerHTML = '<div class="vp-filetree"><span>add src/x.ts</span></div>'
-    const el = document.querySelector('.vp-filetree') as Element
-    expect(insertedWordRanges([el], 'modify src/y.ts')).toEqual([])
+  it('does not touch a section whose prose is unchanged (edge)', () => {
+    document.body.innerHTML = '<div class="vp-phase"><p>Stand up the client</p></div>'
+    const el = document.querySelector('.vp-phase') as Element
+    const original = (el.querySelector('p') as HTMLElement).innerHTML
+    applyInlineWordDiff([el], 'Stand up the client')
+    expect((el.querySelector('p') as HTMLElement).innerHTML).toBe(original)
+  })
+
+  it('ignores data-component prose, only diffing real paragraphs (edge)', () => {
+    document.body.innerHTML =
+      '<div class="vp-phase"><p>Wrap the SDK</p><div class="vp-filetree"><p>add backfill.ts</p></div></div>'
+    const el = document.querySelector('.vp-phase') as Element
+    applyInlineWordDiff([el], 'Wrap the SDK')
+    // The filetree paragraph is left alone (no diff markup injected there).
+    const filetreeP = el.querySelector('.vp-filetree p') as HTMLElement
+    expect(filetreeP.querySelector('del, ins')).toBeNull()
+    expect(filetreeP.textContent).toBe('add backfill.ts')
   })
 })

--- a/packages/runtime/tests/diff.test.ts
+++ b/packages/runtime/tests/diff.test.ts
@@ -1,5 +1,11 @@
 import { afterEach, describe, expect, it } from 'vitest'
-import { diffOverlays, type InjectedDiff, isChanged, readDiff } from '../components/review/diff.js'
+import {
+  diffOverlays,
+  type InjectedDiff,
+  insertedWordRanges,
+  isChanged,
+  readDiff,
+} from '../components/review/diff.js'
 import { collectSections } from '../components/review/SectionComments.js'
 
 afterEach(() => {
@@ -70,5 +76,41 @@ describe('isChanged', () => {
     expect(isChanged('added')).toBe(true)
     expect(isChanged('edited')).toBe(true)
     expect(isChanged('unchanged')).toBe(false)
+  })
+})
+
+describe('insertedWordRanges', () => {
+  const section = (html: string): Element => {
+    document.body.innerHTML = `<div class="vp-phase">${html}</div>`
+    return document.querySelector('.vp-phase') as Element
+  }
+
+  it('ranges cover only the inserted words in the body prose (golden)', () => {
+    // The title is in a non-prose element, so it is never matched even though it changed.
+    const el = section(
+      '<div class="vp-phase__title">Ship it now</div><p>Roll out behind a staged feature flag with metrics</p>',
+    )
+    const ranges = insertedWordRanges([el], 'Roll out behind a feature flag')
+    expect(ranges.map(r => r.toString())).toEqual(['staged', 'with', 'metrics'])
+  })
+
+  it('scans prose across all owned sibling blocks, not just the start element (edge)', () => {
+    // A heading section owns a following intro paragraph that is its sibling, not its child.
+    document.body.innerHTML =
+      '<main class="vp-main"><h1>Title</h1><p>Intro text now with extra words</p></main>'
+    const main = document.querySelector('.vp-main') as Element
+    const ranges = insertedWordRanges(Array.from(main.children), 'Intro text')
+    expect(ranges.map(r => r.toString())).toEqual(['now', 'with', 'extra', 'words'])
+  })
+
+  it('returns no ranges when the body prose is unchanged (edge)', () => {
+    const el = section('<p>Stand up the Redis client</p>')
+    expect(insertedWordRanges([el], 'Stand up the Redis client')).toEqual([])
+  })
+
+  it('returns no ranges when the section has no p/li prose (error / non-prose block)', () => {
+    document.body.innerHTML = '<div class="vp-filetree"><span>add src/x.ts</span></div>'
+    const el = document.querySelector('.vp-filetree') as Element
+    expect(insertedWordRanges([el], 'modify src/y.ts')).toEqual([])
   })
 })

--- a/packages/runtime/tests/diff.test.ts
+++ b/packages/runtime/tests/diff.test.ts
@@ -108,6 +108,17 @@ describe('insertedWordRanges', () => {
     expect(insertedWordRanges([el], 'Stand up the Redis client')).toEqual([])
   })
 
+  it('excludes data-component li (FileTree etc.) from word highlighting (edge)', () => {
+    document.body.innerHTML =
+      '<div class="vp-phase"><p>Wrap the SDK with retries</p><div class="vp-filetree"><ul><li>add backfill.ts</li></ul></div></div>'
+    const el = document.querySelector('.vp-phase') as Element
+    // Only the paragraph's new words highlight; the FileTree entry is excluded despite being "new".
+    expect(insertedWordRanges([el], 'Wrap the SDK').map(r => r.toString())).toEqual([
+      'with',
+      'retries',
+    ])
+  })
+
   it('returns no ranges when the section has no p/li prose (error / non-prose block)', () => {
     document.body.innerHTML = '<div class="vp-filetree"><span>add src/x.ts</span></div>'
     const el = document.querySelector('.vp-filetree') as Element

--- a/packages/runtime/tests/section-comments.test.ts
+++ b/packages/runtime/tests/section-comments.test.ts
@@ -39,4 +39,61 @@ describe('collectSections', () => {
     document.body.innerHTML = '<div>no main here</div>'
     expect(collectSections()).toEqual([])
   })
+
+  // PARITY GOLDEN: the same ordered section sequence is asserted against the mdast-based
+  // `splitSections` in packages/compile/tests/sections.test.ts ("full section-start vocabulary").
+  // The diff maps a status onto a DOM section by document-order index, so the DOM split here and the
+  // mdast split there MUST stay aligned. Add/remove a section component -> update BOTH goldens.
+  it('detects the full section-start vocabulary in order, matching splitSections (parity golden)', () => {
+    setMain(
+      '<h1>Title</h1>',
+      '<h2>Section two</h2>',
+      '<h3>Section three</h3>',
+      '<div class="vp-mermaid"><svg></svg></div>',
+      '<div class="vp-phase"><div class="vp-phase__title">Build</div></div>',
+      '<aside class="vp-callout"><div class="vp-callout__label">Risk</div></aside>',
+      '<div class="vp-filetree"></div>',
+      '<div class="vp-chart"><div class="vp-chart__title">Effort</div></div>',
+      '<div class="vp-matrix-wrap"><table class="vp-matrix"></table></div>',
+      '<div class="vp-compare"></div>',
+      '<div class="vp-checklist"><div class="vp-checklist__title">Done when</div></div>',
+      '<div class="vp-stat"></div>',
+      '<div class="vp-questions"><div class="vp-questions__title">Open questions</div></div>',
+    )
+    expect(collectSections().map(s => tokenForElement(s.element))).toEqual([
+      'h1',
+      'h2',
+      'h3',
+      'mermaid',
+      'phase',
+      'callout',
+      'filetree',
+      'chart',
+      'matrix',
+      'compare',
+      'checklist',
+      'stat',
+      'questions',
+    ])
+  })
 })
+
+/** The section type token for a DOM element, mirroring splitSections' tokens, so the two parity
+ * goldens compare the same vocabulary. */
+function tokenForElement(el: Element): string {
+  if (/^H[1-3]$/.test(el.tagName)) return el.tagName.toLowerCase()
+  const byClass: ReadonlyArray<[string, string]> = [
+    ['vp-mermaid', 'mermaid'],
+    ['vp-phase', 'phase'],
+    ['vp-callout', 'callout'],
+    ['vp-filetree', 'filetree'],
+    ['vp-chart', 'chart'],
+    ['vp-matrix-wrap', 'matrix'],
+    ['vp-compare', 'compare'],
+    ['vp-checklist', 'checklist'],
+    ['vp-stat', 'stat'],
+    ['vp-questions', 'questions'],
+  ]
+  for (const [cls, token] of byClass) if (el.classList.contains(cls)) return token
+  return 'unknown'
+}

--- a/packages/runtime/theme.css
+++ b/packages/runtime/theme.css
@@ -693,7 +693,10 @@ body {
   border: 1px solid var(--vp-question-border);
   border-radius: 7px;
   padding: 0.4rem 0.55rem;
-  resize: vertical;
+  /* The field auto-grows to fit its content (AutoGrowTextarea), so manual resize and the scrollbar
+     it would otherwise need are both off. */
+  resize: none;
+  overflow-y: hidden;
 }
 
 .vp-questions__answer::placeholder {

--- a/packages/runtime/theme.css
+++ b/packages/runtime/theme.css
@@ -135,10 +135,10 @@ body {
 }
 
 .vp-shell {
-  max-width: 800px;
+  max-width: 860px;
   margin: 0 auto;
   min-height: 100dvh;
-  padding: 3rem 1.5rem 6rem;
+  padding: 3rem 1.75rem 6rem;
 }
 
 .vp-main {

--- a/skills/visual-plan/SKILL.md
+++ b/skills/visual-plan/SKILL.md
@@ -45,7 +45,13 @@ and tables, with prose only connecting the visuals, not carrying the plan itself
    background. Then act on the printed feedback:
    - **Approve** -> proceed with the plan as written.
    - **Iterate** -> revise the plan addressing each comment, then review again with `-i N`
-     (`--iteration N`) incremented so the bar shows the round; repeat until Approve or Deny.
+     (`--iteration N`) incremented so the bar shows the round; repeat until Approve or Deny. **Edit
+     the same `.mdx` file in place** and re-render: `vplan` snapshots each plan it presents (keyed by
+     the file path), so the next render automatically marks what changed since the last view with a
+     subtle git-gutter accent and a "N changed" summary, letting the user re-review only the delta.
+     Pass `--diff <baseline.mdx>` to diff against an explicit file instead of the snapshot, or
+     `--no-diff` to suppress diffing (e.g. a clean first look). The diff also shows on a plain
+     `vplan render`, not just `--review`.
    - **Deny** -> stop and reconsider; do not proceed.
 
    **Strongly prefer `--review` as the way to iterate on any non-trivial plan with the user.** It is


### PR DESCRIPTION
## What

Adds **iteration diffing**: when an agent re-renders a plan after revising it, `vplan` marks what changed since the last version, so a human re-reviews only the delta instead of re-reading the whole plan.

A render of a plan *file* snapshots its source (`~/.vplan/snapshots`, keyed by absolute path); the next render of that path diffs the new source against the snapshot and injects the result as `__VP_DIFF__`. Works on `render`, `--watch`, and `--review`. `--diff <path>` forces an explicit baseline; `--no-diff` opts out; `--stdout` never auto-diffs (stays deterministic for pipelines).

## How it works

- **`@visualplan/compile/sections.ts`** — `splitSections` enumerates a plan's sections from the mdast (mirroring the runtime's DOM section set); `diffSections` aligns two versions by key via LCS, then a token-similarity pass so a reworded title or edited title-less block reads as `edited`, not remove+add. Pure/isomorphic.
- **CLI** — a per-file snapshot cache and `planDiffPlugin` that injects `__VP_DIFF__` into the build (render/watch/review alike).
- **Runtime (`DiffCues`)** — always-on change bars flush to the left edge of the viewport; a **"Show changes"** toggle reveals a true inline word diff (`<del>` red strikethrough / `<ins>` green, readable text) for both body edits **and** title renames, and fades unchanged sections. The inline diff mutates only the prose/title, reversibly, scoped to authored `<p>` so data components (file trees, tables, checklists) never produce false diffs.

The load-bearing invariant: the mdast split and the DOM split must produce the same section count and order, since the runtime maps a status onto a DOM section **by document-order index**. Two parity goldens (compile + runtime) pin this; a count mismatch degrades to no cue rather than a mislabeled one.

Also includes a small unrelated fix: review `<Questions>` answer fields now auto-grow.

## Testing

- 329 tests pass (27 files); typecheck + biome clean.
- Parity goldens (compile `splitSections` vs runtime `collectSections` over the full component vocabulary).
- A 21-case subagent-generated simulation corpus (`tests/fixtures/diff-corpus.json`) that pins the classifications and calibrates the rename threshold.
- `wordDiffOps` / `applyInlineWordDiff` / `applyTitleDiff` unit-tested in jsdom; verified end-to-end in a real browser (plain render and review mode).

## Notes / caveats

- **The content column widening (800 → 860px) is global** — it affects every rendered plan, not just diffs. Flagging in case it should be scoped or reverted.
- The inline diff **flattens inline formatting** (bold/links) in an edited paragraph while shown (restored on toggle-off).
- Word-level granularity is approximate (source prose vs rendered DOM text); punctuation-only changes are collapsed.
