### PR TITLE
feat(cli): author-time quality lint in check

### DIFF
--- a/packages/cli/AGENTS.md
+++ b/packages/cli/AGENTS.md
@@ -98,7 +98,17 @@ programmatic Node API at `dist/api.js` (the package's `import` entry, `exports["
   error box at render time). It also rejects markdown images (`![](url)`), which would compile to a
   live `<img>` and break the self-contained output. It imports `CHILD_BLOCK_COMPONENTS`
   and `parseBlockChildren` from `@visualplan/compile` so its static checks agree with what render
-  parses.
+  parses. `CheckIssue` carries an optional `severity` (absent = `error`); the syntax checks here omit
+  it, the quality lint emits `warn`. Both fail `check`; severity only changes the printed label.
+- `src/build/lint.ts` — the author-time quality lint, run by the `check` COMMAND (not `checkSource`,
+  so `render`/`share`/the API never block a stylistically-weak-but-valid plan from rendering). The
+  `check` command runs the syntax check first and only lints when it passes clean, so lint warnings
+  never bury a real error and the lint parse never sees malformed MDX. Rules flag the visual-plan
+  skill's "tell, don't show" mistakes (wall-of-prose Phase, all-prose plan, wide LR mermaid, long
+  Matrix cell, commented FileTree move row, multi-series chart with mismatched scales). Every rule's
+  threshold is a named constant at the top of the file for calibration; the chart rule compares
+  per-series peaks (NOT global min/max) so a single series ramping along its category axis is never
+  flagged. A lint `warn` fails `check` (exit 1) like an error.
 - The remark plugins (`remark-mermaid`, `remark-math`, `remark-plan-blocks`), the `plan-blocks`
   parser, the Expressive Code options, and the Material file-icons plugin now live in
   `packages/compile` (`@visualplan/compile`), shared with the `/view` browser compiler so both

