### PR TITLE
feat(cli): export plans to PDF or JPG

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,6 +26,12 @@ polished, self-contained HTML page, so an AI agent can present plans as scannabl
   injecting `__VP_DIFF__` so the runtime marks added/edited sections git-gutter style. `--diff <path>`
   forces an explicit baseline (no cache touch); `--no-diff` opts out. Works on render, `--watch`, and
   `--review`; a `--stdout` render never auto-diffs (it stays deterministic for pipelines).
+- `vplan export <pdf|jpg> <file.mdx>` builds the same self-contained page, then renders it to a
+  static file via a headless Chromium (`playwright-core`): `pdf` prints a paginated A4 document,
+  `jpg` a full-page hi-dpi screenshot. Output defaults to `<file>.pdf` / `<file>.jpg` (`--out`
+  overrides; stdin input requires it); `--theme` overrides the baked scheme, `--no-open` suppresses
+  opening. Chromium is sourced system-first (Chrome/Edge channel) then a `playwright`-installed one,
+  with `--browser`/`VPLAN_CHROMIUM` overrides, else an error naming `npx playwright install chromium`.
 - `vplan components` prints the component vocabulary cheat-sheet.
 - A programmatic API (`import { renderPlan, checkPlan } from 'vplan'`) renders/validates a plan from
   an in-memory MDX string, with a named export per catalog entry. See `packages/cli/src/api.ts`.
@@ -136,6 +142,10 @@ A release is cut by creating a GitHub release; the tag is the published version 
 
 ## Key Decisions
 
+- 2026-06-24: `vplan export` renders headless via `playwright-core` (a prod dep) and sources Chromium
+  system-first, never bundling a browser binary. Why: a bundled `playwright` would add a huge
+  postinstall to a CLI whose whole point is a small self-contained package; reusing a present Chrome
+  keeps the install tiny. PDF paginates (A4) and JPG is one full-page image, per the approved plan.
 - 2026-06-24: The single-file render bundles only the heavy renderers the plan authors (a
   source-token scan stubs unused `Mermaid`->elkjs and `Chart`->recharts at the component boundary,
   one-shot build only). Why: elkjs alone was 62% of every bundle; a renderer-free plan drops from

--- a/packages/app/src/pages/docs/cli.md
+++ b/packages/app/src/pages/docs/cli.md
@@ -40,6 +40,26 @@ images (which would break the self-contained output).
 
 Run `check` before showing a plan to a user, so they never see a broken render.
 
+## export
+
+```bash
+vplan export <pdf|jpg> <file.mdx>
+```
+
+Builds the same self-contained page, then renders it to a static file with a headless Chromium:
+`pdf` prints a paginated A4 document, `jpg` a full-page hi-dpi screenshot. The output goes to
+`<file>.pdf` / `<file>.jpg` next to the source and opens.
+
+| Flag | Effect |
+|------|--------|
+| `--out <path>` | Write to `<path>` instead of `<file>.<pdf\|jpg>`. Required when reading from stdin. |
+| `--theme <theme>` | Override the baked color scheme: `light`, `dark`, or `system`. |
+| `--browser <path>` | Render with a specific Chromium binary instead of auto-discovering one. |
+| `--no-open` | Do not open the exported file. |
+
+Export needs a Chromium. It uses a system Chrome or Edge if present, then a `playwright`-installed
+Chromium; if none is found it tells you to run `npx playwright install chromium`.
+
 ## components
 
 ```bash

--- a/packages/cli/AGENTS.md
+++ b/packages/cli/AGENTS.md
@@ -7,7 +7,7 @@ programmatic Node API at `dist/api.js` (the package's `import` entry, `exports["
 ## Structure
 
 - `src/index.ts` — commander dispatch (the `bin`). `src/commands/` — one file per command (render,
-  check, components, config, share). `config` is a parent command: bare `config` shows the settings
+  check, components, config, share, export). `config` is a parent command: bare `config` shows the settings
   + path, `config get <key>` / `config set <key> <value>` / `config path` are subcommands. Invalid
   key/value throws, which the top-level catch turns into a stderr message + exit 1.
 - `src/commands/input.ts` — `readPlanSource(file?)`, the shared input layer for `render` and
