### PR TITLE
perf(render): bundle only the heavy renderers a plan uses

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -136,6 +136,10 @@ A release is cut by creating a GitHub release; the tag is the published version 
 
 ## Key Decisions
 
+- 2026-06-24: The single-file render bundles only the heavy renderers the plan authors (a
+  source-token scan stubs unused `Mermaid`->elkjs and `Chart`->recharts at the component boundary,
+  one-shot build only). Why: elkjs alone was 62% of every bundle; a renderer-free plan drops from
+  ~2.3MB to ~320KB. Detection biases toward inclusion so a miss can never break a render.
 - 2026-06-24: Iteration diffing is section-level and maps a status onto a DOM section by
   **document-order index**, so `splitSections` (mdast, `@visualplan/compile`) and the runtime's
   `collectSections` (DOM) MUST enumerate the same sections in the same order; two parity goldens

--- a/packages/cli/AGENTS.md
+++ b/packages/cli/AGENTS.md
@@ -67,6 +67,15 @@ programmatic Node API at `dist/api.js` (the package's `import` entry, `exports["
   This single plugin replaced the old `virtual:plan` path alias AND `@mdx-js/rollup` (the plan is the
   only `.mdx`), so the one-shot build and `--watch` share ONE compile path and cannot drift. For
   `--watch`, `startDevServer(path)` passes `{ path }`; the plugin re-reads the file in `load`.
+  **Content-aware bundling:** `buildHtml` adds `stubUnusedRenderersPlugin`, which scans the plan
+  source and replaces the heavy renderers it does not author with a `() => null` stub at the component
+  boundary (`./components/<Name>.js`), dropping the dep subtree from the single-file output: no
+  ` ```mermaid ` fence stubs `Mermaid` (cuts beautiful-mermaid + elkjs, ~1.5MB), no `<Chart` stubs
+  `Chart` (cuts recharts, ~450KB). A renderer-free plan is ~320KB vs the ~2.3MB full bundle. The
+  per-renderer regexes (`STUBBABLE_RENDERERS`) **must stay biased toward inclusion** (a false positive
+  only costs bytes; a miss drops a renderer the plan uses and breaks it). It is added ONLY in
+  `buildHtml`, never in `baseConfig`/`startDevServer`, because a `--watch` plan can add a diagram or
+  chart after the bundle's renderers were chosen; do not move it into the shared config.
   **HMR gotcha:** the plan is now a virtual module backed by a file, not a real module Vite tracks by
   path, so `addWatchFile` alone does NOT invalidate it on a save (verified: it only adds the file to
   the watcher). The plugin's `handleHotUpdate` is what drives `--watch`: on a change to the plan it

--- a/packages/cli/src/build/compile.ts
+++ b/packages/cli/src/build/compile.ts
@@ -239,6 +239,52 @@ function planDiffPlugin(readSource: () => string, baseline: string): Plugin {
   }
 }
 
+/**
+ * The two heaviest renderers dominate the single-file output, and both sit in the always-imported
+ * `components` map, so a plan ships them even when it uses neither: `Mermaid` pulls in
+ * beautiful-mermaid + elkjs (a ~1.5MB graph-layout engine) and `Chart` pulls in recharts (~450KB).
+ * Each regex matches the only authoring token that can make that component render: a ` ```mermaid `
+ * fence for `Mermaid`, a `<Chart` tag for `Chart` (the `<Mermaid`/`<Chart` JSX forms are matched too,
+ * defensively). Detection is biased toward inclusion, so a false positive only costs bytes while a
+ * miss can never drop a renderer a plan actually uses.
+ */
+const STUBBABLE_RENDERERS: Record<string, RegExp> = {
+  Chart: /<Chart[\s/>]/,
+  Mermaid: /(?:^|\n)[ \t]{0,3}[`~]{3,}[ \t]*mermaid\b|<Mermaid[\s/>]/,
+}
+
+/**
+ * Replace each heavy renderer the plan does not use with a `() => null` stub, dropping its transitive
+ * dep subtree (recharts, or beautiful-mermaid + elkjs) from the bundle. Stubbing at the component
+ * boundary (the one `./components/<Name>.js` specifier `index.tsx` imports) is robust: it needs only
+ * the component's single named export, not a mirror of the underlying library's surface, and a missed
+ * match degrades to the full bundle rather than a broken render. The stub is never invoked, because it
+ * is installed only when the source contains no token that could render that component. Used only by
+ * the one-shot `buildHtml` (the saved `.plan.html`), never the `--watch` server, where a watched plan
+ * could add a diagram or chart after the bundle's renderers were chosen.
+ */
+function stubUnusedRenderersPlugin(source: string): Plugin {
+  const stubbed = Object.entries(STUBBABLE_RENDERERS)
+    .filter(([, token]) => !token.test(source))
+    .map(([name]) => name)
+  const STUB_PREFIX = '\0visualplan-stub:'
+  return {
+    name: 'visualplan:stub-unused-renderers',
+    enforce: 'pre',
+    resolveId(id) {
+      for (const name of stubbed) {
+        if (id === `./components/${name}.js` || id.endsWith(`/components/${name}.js`)) {
+          return STUB_PREFIX + name
+        }
+      }
+    },
+    load(id) {
+      if (id.startsWith(STUB_PREFIX))
+        return `export const ${id.slice(STUB_PREFIX.length)} = () => null`
+    },
+  }
+}
+
 /** How a plan is rendered, beyond its source. Defaults match the CLI (cog + share both on). */
 export interface BuildOptions {
   /** Default color scheme baked into the page. Default `system`. */
@@ -334,7 +380,7 @@ export async function buildHtml(source: string, options: BuildOptions = {}): Pro
     const config = baseConfig(paths, source, options)
     await build({
       ...config,
-      plugins: [...(config.plugins ?? []), viteSingleFile()],
+      plugins: [...(config.plugins ?? []), stubUnusedRenderersPlugin(source), viteSingleFile()],
       build: {
         outDir,
         emptyOutDir: true,

--- a/packages/cli/tests/compile.test.ts
+++ b/packages/cli/tests/compile.test.ts
@@ -115,6 +115,48 @@ describe('renderToFile', () => {
   }, 60_000)
 })
 
+describe('content-aware bundling', () => {
+  // The two heaviest renderers and their dep subtrees dominate the single-file output: a mermaid
+  // diagram pulls in beautiful-mermaid + elkjs (a ~1.5MB layout engine, the `elk.algorithm` marker),
+  // a chart pulls in recharts (~450KB, the `recharts-` class-prefix marker). buildHtml stubs the ones
+  // the plan does not author, so a plan ships only what it uses. These guards pin that: a regression to
+  // statically requiring either renderer would re-inflate the bundle and trip the absence assertions.
+  const ELK_MARKER = 'elk.algorithm'
+  const RECHARTS_MARKER = 'recharts-'
+
+  it('drops both heavy renderers from a plan that uses neither (golden)', async () => {
+    const html = await buildHtml(
+      '# Plain\n\nJust prose.\n\n<Phase title="A">\n\nwork\n\n</Phase>\n',
+    )
+    expect(html).toContain('vp-phase')
+    expect(html).not.toContain(ELK_MARKER)
+    expect(html).not.toContain(RECHARTS_MARKER)
+    // A renderer-free plan is a fraction of the full ~2.3MB bundle; the ceiling catches a regression
+    // to statically bundling elkjs/recharts without flaking on minor dependency size drift.
+    expect(html.length).toBeLessThan(1_000_000)
+  }, 60_000)
+
+  it('keeps recharts but drops elkjs for a chart-only plan (edge)', async () => {
+    const html = await buildHtml(
+      "# Chart\n\n<Chart type='bar' title='Effort'>\n- Limiter: 2\n- Flag: 1\n</Chart>\n",
+    )
+    expect(html).toContain(RECHARTS_MARKER)
+    expect(html).not.toContain(ELK_MARKER)
+  }, 60_000)
+
+  it('keeps elkjs but drops recharts for a diagram-only plan (edge)', async () => {
+    const html = await buildHtml('# Diagram\n\n```mermaid\nflowchart LR\n  A --> B\n```\n')
+    expect(html).toContain(ELK_MARKER)
+    expect(html).not.toContain(RECHARTS_MARKER)
+  }, 60_000)
+
+  it('keeps both renderers for the full example that uses both (golden)', () => {
+    // The example render in beforeAll authors both a chart and a mermaid diagram, so neither is stubbed.
+    expect(html).toContain(ELK_MARKER)
+    expect(html).toContain(RECHARTS_MARKER)
+  })
+})
+
 describe('planTitle', () => {
   it('reads the first H1 as the title (golden)', async () => {
     const path = join(workDir, 'titled.mdx')


### PR DESCRIPTION
## What

Every rendered `.plan.html` shipped beautiful-mermaid + elkjs (~1.5MB) and recharts (~450KB) even when the plan had no diagram and no chart, because both renderers sit in the always-imported `components` map. The bundle was content-independent: four very different plans all landed within 1% of ~2.36MB. This makes the bundle content-aware, so a plan ships only the renderers it actually authors.

## How

Source-map attribution showed elkjs alone was 62% of the bundle (pulled in transitively by beautiful-mermaid for flowchart layout), not recharts as expected. `buildHtml` now scans the plan source and, for each heavy renderer the plan does not author, replaces its component module with a `() => null` stub at the component boundary (`./components/Mermaid.js` / `Chart.js`), dropping the whole dependency subtree from the single-file output.

- Stubbing at the component boundary needs only the one named export per component, not a mirror of each library's surface, and a missed match degrades to the full bundle rather than a broken render.
- Detection (`STUBBABLE_RENDERERS` regexes) is deliberately biased toward inclusion: a `<Chart`/mermaid-fence token keeps the real renderer, so a false positive only costs bytes while a miss can never drop a renderer the plan uses.
- Scoped to the one-shot `buildHtml` (the saved file + programmatic API), not `--watch`, where a watched plan can add a diagram or chart after the renderers were chosen.

Measured payoff (raw single-file size, via the CLI): renderer-free plan 2362KB -> 321KB (86%); chart-only plan drops elkjs (2367KB -> 1849KB); a plan using both is unchanged. Verified across four real example plans that recharts ships iff a `<Chart>` is authored and elkjs iff a mermaid fence is present.

## Verification

All run locally on this branch:

- [x] `pnpm lint` passes
- [x] `pnpm format` reports no changes (`biome format .`)
- [x] `pnpm typecheck` passes
- [x] `pnpm build` succeeds
- [x] `pnpm test` passes (346 tests, including 4 new content-aware-bundling guards in `compile.test.ts`)

## Notes

Render-time improvement follows from the smaller bundle (a renderer-free plan parses ~7x less inlined JS) but was not separately benchmarked. `--watch` and `--review` intentionally keep the full bundle.