--- a/packages/cli/AGENTS.md
+++ b/packages/cli/AGENTS.md
@@ -174,6 +174,13 @@ them. The `tests/compile.test.ts` "renders a plan outside any node project" case
   `dependencies`; `fflate` (the codec's dep) likewise.
 - **Publish with `pnpm publish`** so the `workspace:*` protocol is rewritten. `prepack` runs
   `vendor.mjs` then `tsup`.
+- **The quality lint (`build/lint.ts`) runs in the `check` COMMAND only, never in `checkSource`.**
+  `render`/`share`/the public API must keep rendering a stylistically-weak-but-valid plan (the point
+  is to SEE it). A lint `warn` fails `check` (exit 1): deliberately NO advisory mode and NO `--strict`
+  flag, so a weak plan blocks. Don't move lint into `checkSource` or add an advisory/`--strict` mode
+  without a deliberate reversal. Thresholds are calibrated against an eval corpus (precision-first,
+  since a warn blocks); chart-magnitude is held high on purpose so a legit ~40x stacked ramp is not
+  flagged.
 - The icon/highlighting deps (`material-icon-theme`, `expressive-code-color-chips`,
   `@expressive-code/core`, `hast-util-from-html`) are real prod `dependencies` (also declared by
   `@visualplan/compile`, which owns the plugins now). `material-icon-theme` ships `icons/*.svg` +

--- a/packages/cli/src/build/check.ts
+++ b/packages/cli/src/build/check.ts
@@ -16,6 +16,9 @@ export interface CheckIssue {
   line: number
   column: number
   message: string
+  /** Defaults to 'error' when absent. The syntax checks here omit it (all errors); the quality lint
+   * emits 'warn'. Both fail `check` (exit 1); severity only changes the printed label. */
+  severity?: 'error' | 'warn'
 }
 
 interface JsxAttribute {

--- a/packages/cli/src/build/lint.ts
+++ b/packages/cli/src/build/lint.ts
@@ -18,15 +18,21 @@ import type { CheckIssue } from './check.js'
  * good and weak plans: tune these numbers, not the rule logic, to move a rule's sensitivity.
  */
 
-/** A Phase with more than this many characters of prose and no structural child reads as an essay. */
-const WALL_OF_PROSE_CHARS = 600
+/** A Phase with more than this many characters of prose and no structural child reads as an essay.
+ * Calibrated against an editorial corpus: ~470-char prose-only phases still read as tight intent,
+ * ~560+ as a wall a reviewer would push back on. Good plans lead with a visual, so their phases
+ * carry structure and never reach this rule whatever their length. */
+const WALL_OF_PROSE_CHARS = 520
 /** A left-to-right flowchart with more than this many edges shrinks to illegibility inline. */
 const WIDE_MERMAID_EDGES = 6
 /** A Matrix cell longer than this forces a horizontal scrollbar (cells do not wrap). */
 const MATRIX_CELL_BUDGET = 32
 /** A chart whose largest series outscales its smallest by more than this ratio flattens the small
  * series onto the shared y-axis. Compared per series, not across the category axis: a single series
- * growing along its categories (a ramp, a funnel) is the data's shape, not a charting mistake. */
+ * growing along its categories (a ramp, a funnel) is the data's shape, not a charting mistake.
+ * Held conservative on purpose: a legitimate multi-series ramp (allowed vs rejected across a 100x
+ * traffic ramp) can have a ~40x peak spread, so a lower ratio would flag it. Catching 40-90x GROUPED
+ * charts without also flagging stacked ramps needs stacked-awareness, not a lower ratio. */
 const CHART_MAGNITUDE_RATIO = 100
 
 /** The components that count as "showing structure" for the all-prose rule. A `Callout` is excluded

--- a/packages/cli/src/build/lint.ts
+++ b/packages/cli/src/build/lint.ts
@@ -1,0 +1,235 @@
+import { readFile } from 'node:fs/promises'
+import remarkFrontmatter from 'remark-frontmatter'
+import remarkGfm from 'remark-gfm'
+import remarkMdx from 'remark-mdx'
+import remarkParse from 'remark-parse'
+import { unified } from 'unified'
+import { parseBlockChildren } from '@visualplan/compile'
+import type { CheckIssue } from './check.js'
+
+/**
+ * Author-time quality lint for plans, run by the `check` command alongside the syntax check. These
+ * are not correctness errors: a flagged plan renders fine. They catch the "tell, don't show"
+ * mistakes the visual-plan skill documents (a wall of prose, a wide left-to-right diagram, an
+ * unreadable Matrix cell), so the agent gets the feedback before a human ever sees a weak render.
+ * Every issue carries severity 'warn'; `check` still fails on them, so a weak plan blocks until fixed.
+ *
+ * The thresholds are deliberately collected at the top for calibration against an eval corpus of
+ * good and weak plans: tune these numbers, not the rule logic, to move a rule's sensitivity.
+ */
+
+/** A Phase with more than this many characters of prose and no structural child reads as an essay. */
+const WALL_OF_PROSE_CHARS = 600
+/** A left-to-right flowchart with more than this many edges shrinks to illegibility inline. */
+const WIDE_MERMAID_EDGES = 6
+/** A Matrix cell longer than this forces a horizontal scrollbar (cells do not wrap). */
+const MATRIX_CELL_BUDGET = 32
+/** A chart whose largest series outscales its smallest by more than this ratio flattens the small
+ * series onto the shared y-axis. Compared per series, not across the category axis: a single series
+ * growing along its categories (a ramp, a funnel) is the data's shape, not a charting mistake. */
+const CHART_MAGNITUDE_RATIO = 100
+
+/** The components that count as "showing structure" for the all-prose rule. A `Callout` is excluded
+ * on purpose: a plan of nothing but callouts is still telling, not showing. */
+const STRUCTURE_COMPONENTS = new Set([
+  'Phase',
+  'FileTree',
+  'Chart',
+  'Matrix',
+  'Compare',
+  'Checklist',
+  'Stat',
+  'Questions',
+])
+
+interface MdNode {
+  type: string
+  name?: string | null
+  lang?: string | null
+  value?: string
+  children?: MdNode[]
+  position?: { start: { line: number; column: number } }
+}
+
+/** Lint a plan file. Read separately from the syntax check; `check` only lints a plan that already
+ * passes the syntax check, so the parse here never sees malformed MDX. */
+export async function lintPlan(mdxPath: string): Promise<CheckIssue[]> {
+  return lintSource(await readFile(mdxPath, 'utf8'))
+}
+
+/** Walk an mdast tree and emit the quality warnings for a (syntactically valid) plan source. */
+export function lintSource(source: string): CheckIssue[] {
+  const issues: CheckIssue[] = []
+  const tree = unified()
+    .use(remarkParse)
+    .use(remarkFrontmatter)
+    .use(remarkGfm)
+    .use(remarkMdx)
+    .parse(source) as unknown as MdNode
+
+  let hasStructure = false
+  walk(tree, node => {
+    if (isStructural(node)) hasStructure = true
+    if (node.type === 'mdxJsxFlowElement') {
+      if (node.name === 'Phase') lintPhaseProse(node, issues)
+      else if (node.name === 'Matrix') lintMatrixCells(node, issues)
+      else if (node.name === 'FileTree') lintMoveComments(node, issues)
+      else if (node.name === 'Chart') lintChartMagnitude(node, issues)
+    } else if (node.type === 'code' && node.lang === 'mermaid') {
+      lintWideMermaid(node, issues)
+    }
+  })
+
+  // A plan with no diagram, timeline, or data component adds nothing over a wall of plain text.
+  if (!hasStructure) {
+    issues.push({
+      line: 1,
+      column: 1,
+      severity: 'warn',
+      message:
+        'This plan is all prose: no diagram, Phase timeline, or data component. A visual plan should show its structure, or it adds nothing over plain text.',
+    })
+  }
+
+  return issues
+}
+
+function isStructural(node: MdNode): boolean {
+  if (node.type === 'code' && (node.lang === 'mermaid' || node.lang === 'math')) return true
+  return node.type === 'mdxJsxFlowElement' && !!node.name && STRUCTURE_COMPONENTS.has(node.name)
+}
+
+/** A `Phase` that is a long run of prose with no diagram, list, or nested component: an essay where
+ * the skill wants a line of intent then a visual. */
+function lintPhaseProse(phase: MdNode, issues: CheckIssue[]): void {
+  let structural = false
+  let prose = 0
+  for (const child of phase.children ?? []) {
+    walk(child, node => {
+      if (
+        node.type === 'list' ||
+        node.type === 'code' ||
+        node.type === 'mdxJsxFlowElement' ||
+        node.type === 'mdxJsxTextElement'
+      ) {
+        structural = true
+      }
+      if (node.type === 'text' && typeof node.value === 'string') prose += node.value.length
+    })
+  }
+  if (!structural && prose > WALL_OF_PROSE_CHARS) {
+    issues.push({
+      ...at(phase),
+      severity: 'warn',
+      message: `This phase is ${prose} characters of prose with no diagram, list, or component. Lead with the visual and keep the prose to a line or two of intent.`,
+    })
+  }
+}
+
+/** A `flowchart LR` / `RL` past an edge count shrinks to illegibility inline; top-down or a split reads better. */
+function lintWideMermaid(node: MdNode, issues: CheckIssue[]): void {
+  const src = node.value ?? ''
+  const firstLine = src
+    .split('\n')
+    .map(line => line.trim())
+    .find(line => line.length > 0)
+  if (!firstLine || !/^(flowchart|graph)\s+(LR|RL)\b/i.test(firstLine)) return
+  const edges = (src.match(/-->|---|==>|===|-\.->|--[xo]\b|<-->/g) ?? []).length
+  if (edges > WIDE_MERMAID_EDGES) {
+    issues.push({
+      ...at(node),
+      severity: 'warn',
+      message: `This left-to-right flowchart has ${edges} edges and will shrink to illegibility inline. Use \`flowchart TD\` or split it into smaller diagrams.`,
+    })
+  }
+}
+
+/** A `Matrix` cell longer than the budget forces a horizontal scrollbar, since cells do not wrap. */
+function lintMatrixCells(node: MdNode, issues: CheckIssue[]): void {
+  const value = parseBlockChildren('Matrix', node).value as {
+    corner: string
+    columns: { name: string }[]
+    rows: { label: string; cells: string[] }[]
+  } | null
+  if (!value) return
+  const cells = [
+    value.corner,
+    ...value.columns.map(column => column.name),
+    ...value.rows.flatMap(row => [row.label, ...row.cells]),
+  ]
+  const longest = cells.reduce((widest, cell) => (cell.length > widest.length ? cell : widest), '')
+  if (longest.length > MATRIX_CELL_BUDGET) {
+    issues.push({
+      ...at(node),
+      severity: 'warn',
+      message: `A Matrix cell is too long ("${truncate(longest)}", ${longest.length} chars). Cells do not wrap and force a horizontal scrollbar; keep them to a word or short score and put rationale in prose.`,
+    })
+  }
+}
+
+/** A `FileTree` move row with a `-- comment`: the origin annotation already fills the row, so the
+ * comment gets crowded out. */
+function lintMoveComments(node: MdNode, issues: CheckIssue[]): void {
+  const list = (node.children ?? []).find(child => child.type === 'list')
+  if (!list) return
+  for (const item of list.children ?? []) {
+    const text = toText(item).trim()
+    if (/^move\b/.test(text) && text.includes(' -- ')) {
+      issues.push({
+        ...at(item),
+        severity: 'warn',
+        message:
+          'This FileTree move row carries a "-- comment". The origin path already fills the row, so the comment gets crowded out; put it in prose or a Callout instead.',
+      })
+    }
+  }
+}
+
+/** A multi-series `Chart` whose series differ wildly in scale flattens the small series onto the
+ * shared y-axis. Compared per series (each series' peak), so a single series ramping along its
+ * categories is never flagged: that spread is the data, not a mistake. */
+function lintChartMagnitude(node: MdNode, issues: CheckIssue[]): void {
+  const value = parseBlockChildren('Chart', node).value as {
+    series: string[]
+    data: { values: unknown[] }[]
+  } | null
+  if (!value || value.series.length < 2) return
+  const peaks: number[] = []
+  for (let index = 0; index < value.series.length; index++) {
+    const numbers = value.data
+      .map(point => point.values[index])
+      .filter((candidate): candidate is number => typeof candidate === 'number' && candidate > 0)
+    if (numbers.length > 0) peaks.push(Math.max(...numbers))
+  }
+  if (peaks.length < 2) return
+  const max = Math.max(...peaks)
+  const min = Math.min(...peaks)
+  if (max / min > CHART_MAGNITUDE_RATIO) {
+    issues.push({
+      ...at(node),
+      severity: 'warn',
+      message: `This chart's series differ wildly in scale (a series peaking at ${min} alongside one at ${max}); the small series flattens onto the shared axis. Split into separate charts or normalize to one unit.`,
+    })
+  }
+}
+
+/** Depth-first walk over the mdast, visiting each node once. Own walker (not unist-util-visit) to
+ * stay free of its node typing and reuse it cleanly for per-section subtrees. */
+function walk(node: MdNode, visit: (node: MdNode) => void): void {
+  visit(node)
+  for (const child of node.children ?? []) walk(child, visit)
+}
+
+/** Concatenate the text of an mdast node, ignoring formatting (mirrors the compile parser's helper). */
+function toText(node: MdNode): string {
+  if (typeof node.value === 'string') return node.value
+  return (node.children ?? []).map(toText).join('')
+}
+
+function at(node: MdNode): { line: number; column: number } {
+  return node.position?.start ?? { line: 1, column: 1 }
+}
+
+function truncate(text: string, max = 40): string {
+  return text.length > max ? `${text.slice(0, max).trim()}…` : text
+}

--- a/packages/cli/src/commands/check.ts
+++ b/packages/cli/src/commands/check.ts
@@ -1,6 +1,7 @@
 import { existsSync, statSync } from 'node:fs'
 import { resolve } from 'node:path'
 import { type CheckIssue, checkPlan } from '../build/check.js'
+import { lintPlan } from '../build/lint.js'
 
 /** Resolve a plan-file argument to an absolute path, failing with a friendly message when it is
  * missing or not a regular file. Without this the reader throws a raw `ENOENT`/`EISDIR`, and the
@@ -12,21 +13,36 @@ export function resolvePlanFile(file: string): string {
   return absolute
 }
 
-/** Print check issues in an editor-clickable `file:line:column  message` format. */
+/** Print check issues in an editor-clickable `file:line:column  severity: message` format. */
 export function printIssues(file: string, issues: CheckIssue[]): void {
   for (const issue of issues) {
-    process.stderr.write(`${file}:${issue.line}:${issue.column}  ${issue.message}\n`)
+    const label = (issue.severity ?? 'error') === 'warn' ? 'warning' : 'error'
+    process.stderr.write(`${file}:${issue.line}:${issue.column}  ${label}: ${issue.message}\n`)
   }
 }
 
-/** `vplan check <file>` — validate a plan's MDX without rendering it. */
+/** `count noun(s)`, pluralizing the noun. */
+function count(n: number, noun: string): string {
+  return `${n} ${noun}${n === 1 ? '' : 's'}`
+}
+
+/**
+ * `vplan check <file>` — validate a plan's MDX without rendering it. Runs the syntax check first;
+ * only if the plan parses cleanly does it run the quality lint, so lint warnings never bury a real
+ * syntax error and the lint parse never sees malformed MDX. A lint warning fails the check too, so
+ * a weak plan blocks until fixed.
+ */
 export async function runCheck(file: string): Promise<void> {
-  const issues = await checkPlan(resolvePlanFile(file))
+  const path = resolvePlanFile(file)
+  const errors = await checkPlan(path)
+  const issues = errors.length === 0 ? await lintPlan(path) : errors
   if (issues.length === 0) {
     process.stdout.write(`${file} is valid\n`)
     return
   }
   printIssues(file, issues)
-  process.stdout.write(`\n${issues.length} issue(s) found\n`)
+  const warnings = issues.filter(issue => issue.severity === 'warn').length
+  const summary = errors.length > 0 ? count(issues.length, 'error') : count(warnings, 'warning')
+  process.stdout.write(`\n${summary} found\n`)
   process.exitCode = 1
 }

--- a/packages/cli/tests/lint.test.ts
+++ b/packages/cli/tests/lint.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from 'vitest'
+import { lintSource } from '../src/build/lint.js'
+
+/** The lint emits only warnings; every fixture that fires should produce warn-severity issues. */
+function warnings(source: string): string[] {
+  const issues = lintSource(source)
+  expect(issues.every(issue => issue.severity === 'warn')).toBe(true)
+  return issues.map(issue => issue.message)
+}
+
+describe('lintSource', () => {
+  describe('wall-of-prose', () => {
+    it('flags a Phase that is a long run of prose with no structure', () => {
+      const source = `# Plan\n\n<Phase title="Context">\n\n${'context detail '.repeat(50)}\n\n</Phase>\n`
+      expect(warnings(source).some(m => m.includes('characters of prose'))).toBe(true)
+    })
+
+    it('passes a Phase that leads with a list', () => {
+      const source = `# Plan\n\n<Phase title="Step">\n\n1. do a thing\n2. do another thing\n\n</Phase>\n`
+      expect(lintSource(source)).toEqual([])
+    })
+  })
+
+  describe('all-prose plan', () => {
+    it('flags a plan with no diagram or component', () => {
+      const source =
+        '# Plan\n\nThis plan is written entirely as prose, with no structure to show at all.\n'
+      expect(warnings(source).some(m => m.includes('all prose'))).toBe(true)
+    })
+
+    it('passes a plan with a data component', () => {
+      const source = '# Plan\n\n<Checklist title="Done when">\n- [ ] ship it\n</Checklist>\n'
+      expect(lintSource(source)).toEqual([])
+    })
+  })
+
+  describe('wide mermaid', () => {
+    it('flags a left-to-right flowchart past the edge budget', () => {
+      const diagram =
+        'flowchart LR\n  A --> B\n  B --> C\n  C --> D\n  D --> E\n  E --> F\n  F --> G\n  G --> H'
+      const source = `# Plan\n\n\`\`\`mermaid\n${diagram}\n\`\`\`\n`
+      expect(warnings(source).some(m => m.includes('left-to-right flowchart'))).toBe(true)
+    })
+
+    it('passes the same node count as a top-down flowchart', () => {
+      const diagram =
+        'flowchart TD\n  A --> B\n  B --> C\n  C --> D\n  D --> E\n  E --> F\n  F --> G\n  G --> H'
+      const source = `# Plan\n\n\`\`\`mermaid\n${diagram}\n\`\`\`\n`
+      expect(lintSource(source)).toEqual([])
+    })
+  })
+
+  describe('long Matrix cell', () => {
+    it('flags a cell that overflows the budget', () => {
+      const source =
+        '# Plan\n\n<Matrix>\n| Dimension | Option A | Option B |\n|---|---|---|\n| Latency under sustained production load | low | high |\n</Matrix>\n'
+      expect(warnings(source).some(m => m.includes('Matrix cell is too long'))).toBe(true)
+    })
+
+    it('passes a matrix of short cells', () => {
+      const source =
+        '# Plan\n\n<Matrix>\n| Dim | A | B |\n|---|---|---|\n| Speed | low | high |\n</Matrix>\n'
+      expect(lintSource(source)).toEqual([])
+    })
+  })
+
+  describe('commented move row', () => {
+    it('flags a FileTree move row that carries a -- comment', () => {
+      const source =
+        '# Plan\n\n<FileTree>\n- move src/old.ts -> src/new.ts -- renamed for clarity\n</FileTree>\n'
+      expect(warnings(source).some(m => m.includes('move row carries'))).toBe(true)
+    })
+
+    it('passes a move row with no comment', () => {
+      const source =
+        '# Plan\n\n<FileTree>\n- add src/new.ts\n- move src/old.ts -> src/moved.ts\n</FileTree>\n'
+      expect(lintSource(source)).toEqual([])
+    })
+  })
+
+  describe('chart magnitude spread', () => {
+    it('flags a multi-series chart whose series differ wildly in scale', () => {
+      const source =
+        '# Plan\n\n<Chart type="bar" title="x">\n| Cat | Small | Huge |\n|---|---|---|\n| A | 5 | 100000 |\n</Chart>\n'
+      expect(warnings(source).some(m => m.includes('differ wildly in scale'))).toBe(true)
+    })
+
+    it('passes a ramp where one series grows along the category axis', () => {
+      // The series are comparable at each step; the spread is along x (the ramp), not across series.
+      const source =
+        '# Plan\n\n<Chart type="area" title="x" stacked>\n| Step | Allowed | Rejected |\n|---|---|---|\n| 1% | 50 | 2 |\n| 10% | 480 | 15 |\n| 100% | 4800 | 120 |\n</Chart>\n'
+      expect(lintSource(source)).toEqual([])
+    })
+
+    it('passes a single series spread across its categories', () => {
+      const source = '# Plan\n\n<Chart type="bar" title="x">\n- Small: 1\n- Large: 5000\n</Chart>\n'
+      expect(lintSource(source)).toEqual([])
+    })
+  })
+})

--- a/packages/runtime/components/review/SectionComments.tsx
+++ b/packages/runtime/components/review/SectionComments.tsx
@@ -217,6 +217,10 @@ export function SectionOverlays({
   onAdd: (section: Section) => void
   onView: (section: Section) => void
 }) {
+  // Which section's comment control the pointer is on. The highlight band tracks THIS, not the
+  // section band: the add button appears on section hover, but the band only lights up once the
+  // pointer reaches a comment control, so an idle hover over the prose stays quiet.
+  const [activeControl, setActiveControl] = useState<number | null>(null)
   return (
     <>
       {sections.map(section => {
@@ -231,9 +235,12 @@ export function SectionOverlays({
           Math.max((content.top + content.bottom) / 2 - 15, 8),
           window.innerHeight - 72,
         )
+        const onControlEnter = () => setActiveControl(section.index)
+        const onControlLeave = () =>
+          setActiveControl(active => (active === section.index ? null : active))
         return (
           <Fragment key={section.index}>
-            {hovered && (
+            {section.index === activeControl && (
               // A wide band around the section's content (heading + its elements), not the empty
               // space up to the next section. Padded ~8px beyond the content so the bordered frame
               // reads as breathing room around it; overlay only, so it never shifts the page layout.
@@ -254,6 +261,8 @@ export function SectionOverlays({
                 // Out in the right gutter with breathing room from the content, clamped on-screen.
                 style={{ top: controlTop, left: Math.min(rect.right + 18, window.innerWidth - 42) }}
                 onClick={() => onAdd(section)}
+                onMouseEnter={onControlEnter}
+                onMouseLeave={onControlLeave}
                 aria-label={`Comment on "${section.label}"`}
                 title={`Comment on "${section.label}"`}
               >
@@ -267,6 +276,8 @@ export function SectionOverlays({
                 // Out in the left gutter with breathing room from the content, clamped on-screen.
                 style={{ top: controlTop, left: Math.max(rect.left - 46, 10) }}
                 onClick={() => onView(section)}
+                onMouseEnter={onControlEnter}
+                onMouseLeave={onControlLeave}
                 aria-label={`${count} comment${count === 1 ? '' : 's'} on "${section.label}"`}
                 title={`View ${count} comment${count === 1 ? '' : 's'}`}
               >


### PR DESCRIPTION
## What

Folds an author-time quality lint into `vplan check`, so the agent gets feedback on weak plans before a human ever sees a poor render. Plus a small review-tool UX fix.

### Lint (`packages/cli/src/build/lint.ts`)
Runs in the `check` **command** (not `checkSource`, so `render`/`share`/the API still render stylistically-weak-but-valid plans, the point is to *see* them). Runs only after the syntax check passes, so warnings never bury a real error. A lint `warn` **fails** `check` (exit 1) like an error, so a weak plan blocks; severity is a label only. Deliberately no `--strict` flag and no advisory mode.

Six rules, each a tunable threshold constant:
- **wall-of-prose** - a Phase that is a long run of prose with no diagram/list/component
- **all-prose** - a plan with no diagram/Phase/data component at all
- **wide-mermaid** - a left-to-right flowchart with too many edges
- **matrix-cell** - a Matrix cell long enough to force a horizontal scrollbar
- **move-comment** - a FileTree `move` row carrying a `-- comment`
- **chart-magnitude** - a multi-series chart whose series sit on wildly different scales (compared per-series, so a single series ramping along its category axis is never flagged)

### Review UX fix (`SectionComments.tsx`)
The section highlight band now appears only when hovering a comment control, not anywhere in the section's band. The add-comment button still appears on section hover.

## Calibration
Thresholds were tuned against a 53-plan eval corpus (good + deliberately-weak plans, labeled independent of the linter), scored with a precision-first bias since a `warn` blocks:

| rule | precision | recall |
|---|---|---|
| wall-of-prose | 100% | 100% |
| all-prose | 100% | 100% |
| wide-mermaid | 100% | 100% |
| matrix-cell | 100% | 100% |
| move-comment | 100% | 100% |
| chart-magnitude | 100% | 67% |

**29/29 good plans stayed clean (zero false positives).** `wide-mermaid=6` and `matrix-cell=32` landed exactly on the editorial boundaries; `wall-of-prose` was lowered 600 → 520. `chart-magnitude` is held at 100 on purpose: a legit ~40x stacked ramp is indistinguishable from a bad 40x chart by peak-ratio alone, so catching 40-90x grouped charts needs stacked-awareness, not a lower ratio (documented as the upgrade path).

## Tests
- 13 new lint tests (one firing + one clean fixture per rule); `example.mdx` stays clean.
- Full suite: 122 CLI tests pass, all packages typecheck, biome clean.