@@ -16,6 +16,25 @@ programmatic Node API at `dist/api.js` (the package's `import` entry, `exports["
   interactive terminal throws rather than hang. `render` routes stdin output to stdout by default,
   and `--stdout`/`--out`/`--watch`/`--review` have mutual-exclusion guards (watch needs a real file
   to re-read; review is a server, not a file output).
+- `src/commands/export.ts` + `src/build/capture.ts` — `vplan export <pdf|jpg> [file]`. `export.ts`
+  validates with `checkSource` (same gate as render), resolves the out path (`<stem>.pdf`/`.jpg`
+  beside the input, or `--out`; stdin requires `--out`), builds via `buildHtml` with
+  `{ theme, lockTheme: true, enableSharing: false }` (a static artifact: fixed scheme, no share
+  payload), and hands the HTML to `capture.ts`. `capture.ts` writes the HTML to a temp file, loads it
+  as `file://`, injects `COMMON_EXPORT_CSS` (hides the cog/share/expand chrome) plus, for PDF only,
+  `PDF_EXPORT_CSS` (removes the Questions blue glow, which prints as a muddy box). It then waits for
+  recharts charts to paint (`waitForChartsSettled`: a `ResponsiveContainer` emits no SVG until
+  measured, so a `networkidle` capture can catch a blank chart), then `page.pdf` (A4, `printBackground`,
+  0.5in top/bottom margin so content clears the sheet edge across breaks, 0 left/right so the column is
+  not squeezed) or `page.screenshot` clipped to the `.vp-shell` column (NOT `fullPage`, which captures
+  the wide empty margins beside the centered column), deviceScaleFactor 2 for a crisp hi-dpi JPG.
+  **No `break-inside: avoid`**: with pagination a figure forced whole that exceeds a page gets clipped
+  by Chromium (content lost), worse than an occasional split (content kept). Browser
+  discovery is system-first: `--browser`/`VPLAN_CHROMIUM` override, then a Chrome/Edge `channel`, then
+  a `playwright`-installed Chromium in the per-OS cache (same resolution as the review e2e test), else
+  an error naming `npx playwright install chromium`. **`playwright-core` is a prod dependency** for
+  this path (it ships no browser binary, so the install stays small). The capture e2e in
+  `tests/export.test.ts` is `skipIf`-gated on a locally installed Chromium, like the review e2e.
 - `src/review/` — interactive review mode (`--review`). `session.ts` `runReview` serves the plan via
   `startReviewServer`, opens it, and races `server.feedback` against `--timeout` (`ms`-parsed); it
   prints the feedback to **stdout** (the agent reads it) and status to **stderr**, sets the exit code

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -67,6 +67,7 @@
     "material-icon-theme": "^5.35.0",
     "ms": "^2.1.3",
     "open": "^11.0.0",
+    "playwright-core": "^1.61.0",
     "react": "^19.2.7",
     "react-dom": "^19.2.7",
     "recharts": "^3.8.1",
@@ -88,7 +89,6 @@
     "@types/ms": "^2.1.0",
     "@visualplan/compile": "workspace:*",
     "@visualplan/core": "workspace:*",
-    "@visualplan/runtime": "workspace:*",
-    "playwright-core": "^1.61.0"
+    "@visualplan/runtime": "workspace:*"
   }
 }

--- a/packages/cli/src/build/capture.ts
+++ b/packages/cli/src/build/capture.ts
@@ -1,0 +1,183 @@
+import { existsSync, readdirSync } from 'node:fs'
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { homedir, tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { pathToFileURL } from 'node:url'
+import { type Browser, chromium, type Page } from 'playwright-core'
+
+/** The two formats `vplan export` produces. `jpg` captures a full-page screenshot, `pdf` prints. */
+export type ExportFormat = 'pdf' | 'jpg'
+
+/** JPEG quality for a `jpg` export (0-100). High enough to keep diagrams/text crisp, low enough to
+ * keep the file reasonable. */
+const JPEG_QUALITY = 90
+
+/** Max wait (ms) for client-rendered charts to paint before capturing; on timeout we capture
+ * whatever rendered rather than fail, so a chart selector drift degrades to a possibly-blank chart
+ * instead of a hard error. */
+const CHART_SETTLE_TIMEOUT_MS = 5000
+
+/**
+ * Styles applied to every export. Hides interactive chrome that has no meaning in a static artifact:
+ * the theme cog, the share button, and the diagram/chart expand buttons.
+ */
+const COMMON_EXPORT_CSS = `
+.vp-theme, .vp-share, .vp-expand-btn { display: none !important; }
+`
+
+/**
+ * PDF-only styles. `break-inside: avoid` keeps every self-contained block whole rather than split
+ * across a page break (a chart, diagram, or card sliced by the page edge reads as broken). It is
+ * applied to all block components EXCEPT `.vp-phase`: a phase is the one container that can be taller
+ * than a page, where forcing it whole makes Chromium clip the overflow (content lost), so a phase
+ * must flow and break between its children. The individual blocks inside it are each kept whole. A
+ * single block taller than a page (a huge diagram) is the rare exception that would still clip; the
+ * skill steers authors away from those. The Questions card's blue glow (a `box-shadow`) prints as a
+ * muddy box, so it is removed for print only (the JPG keeps it).
+ */
+const PDF_EXPORT_CSS = `
+.vp-compare, .vp-stat, .vp-chart, .vp-mermaid, .vp-math, .vp-callout,
+.vp-matrix-wrap, .vp-questions, .vp-checklist, .vp-filetree { break-inside: avoid; }
+.vp-questions { box-shadow: none !important; }
+`
+
+/**
+ * Find a Playwright-managed Chromium binary in the standard per-OS browsers cache, full builds and
+ * the headless shell alike. Mirrors the resolution the review e2e test uses; returns an explicit
+ * path so a browser-build version skew with `playwright-core` does not block the launch. Null when
+ * none is installed (the caller then guides the user to install one).
+ */
+function findInstalledChromium(): string | null {
+  const root =
+    process.env.PLAYWRIGHT_BROWSERS_PATH ||
+    (process.platform === 'darwin'
+      ? join(homedir(), 'Library/Caches/ms-playwright')
+      : process.platform === 'win32'
+        ? join(homedir(), 'AppData/Local/ms-playwright')
+        : join(homedir(), '.cache/ms-playwright'))
+  if (!existsSync(root)) return null
+  const dirs = readdirSync(root).filter(
+    d => d.startsWith('chromium-') || d.startsWith('chromium_headless_shell-'),
+  )
+  for (const dir of dirs) {
+    const candidates = [
+      join(root, dir, 'chrome-mac', 'Chromium.app/Contents/MacOS/Chromium'),
+      join(root, dir, 'chrome-mac-arm64', 'Chromium.app/Contents/MacOS/Chromium'),
+      join(root, dir, 'chrome-linux', 'chrome'),
+      join(root, dir, 'chrome-win', 'chrome.exe'),
+      join(root, dir, 'chrome-headless-shell-mac-arm64', 'chrome-headless-shell'),
+      join(root, dir, 'chrome-headless-shell-mac-x64', 'chrome-headless-shell'),
+      join(root, dir, 'chrome-headless-shell-linux', 'chrome-headless-shell'),
+      join(root, dir, 'chrome-headless-shell-win', 'chrome-headless-shell.exe'),
+    ]
+    const found = candidates.find(existsSync)
+    if (found) return found
+  }
+  return null
+}
+
+/**
+ * Launch a headless Chromium, system-first: an explicit override (the `--browser` flag or
+ * `VPLAN_CHROMIUM`) wins, then a system Chrome/Edge install (Playwright resolves the per-OS path
+ * from the channel), then a Playwright-managed Chromium in the cache. Throws an actionable error
+ * naming `npx playwright install chromium` when nothing resolves, so a missing browser never fails
+ * cryptically.
+ */
+async function launchBrowser(override?: string): Promise<Browser> {
+  const explicit = override ?? process.env.VPLAN_CHROMIUM
+  if (explicit) return chromium.launch({ executablePath: explicit })
+
+  for (const channel of ['chrome', 'msedge'] as const) {
+    try {
+      return await chromium.launch({ channel })
+    } catch {
+      // No such system browser; fall through to the next channel, then the managed cache.
+    }
+  }
+
+  const installed = findInstalledChromium()
+  if (installed) return chromium.launch({ executablePath: installed })
+
+  throw new Error(
+    'No Chromium found to export with. Install one with:\n  npx playwright install chromium\n' +
+      'or point vplan at an existing Chrome/Chromium binary via --browser <path> or VPLAN_CHROMIUM.',
+  )
+}
+
+/**
+ * Wait for recharts charts to paint. A `ResponsiveContainer` emits no SVG until it has measured its
+ * width, so a capture taken at `networkidle` can catch a blank chart; we wait until every `.vp-chart`
+ * holds a `recharts-surface`. Animations are already disabled in the runtime, so once the surface
+ * exists the chart is final. No-op when the plan has no charts. Best-effort: a timeout captures
+ * whatever rendered rather than failing the export.
+ */
+async function waitForChartsSettled(page: Page): Promise<void> {
+  // String predicates run in the page; the CLI tsconfig has no DOM lib, so a function body
+  // referencing `document` would not type-check, and adding DOM here would wrongly expose browser
+  // globals to the rest of the Node CLI.
+  const hasCharts = await page.evaluate("document.querySelector('.vp-chart') !== null")
+  if (!hasCharts) return
+  await page
+    .waitForFunction(
+      "Array.from(document.querySelectorAll('.vp-chart')).every(c => c.querySelector('svg.recharts-surface'))",
+      undefined,
+      { timeout: CHART_SETTLE_TIMEOUT_MS },
+    )
+    .catch(() => {})
+}
+
+/**
+ * Render a self-contained plan HTML string to a PDF or JPG at `outPath`. Writes the HTML to a temp
+ * file and loads it as `file://` so every inlined asset resolves exactly as a real open does, waits
+ * for client-rendered charts, then prints (PDF, paginated, backgrounds on) or screenshots (JPG, full
+ * page, hi-dpi). `browserOverride` forces a specific Chromium binary.
+ */
+export async function captureToFile(
+  html: string,
+  format: ExportFormat,
+  outPath: string,
+  browserOverride?: string,
+): Promise<void> {
+  const dir = await mkdtemp(join(tmpdir(), 'visualplan-export-'))
+  const htmlPath = join(dir, 'plan.html')
+  await writeFile(htmlPath, html)
+
+  const browser = await launchBrowser(browserOverride)
+  try {
+    // For PDF, load at the A4 portrait content width (210mm = 794px at 96dpi) so recharts sizes each
+    // chart to the printed page from the first render. Loading at the default wide viewport and then
+    // printing at A4 reflows the column narrower, but a chart's SVG does not reliably re-measure in
+    // that window, so it stays wider than the page and the right edge (end point, last axis label)
+    // clips. JPG keeps a wide viewport so the centered column reaches its 860px max-width before the
+    // `.vp-shell` clip. deviceScaleFactor renders the JPG at 2x (ignored by page.pdf).
+    const viewport = format === 'pdf' ? { width: 794, height: 1123 } : { width: 1280, height: 1024 }
+    const page = await browser.newPage({ viewport, deviceScaleFactor: 2 })
+    await page.goto(pathToFileURL(htmlPath).href, { waitUntil: 'networkidle' })
+    await page.addStyleTag({ content: COMMON_EXPORT_CSS })
+    if (format === 'pdf') await page.addStyleTag({ content: PDF_EXPORT_CSS })
+    await waitForChartsSettled(page)
+
+    if (format === 'pdf') {
+      // Top/bottom margins keep content off the sheet edges across page breaks (without them, content
+      // butts the top of each new page). Left/right stay 0 so the plan column is not squeezed; its
+      // own layout padding is the side gutter.
+      const pdf = await page.pdf({
+        format: 'A4',
+        printBackground: true,
+        margin: { top: '0.5in', right: '0', bottom: '0.5in', left: '0' },
+      })
+      await writeFile(outPath, pdf)
+    } else {
+      // Clip to the plan column, not the full viewport: a fullPage shot captures the wide empty
+      // margins on either side of the centered, max-width column. The shell's own padding is the
+      // gutter, so the JPG is the plan with no surrounding whitespace.
+      const jpg = await page
+        .locator('.vp-shell')
+        .screenshot({ type: 'jpeg', quality: JPEG_QUALITY })
+      await writeFile(outPath, jpg)
+    }
+  } finally {
+    await browser.close()
+    await rm(dir, { recursive: true, force: true })
+  }
+}

--- a/packages/cli/src/commands/export.ts
+++ b/packages/cli/src/commands/export.ts
@@ -1,0 +1,77 @@
+import { basename, dirname, extname, join, resolve } from 'node:path'
+import { InvalidArgumentError } from 'commander'
+import open from 'open'
+import { captureToFile, type ExportFormat } from '../build/capture.js'
+import { checkSource } from '../build/check.js'
+import { buildHtml } from '../build/compile.js'
+import { readConfig, type Theme, THEMES } from '../config.js'
+import { printIssues } from './check.js'
+import { readPlanSource } from './input.js'
+
+export interface ExportOptions {
+  /** Output path; defaults to `<file>.<pdf|jpg>` beside the input. Required for stdin input. */
+  out?: string
+  /** Override the config theme baked into the export (`light` | `dark` | `system`). */
+  theme?: Theme
+  /** Open the exported file when done. `--no-open` sets this false. Default true. */
+  open?: boolean
+  /** Explicit Chromium binary to render with (overrides discovery and `VPLAN_CHROMIUM`). */
+  browser?: string
+}
+
+/** Validate the `<format>` positional as `pdf` or `jpg` (accepting `jpeg` as an alias of `jpg`).
+ * Commander renders the thrown `InvalidArgumentError` as a usage error listing the valid values. */
+export function parseExportFormat(value: string): ExportFormat {
+  const normalized = value.toLowerCase()
+  if (normalized === 'pdf') return 'pdf'
+  if (normalized === 'jpg' || normalized === 'jpeg') return 'jpg'
+  throw new InvalidArgumentError('format must be pdf or jpg')
+}
+
+/** Validate the `--theme` value against the known themes. */
+export function parseTheme(value: string): Theme {
+  if ((THEMES as readonly string[]).includes(value)) return value as Theme
+  throw new InvalidArgumentError(`theme must be one of: ${THEMES.join(', ')}`)
+}
+
+/** Default export path: the input file's stem with the format extension, beside the input. Plain
+ * `plan.pdf` / `plan.jpg` (not `.plan.pdf`), per the approved plan. */
+export function defaultExportPath(absMdx: string, format: ExportFormat): string {
+  const stem = basename(absMdx, extname(absMdx))
+  return join(dirname(absMdx), `${stem}.${format}`)
+}
+
+/**
+ * `vplan export <pdf|jpg> [file]` — validate the plan, build the self-contained page, then render it
+ * to a PDF or JPG via a headless Chromium. Input is a file, `-`, or piped stdin (stdin needs
+ * `--out`, having no path to derive a default from). The theme is the config default unless
+ * `--theme` overrides it; the export bakes a locked theme and no share button (a static artifact).
+ */
+export async function runExport(
+  format: ExportFormat,
+  file: string | undefined,
+  options: ExportOptions,
+): Promise<void> {
+  const { source, label, fromStdin } = await readPlanSource(file)
+
+  const issues = await checkSource(source)
+  if (issues.length > 0) {
+    printIssues(label, issues)
+    process.exitCode = 1
+    return
+  }
+
+  if (fromStdin && !options.out) {
+    throw new Error('Reading a plan from stdin needs --out to know where to write the export.')
+  }
+  const out = options.out
+    ? resolve(options.out)
+    : defaultExportPath(resolve(file as string), format)
+
+  const theme = options.theme ?? (await readConfig()).theme
+  const html = await buildHtml(source, { theme, lockTheme: true, enableSharing: false })
+  await captureToFile(html, format, out, options.browser)
+
+  process.stdout.write(`Exported ${out}\n`)
+  if (options.open !== false) await open(out)
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -4,6 +4,8 @@ import { DEFAULT_DEV_PORT } from './build/compile.js'
 import { runCheck } from './commands/check.js'
 import { runComponents } from './commands/components.js'
 import { runConfigGet, runConfigPath, runConfigSet, runConfigShow } from './commands/config.js'
+import { type ExportOptions, parseExportFormat, parseTheme, runExport } from './commands/export.js'
+import type { ExportFormat } from './build/capture.js'
 import {
   DEFAULT_REVIEW_TIMEOUT_MS,
   parseIteration,
@@ -45,6 +47,19 @@ program
   .option('--no-diff', 'skip iteration diffing (do not read or write the snapshot cache)')
   .option('--no-open', 'do not open the result in a browser')
   .action((file: string | undefined, options: RenderOptions) => runRender(file, options))
+
+program
+  .command('export')
+  .description('Render a plan to a PDF or JPG (headless via Chromium)')
+  .argument('<format>', 'pdf or jpg', parseExportFormat)
+  .argument('[file]', 'the plan .mdx file; - or omit to read from stdin')
+  .option('--out <path>', 'output path (defaults to <file>.<pdf|jpg>; required for stdin)')
+  .option('--theme <theme>', 'override the baked theme: light | dark | system', parseTheme)
+  .option('--browser <path>', 'Chromium binary to render with (else auto-discovered)')
+  .option('--no-open', 'do not open the exported file')
+  .action((format: ExportFormat, file: string | undefined, options: ExportOptions) =>
+    runExport(format, file, options),
+  )
 
 program
   .command('share')

--- a/packages/cli/tests/export.test.ts
+++ b/packages/cli/tests/export.test.ts
@@ -1,0 +1,109 @@
+// @vitest-environment node
+import { existsSync, readdirSync } from 'node:fs'
+import { readFile, rm } from 'node:fs/promises'
+import { homedir, tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { InvalidArgumentError } from 'commander'
+import { describe, expect, it } from 'vitest'
+import { captureToFile } from '../src/build/capture.js'
+import { buildHtml } from '../src/build/compile.js'
+import { defaultExportPath, parseExportFormat, parseTheme } from '../src/commands/export.js'
+
+describe('parseExportFormat', () => {
+  it('accepts pdf and jpg (golden)', () => {
+    expect(parseExportFormat('pdf')).toBe('pdf')
+    expect(parseExportFormat('jpg')).toBe('jpg')
+  })
+
+  it('treats jpeg and mixed case as jpg (edge)', () => {
+    expect(parseExportFormat('JPEG')).toBe('jpg')
+    expect(parseExportFormat('Pdf')).toBe('pdf')
+  })
+
+  it('rejects an unknown format (error)', () => {
+    expect(() => parseExportFormat('png')).toThrow(InvalidArgumentError)
+  })
+})
+
+describe('parseTheme', () => {
+  it('accepts a known theme (golden)', () => {
+    expect(parseTheme('dark')).toBe('dark')
+  })
+
+  it('rejects an unknown theme (error)', () => {
+    expect(() => parseTheme('sepia')).toThrow(InvalidArgumentError)
+  })
+})
+
+describe('defaultExportPath', () => {
+  it('uses the stem with the format extension beside the input (golden)', () => {
+    expect(defaultExportPath('/a/b/plan.mdx', 'pdf')).toBe(join('/a/b', 'plan.pdf'))
+    expect(defaultExportPath('/a/b/plan.mdx', 'jpg')).toBe(join('/a/b', 'plan.jpg'))
+  })
+
+  it('handles a name with no extension (edge)', () => {
+    expect(defaultExportPath('/a/b/plan', 'pdf')).toBe(join('/a/b', 'plan.pdf'))
+  })
+})
+
+/** Find an installed Playwright Chromium so the capture e2e can run; null skips it (e.g. CI without
+ * a browser), mirroring the review tab-close e2e. */
+function findChromium(): string | null {
+  const root =
+    process.env.PLAYWRIGHT_BROWSERS_PATH ||
+    (process.platform === 'darwin'
+      ? join(homedir(), 'Library/Caches/ms-playwright')
+      : process.platform === 'win32'
+        ? join(homedir(), 'AppData/Local/ms-playwright')
+        : join(homedir(), '.cache/ms-playwright'))
+  if (!existsSync(root)) return null
+  const dirs = readdirSync(root).filter(
+    d => d.startsWith('chromium-') || d.startsWith('chromium_headless_shell-'),
+  )
+  for (const dir of dirs) {
+    const found = [
+      join(root, dir, 'chrome-mac-arm64', 'Chromium.app/Contents/MacOS/Chromium'),
+      join(root, dir, 'chrome-mac', 'Chromium.app/Contents/MacOS/Chromium'),
+      join(root, dir, 'chrome-linux', 'chrome'),
+      join(root, dir, 'chrome-win', 'chrome.exe'),
+      join(root, dir, 'chrome-headless-shell-mac-arm64', 'chrome-headless-shell'),
+      join(root, dir, 'chrome-headless-shell-mac-x64', 'chrome-headless-shell'),
+      join(root, dir, 'chrome-headless-shell-linux', 'chrome-headless-shell'),
+      join(root, dir, 'chrome-headless-shell-win', 'chrome-headless-shell.exe'),
+    ].find(existsSync)
+    if (found) return found
+  }
+  return null
+}
+
+const browserPath = findChromium()
+const PLAN = '# Export e2e\n\n<Phase title="Only phase">\n- a step\n</Phase>\n'
+
+describe.skipIf(!browserPath)('captureToFile (e2e, needs a browser)', () => {
+  it('writes a non-empty PDF with a %PDF- header (golden)', async () => {
+    const html = await buildHtml(PLAN, { theme: 'light' })
+    const out = join(tmpdir(), `vplan-export-test-${process.pid}.pdf`)
+    try {
+      await captureToFile(html, 'pdf', out, browserPath as string)
+      const bytes = await readFile(out)
+      expect(bytes.length).toBeGreaterThan(0)
+      expect(bytes.subarray(0, 5).toString('latin1')).toBe('%PDF-')
+    } finally {
+      await rm(out, { force: true })
+    }
+  }, 60_000)
+
+  it('writes a JPEG with the SOI marker (golden)', async () => {
+    const html = await buildHtml(PLAN, { theme: 'light' })
+    const out = join(tmpdir(), `vplan-export-test-${process.pid}.jpg`)
+    try {
+      await captureToFile(html, 'jpg', out, browserPath as string)
+      const bytes = await readFile(out)
+      expect(bytes.length).toBeGreaterThan(0)
+      expect(bytes[0]).toBe(0xff)
+      expect(bytes[1]).toBe(0xd8)
+    } finally {
+      await rm(out, { force: true })
+    }
+  }, 60_000)
+})

--- a/packages/runtime/components/review/SectionComments.tsx
+++ b/packages/runtime/components/review/SectionComments.tsx
@@ -86,11 +86,19 @@ export function sectionBand(
 }
 
 /** The rect wrapping a section's actual content (anchor top to its last owned element's bottom), so
- * the highlight hugs the content instead of the empty space running up to the next section. */
+ * the highlight hugs the content instead of the empty space running up to the next section. A
+ * `<Phase>` box ends with a large structural `padding-bottom` (the gap down to the next step), so the
+ * band would overshoot into that gap; trim it back. Only phases get this trim: on a card (callout,
+ * questions) the bottom padding is the card's own inner inset, and trimming it would pull the band up
+ * across the card and clip it. */
 export function sectionContent(section: Section): { top: number; bottom: number } {
+  const last = section.lastElement
+  const structuralPad = last.classList.contains('vp-phase')
+    ? Number.parseFloat(getComputedStyle(last).paddingBottom) || 0
+    : 0
   return {
     top: section.element.getBoundingClientRect().top,
-    bottom: section.lastElement.getBoundingClientRect().bottom,
+    bottom: last.getBoundingClientRect().bottom - structuralPad,
   }
 }
 

--- a/packages/runtime/components/review/review.css
+++ b/packages/runtime/components/review/review.css
@@ -37,6 +37,10 @@
    tint band (positioned edge to edge inline), faded in so moving between sections does not pop. */
 .vp-review-highlight {
   position: fixed;
+  /* Above the plan content so the faint tint frames the whole hovered section (cards included). The
+     one element that must NOT be dimmed by it, the phase number node, is lifted above this band
+     instead (see `.vp-phase__node` in theme.css), which keeps the number crisp without pushing the
+     band under opaque cards. */
   z-index: 54;
   pointer-events: none;
   border-radius: 10px;

--- a/packages/runtime/tests/section-comments.test.ts
+++ b/packages/runtime/tests/section-comments.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it } from 'vitest'
-import { collectSections } from '../components/review/SectionComments.js'
+import { collectSections, sectionContent } from '../components/review/SectionComments.js'
 
 afterEach(() => {
   document.body.innerHTML = ''
@@ -8,6 +8,12 @@ afterEach(() => {
 /** Build a `.vp-main` from a list of child element HTML strings, as the rendered plan would have. */
 function setMain(...children: string[]): void {
   document.body.innerHTML = `<main class="vp-main">${children.join('')}</main>`
+}
+
+/** jsdom does no layout, so stub the box an element reports for the content-rect math. */
+function stubRect(el: Element, top: number, bottom: number): void {
+  el.getBoundingClientRect = () =>
+    ({ top, bottom, left: 0, right: 0, width: 0, height: bottom - top, x: 0, y: top }) as DOMRect
 }
 
 describe('collectSections', () => {
@@ -75,6 +81,40 @@ describe('collectSections', () => {
       'stat',
       'questions',
     ])
+  })
+})
+
+describe('sectionContent', () => {
+  it('trims a phase last-element bottom padding so the band hugs content, not the gap (golden)', () => {
+    setMain(
+      '<div class="vp-phase" style="padding-bottom: 30px"><div class="vp-phase__title">Build</div></div>',
+    )
+    const [section] = collectSections()
+    if (!section) throw new Error('expected a section')
+    // Single phase: element === lastElement; its 130px-tall box ends 30px past the real content.
+    stubRect(section.element, 100, 230)
+    expect(sectionContent(section)).toEqual({ top: 100, bottom: 200 })
+  })
+
+  it('leaves a section whose last element has no bottom padding unchanged (edge)', () => {
+    setMain('<h2>Heading</h2>', '<p>body</p>')
+    const [section] = collectSections()
+    if (!section) throw new Error('expected a section')
+    stubRect(section.element, 10, 20)
+    stubRect(section.lastElement, 25, 60)
+    expect(sectionContent(section).bottom).toBe(60)
+  })
+
+  it('does NOT trim a card section: its bottom padding is inner inset, not a structural gap (edge)', () => {
+    // A callout's padding-bottom is the card's own content inset; trimming it would pull the band up
+    // across the card and clip it, so the band must reach the card's full box bottom.
+    setMain(
+      '<aside class="vp-callout" style="padding-bottom: 24px"><div class="vp-callout__label">Note</div></aside>',
+    )
+    const [section] = collectSections()
+    if (!section) throw new Error('expected a section')
+    stubRect(section.element, 50, 174)
+    expect(sectionContent(section).bottom).toBe(174)
   })
 })
 

--- a/packages/runtime/theme.css
+++ b/packages/runtime/theme.css
@@ -295,7 +295,9 @@ body {
 
 .vp-phase__node {
   position: relative;
-  z-index: 1;
+  /* Sits above the review-mode hover band (`.vp-review-highlight`, z-index 54) so the number is
+     never dimmed by its tint; harmless in a normal render where nothing else is near the rail. */
+  z-index: 55;
   flex: 0 0 auto;
   width: 34px;
   height: 34px;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -141,6 +141,9 @@ importers:
       open:
         specifier: ^11.0.0
         version: 11.0.0
+      playwright-core:
+        specifier: ^1.61.0
+        version: 1.61.0
       react:
         specifier: ^19.2.7
         version: 19.2.7
@@ -202,9 +205,6 @@ importers:
       '@visualplan/runtime':
         specifier: workspace:*
         version: link:../runtime
-      playwright-core:
-        specifier: ^1.61.0
-        version: 1.61.0
 
   packages/compile:
     dependencies:

--- a/skills/visual-plan/SKILL.md
+++ b/skills/visual-plan/SKILL.md
@@ -59,6 +59,13 @@ and tables, with prose only connecting the visuals, not carrying the plan itself
    back-and-forth chat, and the loop ends in an explicit Approve so you know when it is settled. Fall
    back to a plain render (or `--watch`) only when the user just wants to look at the plan, not shape
    or decide on it.
+5. **To export a plan as a static file**, run `vplan export <pdf|jpg> <file>.mdx`. It builds the
+   same self-contained page and captures it headless: `pdf` prints a paginated A4 document, `jpg` a
+   full-page hi-dpi screenshot. Output defaults to `<file>.pdf` / `<file>.jpg` (override with
+   `--out`); `--theme` overrides the baked color scheme, `--no-open` suppresses opening the result.
+   This needs a Chromium: it uses a system Chrome/Edge or a `playwright`-installed one, and otherwise
+   prints `npx playwright install chromium`. Use this when the user wants a shareable file rather than
+   the interactive HTML page.
 
 Run `vplan components` anytime for the exact prop signatures.
 


### PR DESCRIPTION
## What

Adds a `vplan export <pdf|jpg> [file]` command that renders a plan to a static, shareable file. Also fixes a review-mode bug where the section hover band clipped cards.

## How

- Export builds the same self-contained page via `buildHtml`, then renders it headless with `playwright-core` (a new prod dep that ships no browser binary). Chromium is sourced system-first (Chrome/Edge channel, then a `playwright`-installed one), with an actionable `npx playwright install chromium` error when none is found.
- PDF paginates to A4 and keeps each block whole (`break-inside: avoid` on every block except `.vp-phase`, which must flow since it can exceed a page); the page loads at the A4 content width so recharts sizes charts to the printed page and they do not clip off the right edge. JPG clips to the `.vp-shell` column at 2x.
- Review fix: the hover band trimmed the last element's bottom padding to hug a phase's content, but on a card that padding is the inner inset, so the band cut across it. The trim is now scoped to phases, the phase number is lifted above the band, and the band keeps its fill.

## Verification

Ran the full checklist plus manual export inspection. Exported a plan exercising every component and all 9 chart types (8-page PDF) and pixel-inspected each page: all blocks render whole and in-bounds, no clipping. Review hover fix verified live with Playwright (band fully contains the card, measured).

- [x] `pnpm lint` passes (7 pre-existing CSS-specificity warnings, no errors)
- [x] `pnpm format` reports no changes (`biome format .`)
- [x] `pnpm typecheck` passes
- [x] `pnpm build` succeeds
- [x] `pnpm test` passes (358 tests)