### PR TITLE
docs: cover recent features, add Review mode demo and example plans

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,10 +39,14 @@ npx vplan plan.mdx
 ## Usage
 
 ```bash
-vplan plan.mdx           # render to plan.plan.html and open it
-vplan plan.mdx --watch   # live-reloading dev server while you edit
-vplan check plan.mdx     # validate a plan without rendering it
-vplan components         # print the component vocabulary
+vplan plan.mdx              # render to plan.plan.html and open it
+vplan plan.mdx --watch      # live-reloading dev server while you edit
+vplan plan.mdx --review     # interactive review session, blocks for sign-off
+vplan check plan.mdx        # validate a plan (syntax + quality lint) without rendering
+vplan export pdf plan.mdx   # render to a static PDF or JPG via headless Chromium
+vplan share plan.mdx        # print a shareable visualplan.dev link
+vplan components            # print the component vocabulary
+vplan config                # view or change persistent settings (default theme)
 ```
 
 A plan is an MDX file that starts with a `# Title` (no frontmatter) and uses a fixed set of
@@ -89,7 +93,8 @@ flowchart LR
 Every rendered plan has a share button that copies a link encoding the entire plan. The plan
 is base64url encoded into a query param where it is securely decompressed into a sandboxed iframe
 in the browser at [visualplan.dev](https://visualplan.dev). This means you can share a plan with
-anyone simply by sharing the URL, without having to send files or make any kind of account.
+anyone simply by sharing the URL, without having to send files or make any kind of account. Run
+`vplan share plan.mdx` to print the same link from the CLI without rendering first.
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -88,6 +88,23 @@ flowchart LR
  - `Checklist`
  - syntax-highlighted code blocks with file titles
 
+## Review mode
+
+To get a decision on a plan, not just show it, render with `--review`:
+
+```bash
+vplan render --review plan.mdx
+```
+
+This opens the plan as an interactive session: the reviewer comments on any section, answers the
+plan's open `Questions` inline, and clicks Approve, Deny, or Iterate. The CLI blocks until they
+decide, prints the feedback to stdout, and exits with a decision-specific code (Approve `0`, Deny
+`1`, Iterate `2`), so an agent knows when the plan is settled and what to revise if it is not. On an
+Iterate, the next render diffs the revision against the last view so the reviewer re-reviews only the
+delta.
+
+See the [Review mode guide](https://visualplan.dev/docs/review/) for a live, interactive demo.
+
 ## Share a plan
 
 Every rendered plan has a share button that copies a link encoding the entire plan. The plan

--- a/packages/app/AGENTS.md
+++ b/packages/app/AGENTS.md
@@ -19,7 +19,14 @@ package that is a web app rather than part of the CLI's render pipeline.
 - `src/nav.ts` — `docLinks`, the single source of truth for the docs sidebar order.
 - `src/pages/index.astro` — the landing page (custom hero + feature grid, uses `Base` directly).
 - `src/pages/docs/*` — the docs content: `index.md`, `install.md`, `cli.md`, `programmatic.md` (the
-  `vplan` Node API), and `authoring.mdx` (MDX, because it embeds live component demos).
+  `vplan` Node API), `authoring.mdx` (MDX, because it embeds live component demos), and `review.mdx`
+  (the Review-mode page, which embeds the interactive review demo).
+- `src/pages/review-demo-frame.astro` + `src/components/ReviewDemo.tsx` — the interactive review-mode
+  demo. `ReviewDemo` mounts the **real** runtime `ReviewLayer` over a dummy plan with
+  `__VP_REVIEW__` + `__VP_REVIEW_DEMO__` set, so it behaves exactly like `vplan render --review` but
+  with no CLI server (see the runtime AGENTS.md demo-mode note). It lives in its own page because the
+  review chrome is viewport-`fixed`; `ReviewDemoEmbed.astro` iframes that page into `review.mdx` so the
+  fixed chrome stays contained, and its Reset button reloads the frame to clear all review state.
 - `src/components/Demo.astro` — wraps a live runtime component as a "Renders to" stage (see below).
 - `src/nav.ts` — `docLinks` (the Guide sidebar group) and `exampleLinks` (the Examples group, which
   links straight to the rendered example HTML in a new tab).
@@ -134,6 +141,11 @@ links to these HTML files.
 - **No `!important` for the Shiki dark-mode swap.** `defaultColor: false` makes Shiki emit only
   `--shiki-light`/`--shiki-dark` CSS vars with no resolved inline color, so `global.css` drives token
   color from those vars and the cascade wins cleanly. Do not reintroduce `!important`.
+- **`vite.resolve.dedupe: ['react', 'react-dom']` in `astro.config.mjs` is load-bearing.** The runtime
+  is a workspace package consumed as source, so the dev server otherwise resolves a second React copy
+  for its deep-imported components and an island that mounts many at once (the review demo) dies with
+  an "invalid hook call" / `useState` of null. The production build dedupes via Rollup regardless;
+  this only fixes dev. Do not remove it.
 - `typecheck` is `astro check` (joins the repo's `pnpm -r typecheck`). `build` is `astro build` to
   `dist/` (git-ignored). `dev`/`preview` run the local server.
 - No emojis or em/en dashes in content or code.

--- a/packages/app/astro.config.mjs
+++ b/packages/app/astro.config.mjs
@@ -43,7 +43,14 @@ export default defineConfig({
   // react() renders the @visualplan/runtime plan components (Chart hydrates as an island);
   // mdx() lets the authoring page mix prose, code samples, and live component demos.
   integrations: [react(), mdx()],
-  vite: { plugins: [materialIconClones()] },
+  vite: {
+    plugins: [materialIconClones()],
+    // `@visualplan/runtime` is a workspace package consumed as source, so without this the dev
+    // server can resolve a second React copy for its deep-imported components (the interactive
+    // review demo mounts many at once), triggering an "invalid hook call" / `useState` of null.
+    // The production build already dedupes via Rollup; this makes dev match it.
+    resolve: { dedupe: ['react', 'react-dom'] },
+  },
   markdown: {
     // Dual-theme Shiki to match the rendered-plan highlighting (github light/dark).
     // `defaultColor: false` emits only `--shiki-light` / `--shiki-dark` CSS vars

--- a/packages/app/examples/add-sso-auth.mdx
+++ b/packages/app/examples/add-sso-auth.mdx
@@ -1,0 +1,141 @@
+# Add SSO with OAuth2 and OIDC
+
+Enterprise prospects keep asking for single sign-on, and our password-only login is the
+last blocker on three deals. We will add OAuth2 authorization-code with PKCE and OIDC, so
+users authenticate at their own identity provider and we never touch their credentials.
+Existing password users keep working and link to an IdP on their next login.
+
+```mermaid
+sequenceDiagram
+  participant B as Browser
+  participant A as App (api.acme.com)
+  participant I as IdP (login page)
+  participant T as Token endpoint
+  B->>A: GET /auth/login
+  A->>B: 302 to IdP (code_challenge, state)
+  B->>I: Authenticate + consent
+  I->>B: 302 /auth/callback?code&state
+  B->>A: GET /auth/callback?code&state
+  A->>T: POST code + code_verifier
+  T->>A: id_token + access_token
+  A->>B: Set-Cookie session, 302 /app
+```
+
+<Stat>
+- Providers at launch: 3 (good) -- one OIDC adapter covers all
+- Est. integration: 9 days (note) -- one engineer, end to end
+- Password users to migrate: 14,200 (warn) -- linked lazily on next login
+- New stored secrets: 0 (good) -- IdP holds the credentials
+</Stat>
+
+<Phase title="Pick the identity providers" status="done">
+Score the candidates we can ship a single OIDC adapter against. We need OIDC discovery,
+PKCE, and a hosted login page so we own no credential UI.
+
+<Matrix>
+| Criterion      | Auth0 (pick) | Okta   | Cognito | Keycloak |
+|----------------|--------------|--------|---------|----------|
+| OIDC discovery | yes          | yes    | partial | yes      |
+| PKCE support   | native       | native | native  | native   |
+| Setup effort   | low          | medium | medium  | high     |
+| Ops burden     | none         | none   | low     | self-run |
+| Price at scale | high         | high   | low     | infra    |
+</Matrix>
+
+<Callout type="decision">
+Ship Auth0 first for the fastest enterprise onboarding, then add Cognito for cost-sensitive
+tiers. All three are OIDC compliant, so the adapter stays provider-agnostic and Keycloak
+remains a drop-in option for on-prem customers later.
+</Callout>
+</Phase>
+
+<Phase title="Model the auth flow and session" status="active">
+Authorization-code with PKCE: generate a `code_verifier`, send its SHA-256 `code_challenge`
+to the IdP, and exchange the returned code plus verifier for tokens. State and verifier live
+in a short-lived signed cookie, never in the URL.
+
+<FileTree>
+- add src/auth/oidc-client.ts -- discovery, PKCE challenge, token exchange
+- add src/auth/session.ts -- signed httpOnly cookie, 30 min sliding TTL
+- modify src/server/routes.ts -- mount /auth/login and /auth/callback
+- modify src/config/auth.ts -- per-provider issuer, client id, redirect uri
+</FileTree>
+</Phase>
+
+<Phase title="Implement the callback handler" status="planned">
+The callback validates `state`, exchanges the code with the verifier, verifies the
+`id_token` signature and `nonce`, then mints our own session cookie.
+
+```ts title="src/auth/callback.ts"
+export async function handleCallback(req: Request, res: Response) {
+  const { code, state } = req.query;
+  const stored = readSignedCookie(req, "oidc_tx");
+  if (!stored || stored.state !== state) {
+    return res.status(400).json({ error: "invalid_state" });
+  }
+
+  const tokens = await oidcClient.exchange({
+    code: String(code),
+    codeVerifier: stored.codeVerifier,
+    redirectUri: config.redirectUri,
+  });
+
+  const claims = await oidcClient.verifyIdToken(tokens.idToken, stored.nonce);
+  const user = await linkOrCreateUser(claims.email, claims.sub);
+
+  setSessionCookie(res, await createSession(user.id));
+  clearCookie(res, "oidc_tx");
+  return res.redirect("/app");
+}
+```
+
+<Callout type="note">
+The `id_token` is verified against the IdP's JWKS (cached from the discovery document), and
+the `nonce` is checked against the one we stored before redirecting. Skipping either check
+would let a stolen or replayed token forge a session.
+</Callout>
+</Phase>
+
+<Phase title="Migrate existing password users" status="planned">
+We do not force a reset. On the next login, if the IdP email matches a password account, we
+link `provider_sub` to that user and retire the password hash. Until then, both paths work.
+
+<Checklist title="Migration is safe when">
+- [ ] Email match links IdP `sub` to the existing user, no duplicate row
+- [ ] Password login stays enabled for unlinked accounts
+- [ ] Linked accounts have their `password_hash` nulled, not deleted in place
+- [ ] Mismatched email shows a clear "no matching account" error
+</Checklist>
+</Phase>
+
+<Phase title="Roll out behind a flag" status="planned">
+Gate the SSO buttons behind `sso_enabled` per tenant. Enable for one friendly enterprise
+tenant, watch the callback error rate for a week, then open it to all tenants.
+
+<FileTree>
+- move src/legacy/passport-local.ts -> src/auth/password.ts
+- modify src/server/login-page.tsx -- render IdP buttons when sso_enabled
+- add test/auth/callback.test.ts -- state, nonce, and exchange coverage
+</FileTree>
+</Phase>
+
+<Callout type="risk">
+A token-exchange failure (IdP down, clock skew on `id_token` expiry, or a misconfigured
+redirect uri) locks affected users out of login entirely. We keep password login as the
+fallback during rollout and alert on any callback 5xx rate above one percent.
+</Callout>
+
+<Questions>
+- Should an unmatched IdP email auto-provision a new account, or hard-fail?
+- Is a 30 minute session TTL with sliding renewal acceptable for enterprise tenants?
+- Do we rotate refresh tokens on every use, or only on expiry?
+</Questions>
+
+<Checklist title="Done when">
+- [ ] Authorization-code with PKCE completes against all three providers
+- [ ] `id_token` signature and `nonce` verified on every callback
+- [ ] Session issued as an httpOnly, SameSite cookie
+- [ ] Password users link on next login with no duplicate accounts
+- [ ] Callback error rate under one percent for the pilot tenant
+- [ ] SSO buttons gated behind the `sso_enabled` tenant flag
+</Checklist>

--- a/packages/app/examples/churn-model.mdx
+++ b/packages/app/examples/churn-model.mdx
@@ -1,0 +1,143 @@
+# Train and ship a churn prediction model
+
+Subscriber churn at renewal is the largest controllable revenue leak, and the retention
+team currently flags at-risk accounts by hand. The goal is a model that scores each active
+account daily for its probability of cancelling within the next 30 days, surfaced to the
+retention team and to an automated save-offer flow. We frame it as binary classification,
+optimize calibrated probability, and judge candidates on ranking quality (AUC) and on
+precision at the recall the save-offer budget can afford.
+
+```mermaid
+flowchart TD
+  Events[Account events] --> FS[Feature store]
+  Billing[Billing history] --> FS
+  Usage[Product usage] --> FS
+  FS --> Train[Training set, 30d label]
+  Train --> Sweep[Hyperparameter sweep]
+  Sweep --> Eval[Candidate evaluation]
+  Eval --> Model[Chosen model]
+  Model --> Service[Scoring service]
+  Service --> Retention[Retention queue]
+  Service --> Offer[Save-offer flow]
+```
+
+<Phase title="Frame the objective and label" status="done">
+Label an account positive if it cancels within 30 days of the score date. We minimize
+log loss so the output is a calibrated probability the save-offer flow can threshold on,
+not just a rank.
+
+```math
+\mathcal{L} = -\frac{1}{N}\sum_{i=1}^{N} \left[ y_i \log p_i + (1 - y_i)\log(1 - p_i) \right]
+```
+</Phase>
+
+<Phase title="Assemble features" status="done">
+Pull from three sources into the feature store, point-in-time correct so no future
+information leaks into a training row. About 40 features across engagement, billing, and
+support.
+
+<FileTree>
+- add features/engagement.sql -- logins, active days, feature breadth over 7/30/90d
+- add features/billing.sql -- plan tier, payment failures, discount history
+- add features/support.sql -- ticket count, last-contact recency, CSAT
+- modify pipelines/feature_store.py -- register the three groups, point-in-time joins
+</FileTree>
+</Phase>
+
+<Phase title="Sweep hyperparameters" status="active">
+Tune the gradient-boosted tree candidate with a random search over learning rate, leaf
+count, and subsample, scoring each trial by validation AUC on a time-based holdout.
+
+<Chart type="scatter" title="Learning-rate sweep (val AUC)">
+| trial | learning_rate | val_auc |
+|-------|---------------|---------|
+| t1    | 0.01          | 0.831   |
+| t2    | 0.03          | 0.857   |
+| t3    | 0.05          | 0.871   |
+| t4    | 0.08          | 0.878   |
+| t5    | 0.12          | 0.874   |
+| t6    | 0.20          | 0.862   |
+| t7    | 0.30          | 0.845   |
+</Chart>
+
+<Callout type="tip">
+The peak sits near a learning rate of 0.08. Rather than chase a marginally higher AUC at a
+single point, pick the rate at the top of the plateau and lean on early stopping, which
+holds up better when the next month of data shifts.
+</Callout>
+</Phase>
+
+<Phase title="Watch for overfitting" status="active">
+Track train and validation log loss per boosting round on the chosen configuration. The
+two curves stay close and the validation curve flattens, so we stop where it bottoms.
+
+<Chart type="line" title="Train vs validation log loss">
+| epoch | train | val  |
+|-------|-------|------|
+| 10    | 0.62  | 0.64 |
+| 20    | 0.54  | 0.57 |
+| 30    | 0.48  | 0.52 |
+| 40    | 0.44  | 0.49 |
+| 50    | 0.41  | 0.47 |
+| 60    | 0.39  | 0.46 |
+| 70    | 0.37  | 0.46 |
+| 80    | 0.35  | 0.47 |
+</Chart>
+</Phase>
+
+<Phase title="Compare candidate models" status="planned">
+Score three model families on the same holdout. Logistic regression is the interpretable
+baseline, the gradient-boosted trees lead on AUC, and a small neural net is the upside
+gamble. We weigh ranking quality against latency, interpretability, and serving cost.
+
+<Matrix>
+| Criterion        | Logistic regression | Gradient-boosted trees (pick) | Neural net |
+|------------------|---------------------|-------------------------------|------------|
+| AUC              | 0.82                | 0.88                          | 0.87       |
+| Latency          | low                 | low                           | medium     |
+| Interpretability | high                | medium                        | low        |
+| Cost             | low                 | low                           | high       |
+</Matrix>
+
+<Callout type="note">
+The neural net matches the trees on AUC but loses on every other axis: higher serving cost,
+worse interpretability for the retention team, and no precision-recall gain at our operating
+point. The boosted trees win on the whole scorecard, not just one number.
+</Callout>
+</Phase>
+
+<Phase title="Ship behind a scoring service" status="planned">
+Wrap the chosen model in a daily batch scoring job plus a low-latency endpoint for ad-hoc
+lookups, writing scores to the retention queue and the save-offer flow. Gate the rollout
+behind a flag and shadow-score for one week before any offer fires.
+
+<FileTree>
+- add services/scoring/handler.py -- load model, score an account, return calibrated p
+- add services/scoring/batch.py -- nightly scoring of all active accounts
+- modify retention/queue.py -- ingest scores, rank the at-risk queue
+- add infra/scoring_service.tf -- endpoint, autoscaling, model artifact bucket
+</FileTree>
+</Phase>
+
+<Callout type="note">
+Precision-recall matters more than raw AUC here because the save-offer budget caps how many
+accounts we can act on. We operate at the recall the budget affords and report precision
+there, so a model that ranks well overall but is weak in the top decile is not good enough.
+</Callout>
+
+<Questions>
+- What 30-day churn recall can the save-offer budget actually fund per month?
+- Do we recalibrate probabilities monthly, or only on a drift alarm?
+- Should canceled-then-reactivated accounts count as positive, negative, or be excluded?
+- Is a daily batch score fresh enough, or does the save-offer flow need real-time scoring?
+</Questions>
+
+<Checklist title="Done when">
+- [x] 30-day churn label defined and validated against historical cancellations
+- [x] Feature store backfilled point-in-time correct, no label leakage
+- [ ] Hyperparameter sweep complete, configuration frozen
+- [ ] Boosted-tree candidate beats baseline AUC and precision at target recall
+- [ ] Probabilities calibrated, reliability curve within tolerance
+- [ ] Scoring service shadow-scored a full week with no incidents
+- [ ] Scores flowing to the retention queue and save-offer flow behind a flag
+</Checklist>

--- a/packages/app/examples/design-system-rollout.mdx
+++ b/packages/app/examples/design-system-rollout.mdx
@@ -1,0 +1,126 @@
+# Roll out the design system to every app
+
+Every app ships its own buttons, modals, and form fields, so the same fix lands four times
+and the products drift apart visually. This plan extracts the shared UI into a versioned
+`@acme/design-system` package built on design tokens, migrates each app onto it with
+codemods and visual regression as the safety net, then sets up governance so contributions
+stay healthy.
+
+```mermaid
+flowchart TD
+  A[Audit current UI usage] --> B[Build tokens and package]
+  B --> C[Publish v0 to the registry]
+  C --> D[Migrate apps one at a time]
+  D --> E{Visual regression clean?}
+  E -->|no| F[Fix drift, re-snapshot]
+  F --> D
+  E -->|yes| G[Adopt as the only UI source]
+  G --> H[Govern contributions]
+```
+
+<Chart type="pie" title="UI component code by app today (%)">
+- Web app: 62
+- Admin console: 21
+- Marketing site: 11
+- Mobile web: 6
+</Chart>
+
+<Callout type="note">
+The web app holds most of the shared UI by sheer volume, so it becomes the source of truth:
+its `src/ui` directory is what we extract first, and the other apps adopt from there rather
+than each contributing a competing copy.
+</Callout>
+
+<Phase title="Audit where UI lives today" status="active">
+Inventory every component across the four apps, tag duplicates, and pick the canonical
+version of each. The chart above is the output: it tells us which app to extract from.
+
+<Checklist title="Audit done when">
+- [x] Component inventory exported across all four apps
+- [ ] Duplicate components reconciled to one canonical version each
+- [ ] Token candidates (color, spacing, type) pulled from existing CSS
+</Checklist>
+</Phase>
+
+<Phase title="Decide the build approach" status="planned">
+Adopt a headless primitives library and own our tokens and styling on top, versus building
+every primitive in-house. This is the load-bearing call for the whole rollout.
+
+<Compare>
+## Adopt Radix primitives, own tokens (pick)
+- pro: accessibility (focus, ARIA, keyboard) handled by the library
+- pro: we still own tokens, theming, and visual identity
+- con: a third-party dependency to track and upgrade
+- con: team learns the primitive API
+
+## Build primitives in-house
+- pro: zero external dependencies, full control
+- con: we re-implement accessibility from scratch and will get it wrong
+- con: months of work before any app benefits
+</Compare>
+
+<Callout type="decision">
+Adopt Radix for unstyled, accessible primitives and layer our tokens and components on top.
+Re-building accessible primitives in-house is the kind of work that looks cheap and is not;
+owning the tokens gives us the visual control that actually differentiates the product.
+</Callout>
+</Phase>
+
+<Phase title="Build the package and tokens" status="planned">
+Stand up `@acme/design-system`: tokens as the base layer, then components that consume them.
+Move the web app's canonical `ui` directory into the package as the seed.
+
+<FileTree>
+- add packages/design-system/
+- move apps/web/src/ui -> packages/design-system/src
+- add packages/design-system/src/tokens.ts -- color, spacing, type scale as exports
+- add packages/design-system/package.json -- versioned, published to the private registry
+- modify apps/web/package.json -- depend on `@acme/design-system`
+</FileTree>
+</Phase>
+
+<Phase title="Migrate apps with codemods" status="planned">
+Run a codemod per app to rewrite local imports to the package, one app at a time, gated by
+visual regression snapshots so silent drift fails the build instead of shipping.
+
+```bash
+npx @acme/ds-codemod apps/admin --dry-run
+npx @acme/ds-codemod apps/admin --write
+npm run test:visual -w apps/admin
+```
+</Phase>
+
+<Phase title="Track adoption and govern" status="planned">
+Publish an adoption metric per app (share of UI sourced from the package) and stand up a
+lightweight RFC process for new components so the package does not re-fragment.
+
+<Chart type="radar" title="Design system maturity: current vs target">
+| dimension | current | target |
+|----------------|---------|--------|
+| Adoption       | 35      | 90     |
+| Accessibility  | 50      | 95     |
+| Token coverage | 40      | 90     |
+| Documentation  | 30      | 85     |
+| Visual tests   | 20      | 80     |
+</Chart>
+
+<Callout type="tip">
+Track adoption as a percentage per app and put it on a shared dashboard. A visible number
+turns migration from a one-off project into a metric teams keep moving on their own.
+</Callout>
+</Phase>
+
+<Questions>
+- Do we hard-fail CI on visual regression diffs, or require a human to approve each diff?
+- Is `@acme/design-system` versioned independently, or pinned to a monorepo-wide release?
+- Who owns the component RFC review, and what is the bar for adding a new primitive?
+</Questions>
+
+<Checklist title="Done when">
+- [ ] `@acme/design-system` published with tokens and the seed components
+- [ ] All four apps import UI only from the package
+- [ ] Codemods retired after the last app migrates
+- [ ] Visual regression runs in CI for every app
+- [ ] Adoption dashboard live and tracked per app
+- [ ] Component contribution RFC process documented
+</Checklist>

--- a/packages/app/examples/frontend-performance.mdx
+++ b/packages/app/examples/frontend-performance.mdx
@@ -1,0 +1,105 @@
+# Halve the dashboard's load time
+
+The analytics dashboard loads slowly: Largest Contentful Paint sits at ~4.2s on
+the 75th-percentile mobile profile, well past the 2.5s "good" threshold, and the
+main JS bundle ships ~860 KB gzipped. The cost is concentrated in one eager
+charting library and a route that fetches and renders everything up front. We
+will profile to confirm the hot spots, code-split and lazy-load the heavy routes,
+swap the charting dependency for a lighter one, cache the API data, then verify
+against a perf budget enforced in CI.
+
+<Stat>
+- LCP now: 4.2 s (risk) -- 75th percentile, field data
+- LCP target: 2.1 s (good) -- pass the 2.5 s Core Web Vitals bar
+- Bundle now: 860 KB (warn) -- main chunk, gzipped
+- Bundle target: 430 KB (good) -- after split and dependency swap
+</Stat>
+
+```mermaid
+flowchart TD
+  A[Dashboard route request] --> B[Eager main bundle 860 KB]
+  B --> C[Parse and execute all chart code]
+  C --> D[Fetch every widget's data]
+  D --> E[Render full grid at once]
+  E --> F[LCP at 4.2s]
+  B -.split.-> G[Lazy chart chunks]
+  D -.cache.-> H[Stale-while-revalidate query cache]
+```
+
+<Chart type="area" title="Projected main bundle size (KB gzipped)">
+- Baseline: 860
+- After code-split: 690
+- After lazy charts: 540
+- After dep swap: 430
+</Chart>
+
+<Chart type="gauge" title="Lighthouse performance score (mobile)">
+- Score: 58
+</Chart>
+
+<Phase title="Profile and confirm the hot spots" status="active">
+Capture a production trace before changing anything, so each later step has a
+measured baseline rather than a guess.
+
+<Checklist title="Captured before any change">
+- [x] Lighthouse CI run saved on the dashboard route
+- [x] `webpack-bundle-analyzer` treemap of the main chunk
+- [ ] Chrome performance trace of the LCP path on a throttled mobile profile
+</Checklist>
+</Phase>
+
+<Phase title="Code-split and lazy-load the heavy routes" status="planned">
+The dashboard, reports, and settings routes all ship in the entry chunk. Split
+them at the router boundary and lazy-load below-the-fold widgets so the first
+paint carries only what the viewport needs.
+
+```tsx title="src/dashboard/routes.tsx" del={1} ins={2-3}
+import { ReportsPage } from "./pages/ReportsPage";
+const ReportsPage = lazy(() => import("./pages/ReportsPage"));
+const SettingsPage = lazy(() => import("./pages/SettingsPage"));
+```
+</Phase>
+
+<Phase title="Drop the heavy charting dependency" status="planned">
+The dashboard pulls in a full-featured charting suite (~210 KB gzipped) for what
+is really a handful of line and area charts. Replace it with a lightweight
+renderer and delete the wrapper that adapts its API.
+
+<FileTree>
+- delete src/dashboard/legacy-charts/ -- remove the heavy-suite wrapper and adapters
+- modify src/dashboard/widgets/TrendCard.tsx -- render via the lighter chart primitive
+- modify package.json -- drop the heavy dep, add the lightweight one
+</FileTree>
+</Phase>
+
+<Phase title="Cache the data layer" status="planned">
+Each widget refetches on every mount, so a single navigation triggers a burst of
+duplicate requests. Move reads behind a stale-while-revalidate query cache with a
+shared key per dataset.
+
+<Callout type="tip">
+With a 30s `staleTime` the grid paints instantly from cache on revisit and
+refetches in the background, so perceived load time drops even when the network is
+unchanged.
+</Callout>
+</Phase>
+
+<Phase title="Enforce the perf budget in CI" status="planned">
+Wire Lighthouse CI and a bundle-size assertion into the pipeline so a regression
+fails the build instead of reaching production.
+</Phase>
+
+<Callout type="warn">
+Lazy boundaries change the loading sequence, so an unsuspended chunk can flash a
+blank panel or shift layout. Reserve each widget's height with a skeleton to keep
+Cumulative Layout Shift under the 0.1 budget.
+</Callout>
+
+<Checklist title="Done when">
+- [ ] LCP at or below 2.5 s on the throttled mobile profile (target 2.1 s)
+- [ ] Total Blocking Time under 200 ms
+- [ ] Cumulative Layout Shift under 0.1
+- [ ] Main bundle at or below 450 KB gzipped
+- [ ] Lighthouse performance score at or above 90
+- [ ] CI fails on any budget regression
+</Checklist>

--- a/packages/app/examples/incident-runbook.mdx
+++ b/packages/app/examples/incident-runbook.mdx
@@ -1,0 +1,86 @@
+# Sev1 incident response runbook
+
+Checkout is down. This is the on-call path from the first alert to the all-clear: triage
+the severity, page the right people, mitigate fast, and keep comms flowing. Follow the
+tree, hit the targets, work the checklist.
+
+```mermaid
+flowchart TD
+  A[Alert fires] --> B{Checkout failing?}
+  B -->|no| C[Stand down, log noise]
+  B -->|yes| D{Error rate over 5%?}
+  D -->|yes| E[Sev1: page IC + on-call]
+  D -->|no| F[Sev2: on-call only]
+  E --> G[Mitigate: roll back or shed load]
+  G --> H[Post status, update every 15 min]
+```
+
+<Stat>
+- Detect: under 5 min (good) -- from first failed health check to alert
+- Ack: under 5 min (good) -- on-call acknowledges the page
+- MTTR target: under 60 min (warn) -- alert to checkout recovered
+</Stat>
+
+<Chart type="gauge" title="Error budget remaining (%)">
+- Remaining: 62
+</Chart>
+
+<Callout type="warn">
+The checkout error-budget burn is fast: at the current rate the remaining 62 percent is
+gone in roughly nine days. A second Sev1 this week tips us into a budget freeze.
+</Callout>
+
+<Phase title="Detect and declare" status="active">
+On-call acknowledges the page, opens the incident, and assigns the incident commander (IC).
+Declare the severity from the tree before touching anything.
+
+- [ ] Acknowledge the page in PagerDuty
+- [ ] Open `#inc-checkout` and pin the incident doc
+- [ ] Assign IC and scribe
+</Phase>
+
+<Phase title="Assess severity" status="planned">
+The IC reads the signals and confirms the severity. Error rate over 5 percent or p99 over
+2s on the checkout path is a Sev1.
+
+<Callout type="tip">
+Check the deploy timeline first: most checkout Sev1s trace to a release in the last 30
+minutes. A clean rollback is faster than a root-cause hunt.
+</Callout>
+</Phase>
+
+<Phase title="Mitigate" status="planned">
+Stop the bleeding before explaining it. Roll back the suspect deploy, or shed load by
+disabling non-critical features, whichever restores checkout fastest.
+
+- [ ] Roll back the last checkout deploy if timing matches
+- [ ] Shed load: disable recommendations and upsell calls
+- [ ] Confirm error rate and p99 latency recovering
+</Phase>
+
+<Phase title="Communicate" status="planned">
+The IC owns comms. Post to the status page, update stakeholders in `#inc-checkout` every
+15 minutes, and notify support so they can hold the line with customers.
+</Phase>
+
+<Callout type="risk">
+Rolling back checkout also reverts the new tax-calculation logic. If the rollback window
+crosses a pricing change, orders may compute the wrong tax until the fix re-lands. Flag
+finance before rolling back across that boundary.
+</Callout>
+
+<Questions>
+- Who is the backup IC when the primary is unreachable within the 5-minute ack target?
+- Do we auto-page finance on any checkout rollback, or only when tax logic is in the diff?
+- Is the status page update manual, or wired to the incident tool?
+</Questions>
+
+<Checklist title="Runbook checklist">
+- [ ] Page acknowledged and IC assigned
+- [ ] Severity declared from the triage tree
+- [ ] Mitigation applied (rollback or load shed)
+- [ ] Checkout error rate and p99 back to baseline
+- [ ] Status page posted and stakeholders updated
+- [ ] Support notified with a customer-facing message
+- [ ] Postmortem scheduled within 48 hours
+</Checklist>

--- a/packages/app/examples/lakehouse-pipeline.mdx
+++ b/packages/app/examples/lakehouse-pipeline.mdx
@@ -1,0 +1,171 @@
+# Build the events lakehouse pipeline
+
+Product events land in Kafka at peak rates but we have no durable, queryable history:
+analysts reconstruct funnels from ad-hoc log exports that take hours and disagree with
+each other. This plan stands up a lakehouse: ingest events from Kafka, land them raw as
+Parquet in object storage, transform them into a modeled star schema with dbt-style
+models, enforce data quality, and serve analytics from the marts layer.
+
+```mermaid
+flowchart TD
+  Kafka[Kafka events topic] --> Ingest[Ingest consumer]
+  Ingest --> Raw[Raw Parquet in object storage]
+  Raw --> Staged[Staged + deduped]
+  Staged --> Marts[Modeled star schema]
+  Marts --> Serve[Analytics serving layer]
+```
+
+<Stat>
+- Events/day: 2.4B (note) -- peak 60k/s
+- p95 freshness: 9 min (good) -- raw to marts
+- Steady-state storage: 84 TB (note) -- all layers, Snappy Parquet
+</Stat>
+
+<Phase title="Ingest from Kafka" status="active">
+A consumer group reads the `product.events` topic and writes micro-batches every 60s,
+committing offsets only after a durable write so a crash replays rather than drops.
+
+<Callout type="note">
+Events carry a producer-side `event_time` and a consumer-side `ingest_time`. Partition
+on `ingest_time` so a late event never rewrites an old partition; correct for true event
+time downstream in the staging layer.
+</Callout>
+</Phase>
+
+<Phase title="Land raw in object storage" status="planned">
+Write immutable Snappy-compressed Parquet, partitioned by date and event name, sized to
+roughly 128 MB files to keep the small-file count low.
+
+```text title="s3://lake/raw/ layout"
+raw/event_name=checkout/dt=2026-06-23/part-0001.parquet
+raw/event_name=checkout/dt=2026-06-23/part-0002.parquet
+raw/event_name=page_view/dt=2026-06-23/part-0001.parquet
+```
+
+<Chart type="treemap" title="Raw storage by dataset (GB)">
+- events_raw: 1200
+- page_view: 540
+- checkout: 180
+- add_to_cart: 95
+- session_start: 60
+</Chart>
+</Phase>
+
+<Phase title="Model the warehouse star schema" status="planned">
+Transform staged events into a single grain-`one-row-per-event` fact table surrounded by
+conformed dimensions, so analysts join on stable surrogate keys instead of raw payloads.
+
+```mermaid
+erDiagram
+  DIM_USER ||--o{ FCT_EVENT : performs
+  DIM_DATE ||--o{ FCT_EVENT : occurs_on
+  DIM_DEVICE ||--o{ FCT_EVENT : from
+  DIM_PAGE ||--o{ FCT_EVENT : on
+  FCT_EVENT {
+    bigint event_key PK
+    bigint user_key FK
+    int date_key FK
+    bigint device_key FK
+    bigint page_key FK
+    timestamp event_time
+    string event_name
+  }
+  DIM_USER {
+    bigint user_key PK
+    string user_id
+    string plan_tier
+  }
+  DIM_DATE {
+    int date_key PK
+    date full_date
+    int week_of_year
+  }
+  DIM_DEVICE {
+    bigint device_key PK
+    string os
+    string browser
+  }
+  DIM_PAGE {
+    bigint page_key PK
+    string path
+    string section
+  }
+```
+</Phase>
+
+<Phase title="Transform with dbt-style models" status="planned">
+Layer the models staging -> intermediate -> marts so each transform is testable in
+isolation and the lineage is explicit. Deduplicate on `event_id` and resolve late
+arrivals against true `event_time` here.
+
+<FileTree>
+- add models/staging/stg_events.sql -- typecast, dedupe on event_id
+- add models/intermediate/int_sessions.sql -- sessionize by user and gap
+- add models/marts/fct_event.sql -- one row per event at the grain
+- add models/marts/dim_user.sql -- SCD2 on plan_tier changes
+- modify models/sources.yml -- register the raw Parquet external tables
+</FileTree>
+
+<Callout type="risk">
+Late-arriving events can land hours after their `event_time` and silently fall outside a
+day's partition, undercounting that day. Reprocess a trailing 3-day window on every run
+and treat marts as eventually-correct, not point-in-time frozen.
+</Callout>
+</Phase>
+
+<Phase title="Enforce data quality" status="planned">
+Run schema, not-null, uniqueness, and referential tests in the transform DAG; a failing
+test halts the run before bad data reaches the marts.
+
+<Chart type="funnel" title="Records surviving each stage (millions/day)">
+- Ingested: 2400
+- Parsed: 2360
+- Deduped: 2180
+- Valid schema: 2150
+- Loaded to marts: 2140
+</Chart>
+</Phase>
+
+<Phase title="Serve analytics" status="planned">
+Expose the marts to BI and notebooks through a query engine over the same Parquet, so
+serving reads the modeled tables without copying data into a separate warehouse.
+
+<Chart type="bar" stacked title="Storage growth by layer (TB)">
+| month | raw | staged | marts |
+|-------|-----|--------|-------|
+| Jan   | 18  | 9      | 4     |
+| Feb   | 23  | 11     | 5     |
+| Mar   | 29  | 14     | 6     |
+| Apr   | 36  | 17     | 7     |
+</Chart>
+</Phase>
+
+<Phase title="Choose the query engine" status="planned">
+Score three engines for the serving layer against operational fit. Rationale is in the
+callout below, not in the cells.
+
+<Matrix>
+| Dimension      | Trino (pick) | DuckDB  | Spark SQL |
+|----------------|--------------|---------|-----------|
+| Concurrency    | high         | low     | medium    |
+| Ops burden     | medium       | low     | high      |
+| Parquet scans  | high         | high    | high      |
+| Large joins    | high         | medium  | high      |
+| Cost           | medium       | low     | high      |
+</Matrix>
+
+<Callout type="decision">
+We pick Trino: it handles the concurrent BI workload that DuckDB cannot and avoids the
+cluster-management overhead Spark SQL imposes for interactive queries. DuckDB stays as
+the local engine analysts use against single-day extracts.
+</Callout>
+</Phase>
+
+<Checklist title="Done when">
+- [ ] Kafka consumer writes raw Parquet with offsets committed after durable write
+- [ ] Raw layer partitioned by ingest date and event name, files near 128 MB
+- [ ] Star schema fact and dimension tables build from dbt-style models
+- [ ] Late-arriving events reprocessed over a trailing 3-day window
+- [ ] Data-quality tests gate the marts and halt on failure
+- [ ] Trino serves the marts with p95 freshness under 10 minutes
+</Checklist>

--- a/packages/app/examples/offline-sync.mdx
+++ b/packages/app/examples/offline-sync.mdx
@@ -1,0 +1,113 @@
+# Offline-first sync for the mobile app
+
+The app assumes a live connection, so a dropped signal blocks reads and silently
+loses writes. We will keep a local store as the source of truth for the UI, queue
+every mutation while offline, and reconcile against the server with a sync cursor
+when connectivity returns. Conflicts and deletes are the hard part, so we model
+tombstones and a resolution strategy up front.
+
+```mermaid
+classDiagram
+  class SyncRecord {
+    +string id
+    +json payload
+    +int version
+    +datetime updatedAt
+    +bool tombstone
+  }
+  class MutationQueue {
+    +string opId
+    +string recordId
+    +string op
+    +int retries
+    enqueue()
+    drain()
+  }
+  class SyncCursor {
+    +string serverToken
+    +datetime lastPulledAt
+  }
+  MutationQueue --> SyncRecord : targets
+  SyncCursor --> SyncRecord : bounds pull
+```
+
+<Phase title="Model the local store and tombstones" status="done">
+Define `SyncRecord` as the local row with a monotonic `version` and a `tombstone`
+flag so deletes replicate instead of vanishing. The queue and cursor are separate
+local tables.
+
+<FileTree>
+- add src/sync/schema.ts -- SyncRecord, MutationQueue, SyncCursor tables
+- add src/sync/local-store.ts -- read/write SyncRecords, soft-delete via tombstone
+- modify src/db/migrations/index.ts -- create the three sync tables
+</FileTree>
+</Phase>
+
+<Phase title="Choose a conflict-resolution strategy" status="active">
+The strategy decides what happens when the same record changed on two devices. We
+pick the lighter option that fits our data shape, with field-level merge as the
+escape hatch for the few records that need it.
+
+<Compare>
+## Last-write-wins (pick)
+- pro: trivial to implement with `version` plus `updatedAt`
+- pro: deterministic, no merge state to store or replay
+- con: a losing edit is discarded silently
+- con: needs a per-field override for records users co-edit
+
+## CRDT / operational merge
+- pro: no lost writes, concurrent edits converge
+- pro: works for collaborative text and counters
+- con: heavier runtime and on-device storage
+- con: every type needs a bespoke merge function
+</Compare>
+</Phase>
+
+<Phase title="Build the sync engine" status="planned">
+A single engine drains the `MutationQueue` to the server, then pulls changes since
+the `SyncCursor` token and applies them through the resolver.
+
+<FileTree>
+- add src/sync/engine.ts -- push queue, pull by cursor, resolve, advance token
+- add src/sync/resolver.ts -- last-write-wins with per-field overrides
+- add src/sync/mutation-queue.ts -- enqueue, drain, backoff on retries
+</FileTree>
+</Phase>
+
+<Phase title="Wire connectivity and roll out" status="planned">
+Trigger a sync on reconnect and on app foreground, behind a flag so we can enable
+it per cohort and fall back to online-only instantly.
+
+<FileTree>
+- add src/sync/connectivity.ts -- reconnect and foreground triggers
+- modify src/app/providers.tsx -- mount the sync engine behind the flag
+</FileTree>
+</Phase>
+
+<Callout type="decision">
+Default to last-write-wins keyed on `version`, with a small allowlist of records
+(notes, tags) that use field-level merge. This keeps the common path cheap and
+reserves the expensive merge for the few types that genuinely need it.
+</Callout>
+
+<Callout type="risk">
+A queued mutation against a record the server already tombstoned would resurrect a
+deleted row. The engine must check the tombstone on apply and drop the orphaned
+mutation, or a delete on one device silently undoes on another.
+</Callout>
+
+<Questions>
+- Should the sync cursor be a server-issued opaque token or a client timestamp?
+- How long do we retain tombstones before the server may garbage-collect them?
+- Does a queued mutation that fails validation server-side roll back the local row or surface a conflict to the user?
+- What is the max queue depth before we force a full resync instead of replaying?
+</Questions>
+
+<Checklist title="Done when">
+- [x] Local store reads and writes work fully offline
+- [ ] Mutations queue offline and drain in order on reconnect
+- [ ] Pull applies server changes since the cursor and advances the token
+- [ ] Last-write-wins resolves conflicts deterministically by version
+- [ ] Tombstones replicate, and a mutation against a tombstoned record is dropped
+- [ ] Sync runs behind a flag with an online-only fallback
+</Checklist>

--- a/packages/app/src/components/ReviewDemo.tsx
+++ b/packages/app/src/components/ReviewDemo.tsx
@@ -1,0 +1,75 @@
+import { Callout } from '@visualplan/runtime/components/Callout'
+import { Checklist } from '@visualplan/runtime/components/Checklist'
+import { FileTree } from '@visualplan/runtime/components/FileTree'
+import { Mermaid } from '@visualplan/runtime/components/Mermaid'
+import { Phase } from '@visualplan/runtime/components/Phase'
+import { Questions } from '@visualplan/runtime/components/Questions'
+import { ReviewAnswersProvider } from '@visualplan/runtime/components/review/ReviewAnswers'
+import { ReviewLayer } from '@visualplan/runtime/components/review/ReviewLayer'
+
+// Turn review mode on AND mark it a demo before the layer mounts. Demo mode keeps every decision in
+// the page: no CLI server is posted to, the tab is never closed, and the beforeunload prompt is off,
+// so the embedded preview is safe to click through and to reset by reloading the frame. This mirrors
+// the CLI build's `__VP_REVIEW__` injection; the module runs only in the browser (the frame mounts it
+// `client:only`), so assigning on `globalThis` is assigning on `window`.
+const globals = globalThis as { __VP_REVIEW__?: boolean; __VP_REVIEW_DEMO__?: boolean }
+globals.__VP_REVIEW__ = true
+globals.__VP_REVIEW_DEMO__ = true
+
+const ARCHITECTURE =
+  'flowchart LR\n  Client --> Gateway --> Limiter --> API\n  Limiter --> Redis[(Redis)]'
+
+/**
+ * A self-contained dummy plan with the real review layer mounted over it, exactly as `vplan render
+ * --review` produces. It replicates the runtime's `Layout` shape (an `.vp-main` column the section
+ * collector reads, wrapped in `ReviewAnswersProvider` so the inline `Questions` answers flow into the
+ * feedback). It is rendered inside the `/review-demo-frame` iframe so the layer's viewport-fixed
+ * chrome (the decision bar, the section overlays) stays contained to the preview.
+ */
+export function ReviewDemo() {
+  return (
+    <ReviewAnswersProvider>
+      <div className='vp-shell'>
+        <main className='vp-main'>
+          <h1>Add rate limiting to the API</h1>
+          <p>
+            Add a sliding-window limiter at the gateway, behind a flag, then ramp it from 1% to 100%
+            while watching the rejection rate.
+          </p>
+          <Mermaid chart={ARCHITECTURE} />
+          <Phase title='Build the limiter' status='done'>
+            Implement the Redis-backed sliding window and return 429 over the limit.
+          </Phase>
+          <Phase title='Wire the middleware' status='active'>
+            Mount the limiter behind the flag and send a Retry-After header on rejection.
+          </Phase>
+          <Phase title='Dashboards' status='planned'>
+            Emit metrics and chart the rejection rate so the ramp can be watched.
+          </Phase>
+          <Callout type='risk'>A Redis outage must fail open, not closed.</Callout>
+          <FileTree
+            files={[
+              { path: 'src/gateway/rate-limiter.ts', change: 'add' },
+              { path: 'src/gateway/middleware.ts', change: 'modify' },
+              { path: 'src/gateway/legacy/', change: 'delete' },
+            ]}
+          />
+          <Questions
+            items={[
+              'Should the limiter fail open or fail closed if Redis is unreachable?',
+              'Is a per-IP limit enough, or do we need per-API-key buckets too?',
+            ]}
+          />
+          <Checklist
+            title='Done when'
+            items={[
+              { text: 'Returns 429 over the limit', done: true },
+              { text: 'Dashboards live', done: false },
+            ]}
+          />
+        </main>
+        <ReviewLayer />
+      </div>
+    </ReviewAnswersProvider>
+  )
+}

--- a/packages/app/src/components/ReviewDemoEmbed.astro
+++ b/packages/app/src/components/ReviewDemoEmbed.astro
@@ -1,0 +1,77 @@
+---
+// Embeds the interactive review-mode demo (/review-demo-frame) in a contained, resettable frame.
+// The review layer is viewport-fixed (built as a full-page takeover), so it must live in its own
+// iframe to stay inside the docs page rather than overlaying it. Reset simply reloads the frame,
+// which clears every staged comment, answer, and decision.
+---
+
+<figure class="review-embed">
+  <figcaption class="review-embed__bar">
+    <span>
+      Live demo: hover a section to comment, answer a question inline, then Approve, Deny, or
+      Iterate. Nothing leaves this page.
+    </span>
+    <button type="button" class="review-embed__reset" data-review-reset>Reset</button>
+  </figcaption>
+  <iframe
+    class="review-embed__frame"
+    src="/review-demo-frame/"
+    title="Interactive demo of vplan review mode"
+    loading="lazy"></iframe>
+</figure>
+
+<script>
+  const frame = document.querySelector<HTMLIFrameElement>('.review-embed__frame')
+  const reset = document.querySelector<HTMLButtonElement>('[data-review-reset]')
+  // Reloading the frame is the simplest full reset: it drops all in-page review state.
+  reset?.addEventListener('click', () => {
+    if (frame) frame.src = frame.src
+  })
+</script>
+
+<style>
+  .review-embed {
+    margin: 2rem 0;
+    border: 1px solid var(--vp-border);
+    border-radius: 12px;
+    overflow: hidden;
+    background: var(--vp-bg);
+  }
+
+  .review-embed__bar {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    padding: 0.6rem 0.9rem;
+    background: var(--vp-surface);
+    border-bottom: 1px solid var(--vp-border);
+    font-size: 0.85rem;
+    color: var(--vp-muted);
+  }
+
+  .review-embed__reset {
+    flex: none;
+    padding: 0.35rem 0.85rem;
+    border: 1px solid var(--vp-border);
+    border-radius: 7px;
+    background: var(--vp-bg);
+    color: var(--vp-text);
+    font: inherit;
+    font-size: 0.8rem;
+    cursor: pointer;
+    transition: border-color 0.15s var(--vp-ease);
+  }
+
+  .review-embed__reset:hover {
+    border-color: var(--vp-accent);
+  }
+
+  .review-embed__frame {
+    display: block;
+    width: 100%;
+    height: 720px;
+    border: 0;
+    background: var(--vp-bg);
+  }
+</style>

--- a/packages/app/src/nav.ts
+++ b/packages/app/src/nav.ts
@@ -9,6 +9,7 @@ export const docLinks: DocLink[] = [
   { href: '/docs/install/', label: 'Installation' },
   { href: '/docs/authoring/', label: 'Authoring plans' },
   { href: '/docs/review/', label: 'Review mode' },
+  { href: '/docs/export/', label: 'Exporting' },
   { href: '/docs/cli/', label: 'CLI reference' },
   { href: '/docs/programmatic/', label: 'Programmatic interface' },
 ]

--- a/packages/app/src/nav.ts
+++ b/packages/app/src/nav.ts
@@ -8,8 +8,8 @@ export const docLinks: DocLink[] = [
   { href: '/docs/', label: 'Introduction' },
   { href: '/docs/install/', label: 'Installation' },
   { href: '/docs/authoring/', label: 'Authoring plans' },
-  { href: '/docs/cli/', label: 'CLI reference' },
   { href: '/docs/review/', label: 'Review mode' },
+  { href: '/docs/cli/', label: 'CLI reference' },
   { href: '/docs/programmatic/', label: 'Programmatic interface' },
 ]
 

--- a/packages/app/src/nav.ts
+++ b/packages/app/src/nav.ts
@@ -41,4 +41,39 @@ export const exampleLinks: ExampleLink[] = [
     label: 'Product launch',
     title: 'Launch the Insights dashboard',
   },
+  {
+    href: '/examples/add-sso-auth.html',
+    label: 'SSO and OAuth2',
+    title: 'Add SSO with OAuth2 and OIDC',
+  },
+  {
+    href: '/examples/incident-runbook.html',
+    label: 'Incident runbook',
+    title: 'Sev1 incident response runbook',
+  },
+  {
+    href: '/examples/churn-model.html',
+    label: 'Churn model',
+    title: 'Train and ship a churn prediction model',
+  },
+  {
+    href: '/examples/frontend-performance.html',
+    label: 'Frontend performance',
+    title: "Halve the dashboard's load time",
+  },
+  {
+    href: '/examples/offline-sync.html',
+    label: 'Offline sync',
+    title: 'Offline-first sync for the mobile app',
+  },
+  {
+    href: '/examples/lakehouse-pipeline.html',
+    label: 'Lakehouse pipeline',
+    title: 'Build the events lakehouse pipeline',
+  },
+  {
+    href: '/examples/design-system-rollout.html',
+    label: 'Design system',
+    title: 'Roll out the design system to every app',
+  },
 ]

--- a/packages/app/src/nav.ts
+++ b/packages/app/src/nav.ts
@@ -58,7 +58,7 @@ export const exampleLinks: ExampleLink[] = [
   },
   {
     href: '/examples/frontend-performance.html',
-    label: 'Frontend performance',
+    label: 'Page speed',
     title: "Halve the dashboard's load time",
   },
   {

--- a/packages/app/src/nav.ts
+++ b/packages/app/src/nav.ts
@@ -9,6 +9,7 @@ export const docLinks: DocLink[] = [
   { href: '/docs/install/', label: 'Installation' },
   { href: '/docs/authoring/', label: 'Authoring plans' },
   { href: '/docs/cli/', label: 'CLI reference' },
+  { href: '/docs/review/', label: 'Review mode' },
   { href: '/docs/programmatic/', label: 'Programmatic interface' },
 ]
 

--- a/packages/app/src/pages/docs/cli.md
+++ b/packages/app/src/pages/docs/cli.md
@@ -41,7 +41,8 @@ render, not `--watch`.
 comments on sections or selected text, answers any `<Questions>` inline, then clicks Approve, Deny,
 or Iterate. The command **blocks** until they submit, prints the decision, comments, and answers to
 stdout, then exits with a decision-specific code (see [Exit codes](#exit-codes)). It is a
-long-running foreground server; a closed tab counts as Deny, and `--timeout` bounds the wait.
+long-running foreground server; a closed tab counts as Deny, and `--timeout` bounds the wait. See
+[Review mode](/docs/review/) for an interactive demo and the full session walkthrough.
 
 ### Iteration diffing
 

--- a/packages/app/src/pages/docs/cli.md
+++ b/packages/app/src/pages/docs/cli.md
@@ -82,7 +82,8 @@ vplan export <pdf|jpg> <file.mdx>
 
 Builds the same self-contained page, then renders it to a static file with a headless Chromium:
 `pdf` prints a paginated A4 document, `jpg` a full-page hi-dpi screenshot. The output goes to
-`<file>.pdf` / `<file>.jpg` next to the source and opens.
+`<file>.pdf` / `<file>.jpg` next to the source and opens. See [Exporting](/docs/export/) for when to
+reach for it over the HTML page.
 
 | Flag | Effect |
 |------|--------|

--- a/packages/app/src/pages/docs/cli.md
+++ b/packages/app/src/pages/docs/cli.md
@@ -16,16 +16,41 @@ vplan <file.mdx>
 ```
 
 Compiles a plan to a single self-contained `<file>.plan.html` next to the source and opens it.
-`render` is the default command, so `vplan plan.mdx` and `vplan render plan.mdx` are the same.
+`render` is the default command, so `vplan plan.mdx` and `vplan render plan.mdx` are the same. The
+file argument may be `-` (or omitted) to read the plan from stdin.
 
 | Flag | Effect |
 |------|--------|
 | `--watch` | Start a hot-reloading dev server instead of writing a file. Long-running; stops on Ctrl+C. |
+| `--port <number>` | Port for the `--watch` dev server (default `9140`, auto-incrementing if taken). |
 | `--out <path>` | Write the HTML to `<path>` instead of `<file>.plan.html`. |
+| `--stdout` | Write the rendered HTML to stdout instead of a file (composes in a pipeline; never auto-diffs). |
+| `--review` | Open an interactive review session and block until the reviewer decides (see below). |
+| `-i, --iteration <n>` | Plan revision number shown in the review bar; increment it each re-review. |
+| `--timeout <duration>` | Max wait for review feedback, e.g. `15m`, `30s`, `1h` (default `15m`). |
+| `--diff <path>` | Diff this render against an explicit baseline plan, overriding the snapshot cache. |
+| `--no-diff` | Skip iteration diffing (do not read or write the snapshot cache). |
 | `--no-open` | Do not open the result in the browser. |
 
 `--watch` serves a local URL and writes no file, so for a one-shot HTML output use the plain
 render, not `--watch`.
+
+### Review mode
+
+`vplan render --review <file.mdx>` opens the plan as an interactive review session: the reviewer
+comments on sections or selected text, answers any `<Questions>` inline, then clicks Approve, Deny,
+or Iterate. The command **blocks** until they submit, prints the decision, comments, and answers to
+stdout, then exits with a decision-specific code (see [Exit codes](#exit-codes)). It is a
+long-running foreground server; a closed tab counts as Deny, and `--timeout` bounds the wait.
+
+### Iteration diffing
+
+A render of a plan **file** snapshots its source (under `~/.vplan/snapshots`, keyed by absolute
+path), and the next render of that path diffs the new source against the snapshot, marking
+added and edited sections git-gutter style with an "N changed" summary so the reviewer re-reviews
+only the delta. Diffing applies to `render`, `--watch`, and `--review`; a `--stdout` render never
+auto-diffs (it stays deterministic for pipelines). Use `--diff <path>` to force an explicit baseline
+without touching the cache, or `--no-diff` to opt out (for example a clean first look).
 
 ## check
 
@@ -37,6 +62,14 @@ Validates a plan without rendering it, the self-correction loop. It reports MDX 
 plus static component checks as `file:line:col`, naming the valid values for bad enums and flagging
 unknown components. It also validates each mermaid diagram and math block, and rejects markdown
 images (which would break the self-contained output).
+
+Once a plan parses cleanly, `check` also runs an author-time **quality lint** that flags weak
+renders before a human sees them: a plan that is all prose with no structure, a `Phase` that is a
+wall of prose with no visual, a wide left-to-right mermaid diagram that will shrink to illegibility,
+an over-long `Matrix` cell, a `-- comment` on a `FileTree` move row, or a `Chart` whose series
+differ wildly in scale. These surface as warnings, and **a warning fails the check** (non-zero exit)
+just like an error, so the lint is not advisory. The quality lint runs only on the `check` command;
+the programmatic `checkPlan` runs the static checks alone.
 
 Run `check` before showing a plan to a user, so they never see a broken render.
 
@@ -60,6 +93,17 @@ Builds the same self-contained page, then renders it to a static file with a hea
 Export needs a Chromium. It uses a system Chrome or Edge if present, then a `playwright`-installed
 Chromium; if none is found it tells you to run `npx playwright install chromium`.
 
+## share
+
+```bash
+vplan share <file.mdx>
+```
+
+Prints a stateless `visualplan.dev/view?data=...` link that encodes the entire plan (its MDX source,
+deflate plus base64url) in the URL, so anyone can open the rendered plan with no files, server, or
+account. It validates the plan first, so a broken plan is never shared, and reads a file or stdin
+(`-`). This is the CLI equivalent of the share button on a rendered page.
+
 ## components
 
 ```bash
@@ -69,8 +113,24 @@ vplan components
 Prints the component vocabulary cheat-sheet with the exact prop signatures. See
 [Authoring plans](/docs/authoring/) for the full guide.
 
+## config
+
+```bash
+vplan config            # show the current settings
+vplan config get <key>  # print one setting
+vplan config set <key> <value>
+vplan config path       # print the config file path
+```
+
+Views and edits persistent settings stored in `~/.vplan/config.json`. The only setting is `theme`
+(`light`, `dark`, or `system`), the default color scheme baked into every rendered plan. The in-page
+settings cog overrides this per view in the browser (via `localStorage`) and never writes the file,
+so the on-disk default and the in-page override are separate layers.
+
 ## Exit codes
 
 - `0`, success (rendered, or `check` found no issues).
-- Non-zero, a compile error or a `check` failure. The reported `file:line:col` issues are printed
-  to stderr.
+- Non-zero, a compile error or a `check` failure (errors or quality-lint warnings). The reported
+  `file:line:col` issues are printed to stderr.
+- A `--review` session exits by the reviewer's decision: `0` Approve, `1` Deny, `2` Iterate, `3`
+  timeout. A closed tab counts as Deny.

--- a/packages/app/src/pages/docs/export.md
+++ b/packages/app/src/pages/docs/export.md
@@ -1,0 +1,61 @@
+---
+layout: ../../layouts/Docs.astro
+title: Exporting
+description: Render a plan to a static PDF or JPG.
+---
+
+# Exporting
+
+The default output of `vplan` is an interactive HTML page. When you need a static artifact to attach
+to a ticket, drop in a doc, email, or print, export the plan to a **PDF** or a **JPG** instead:
+
+```bash
+vplan export pdf plan.mdx    # paginated A4 document -> plan.pdf
+vplan export jpg plan.mdx    # one full-page hi-dpi image -> plan.jpg
+```
+
+Export builds the exact same self-contained page the HTML render produces, then captures it with a
+headless Chromium, so the output is the fully rendered plan, diagrams, charts, and typeset math
+included, not a degraded copy. The file is written next to the source (`<file>.pdf` / `<file>.jpg`)
+and opened.
+
+## Formats
+
+- **`pdf`** prints a paginated A4 document, so a long plan flows across pages and prints cleanly.
+- **`jpg`** captures a single full-page, high-DPI screenshot of the whole plan, best for a preview
+  thumbnail or pasting an image inline.
+
+## Flags
+
+| Flag | Effect |
+|------|--------|
+| `--out <path>` | Write to `<path>` instead of `<file>.<pdf\|jpg>`. Required when reading from stdin. |
+| `--theme <theme>` | Override the baked color scheme: `light`, `dark`, or `system`. |
+| `--browser <path>` | Render with a specific Chromium binary instead of auto-discovering one. |
+| `--no-open` | Do not open the exported file. |
+
+The plan can come from a file, `-`, or piped stdin; when the input is stdin there is no source name
+to derive an output from, so `--out` is required.
+
+## Chromium
+
+Export needs a Chromium to render the page. It is sourced without bundling a browser, so the CLI
+stays small:
+
+1. A system Chrome or Edge, if one is installed.
+2. Otherwise a `playwright`-installed Chromium.
+
+If neither is found, the command stops and tells you to run `npx playwright install chromium`. You
+can also point it at a specific binary with `--browser <path>` or the `VPLAN_CHROMIUM` environment
+variable.
+
+## Which output should I use?
+
+| Goal | Use |
+|------|-----|
+| Read, review, or interact with the plan | the HTML render (`vplan plan.mdx`) |
+| Get a sign-off decision | [review mode](/docs/review/) (`--review`) |
+| Send a link with nothing to install | [share](/docs/cli/#share) (`vplan share`) |
+| Attach a static file to a ticket, doc, or email | **export** (`vplan export`) |
+
+See the [CLI reference](/docs/cli/#export) for the command in the context of every other flag.

--- a/packages/app/src/pages/docs/index.md
+++ b/packages/app/src/pages/docs/index.md
@@ -8,8 +8,8 @@ description: What Visual Plan is and why it exists.
 
 Visual Plan renders an AI agent's implementation and design plans as polished, visual web pages
 instead of walls of text. A plan is written as MDX and compiled to a single self-contained HTML
-page with architecture diagrams, charts, file-change trees, option comparisons, callouts, and a
-numbered phase timeline.
+page with architecture diagrams, charts, metric cards, file-change trees, option comparisons,
+callouts, math, and a numbered phase timeline.
 
 It comes in two parts that work together:
 

--- a/packages/app/src/pages/docs/programmatic.md
+++ b/packages/app/src/pages/docs/programmatic.md
@@ -93,8 +93,10 @@ checkPlan(source: string): Promise<CheckIssue[]>
 ```
 
 Validates a plan's MDX source without rendering it, returning the issues (an empty array when the
-plan is valid). Each issue has a `line`, `column`, and `message`, the same checks the CLI's
-`vplan check` runs:
+plan is valid). Each issue has a `line`, `column`, and `message`. This runs the static checks
+(compile errors, component and enum validation, mermaid and math), the same ones `renderPlan` throws
+on. The author-time quality lint (wall of prose, wide diagram, over-long `Matrix` cell, and the like)
+runs only on the `vplan check` CLI command, not here:
 
 ```ts
 const issues = await checkPlan(source)

--- a/packages/app/src/pages/docs/review.mdx
+++ b/packages/app/src/pages/docs/review.mdx
@@ -1,0 +1,66 @@
+---
+layout: ../../layouts/Docs.astro
+title: Review mode
+description: Get a decision on a plan with an interactive review session.
+---
+
+import ReviewDemoEmbed from '../../components/ReviewDemoEmbed.astro'
+
+# Review mode
+
+Most of the time you render a plan just to read it. **Review mode** is for when you want a decision:
+it opens the plan as an interactive session where you comment on the plan, answer its open questions,
+and end with an explicit Approve, Deny, or Iterate. The CLI blocks on that verdict and hands it back
+to the agent, so the agent knows exactly when the plan is settled and what to change if it is not.
+
+```bash
+vplan render --review plan.mdx
+```
+
+The demo below is the real review layer running over a dummy plan, in a self-contained mode with no
+agent behind it. Hover a section to leave a comment, drag-select text to comment on an exact quote,
+type an answer into a question, then click a decision. Use **Reset** to start over.
+
+<ReviewDemoEmbed />
+
+## What you can do in a session
+
+- **Comment on any section.** Hover a phase, a callout, a diagram, or any block and a comment button
+  appears beside it. Each comment is tagged with the section so the agent can map it back to the MDX.
+- **Quote an exact span.** Select text inside the plan and comment on just that selection; the quote
+  rides along so the agent can find the precise wording you meant.
+- **Answer the open questions.** A `<Questions>` block is directly answerable in review mode: each
+  question gets an inline field, and your answers come back on their own channel, keyed to the
+  question, instead of being buried in a comment.
+- **Decide.** Approve, Deny, or Iterate from the bottom bar. Iterate needs at least one comment,
+  answer, or note, since "revise with feedback" needs feedback to act on.
+
+## What the agent gets back
+
+The CLI prints the decision, every comment, every answer, and an optional overall note to stdout,
+then exits with a decision-specific code:
+
+| Decision | Exit code | What it means |
+|----------|-----------|---------------|
+| Approve | `0` | Proceed with the plan as written. |
+| Deny | `1` | Stop and reconsider; do not proceed. |
+| Iterate | `2` | Revise the plan against the comments, then review again. |
+| Timeout | `3` | No decision before `--timeout` elapsed (default 15 minutes). |
+
+Closing the tab without deciding counts as Deny, and still carries any comments and answers you
+staged, so the agent always gets something to act on.
+
+## Iterating
+
+On an **Iterate**, the agent revises the same `.mdx` file in place and re-runs the review. Because a
+render snapshots the plan's source, the next session marks what changed since your last view with a
+git-gutter accent and an "N changed" summary, so you re-review only the delta. The agent passes
+`-i N` (`--iteration N`) so the bar shows which round you are on. This repeats until you Approve or
+Deny.
+
+```bash
+vplan render --review plan.mdx -i 2   # second review round, shows the diff since round 1
+```
+
+See the [CLI reference](/docs/cli/#review-mode) for the full flag list, including `--timeout`,
+`--diff`, and `--no-diff`.

--- a/packages/app/src/pages/review-demo-frame.astro
+++ b/packages/app/src/pages/review-demo-frame.astro
@@ -1,0 +1,22 @@
+---
+import { ReviewDemo } from '../components/ReviewDemo'
+import '@visualplan/runtime/theme.css'
+
+// The contents of the iframe embedded by /docs/review. It mounts the real review layer over a dummy
+// plan in demo mode (no CLI server), so the viewport-fixed review chrome stays scoped to this frame
+// instead of floating over the docs page. noindex: it is only meaningful inside that embed.
+---
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="robots" content="noindex" />
+    <title>Review mode demo</title>
+    <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
+  </head>
+  <body>
+    <ReviewDemo client:only="react" />
+  </body>
+</html>

--- a/packages/runtime/AGENTS.md
+++ b/packages/runtime/AGENTS.md
@@ -37,7 +37,11 @@ the root AGENTS.md for why Vite is configured without `@vitejs/plugin-react`.
   closes the connection drops and the CLI resolves Deny with that draft. This replaced an unload
   `sendBeacon`, which is dropped on a real close (it only survived navigation). A `beforeunload` prompt
   while undecided is now just a courtesy, the actual Deny no longer depends on the page sending
-  anything during unload.
+  anything during unload. **Demo mode** (`isReviewDemo()`, gated on an injected `__VP_REVIEW_DEMO__`,
+  used by the docs site's Review-mode page) keeps a session fully in-page: `decide` records the verdict
+  and stops instead of POSTing or calling `window.close()`, and the keepalive, draft, and `beforeunload`
+  effects are all skipped, so the embedded preview is safe to click through and reset. It is never set
+  by the CLI.
 - `components/DiffCues.tsx` renders iteration diff cues when the CLI injected `__VP_DIFF__` (any
   render/watch/review with a baseline, NOT review-gated). Always on: a change bar **flush to the left
   edge of the viewport** (`left: 0`, a dedicated lane clear of the content gutter so it never piles up

--- a/packages/runtime/components/review/ReviewLayer.tsx
+++ b/packages/runtime/components/review/ReviewLayer.tsx
@@ -4,7 +4,7 @@ import { useEffect, useRef, useState } from 'react'
 import { CommentModal } from './CommentModal.js'
 import { CommentsPopover } from './CommentsPopover.js'
 import { DecisionBar } from './DecisionBar.js'
-import { isReviewMode, openKeepalive, postDraft, postFeedback } from './feedback.js'
+import { isReviewDemo, isReviewMode, openKeepalive, postDraft, postFeedback } from './feedback.js'
 import { useQuestionAnswers } from './ReviewAnswers.js'
 import {
   type Section,
@@ -83,7 +83,9 @@ function ReviewSession() {
 
   // Hold a connection open so the server resolves Deny if the tab closes; the server, not an
   // unreliable unload beacon, detects the drop. Aborted on unmount (e.g. after a submitted decision).
+  // A demo has no server behind it, so there is nothing to keep alive.
   useEffect(() => {
+    if (isReviewDemo()) return
     const connection = openKeepalive()
     return () => connection.abort()
   }, [])
@@ -92,7 +94,7 @@ function ReviewSession() {
   // and answers. Build the payload inside the effect so it runs only when the state actually changes.
   const answersMap = questionAnswers?.answers
   useEffect(() => {
-    if (!submitted) {
+    if (!submitted && !isReviewDemo()) {
       const draft = comments.map(c => ({ section: c.quote ?? c.label, body: c.body }))
       postDraft({
         decision: 'deny',
@@ -108,6 +110,8 @@ function ReviewSession() {
   const submittedRef = useRef(submitted)
   submittedRef.current = submitted
   useEffect(() => {
+    // A demo is meant to be navigated away from and reset freely, so it never arms the prompt.
+    if (isReviewDemo()) return
     const onBeforeUnload = (event: BeforeUnloadEvent) => {
       if (!submittedRef.current) {
         event.preventDefault()
@@ -155,6 +159,13 @@ function ReviewSession() {
   }
 
   const decide = async (decision: ReviewDecision) => {
+    // A demo has no CLI behind it: record the decision in-page so the buttons are live, but never
+    // post to a server or close the tab. The embedding page's Reset returns to the live state.
+    if (isReviewDemo()) {
+      submittedRef.current = decision
+      setSubmitted(decision)
+      return
+    }
     const feedback: Feedback = {
       decision,
       comments: payloadComments,
@@ -177,7 +188,7 @@ function ReviewSession() {
     }
   }
 
-  if (submitted) return <SubmittedNotice decision={submitted} />
+  if (submitted) return <SubmittedNotice decision={submitted} demo={isReviewDemo()} />
 
   const viewingComments = viewing
     ? comments
@@ -285,13 +296,23 @@ function ReviewSession() {
   )
 }
 
-/** Replaces the decision bar once a verdict is sent, so the reviewer knows it is safe to close. */
-function SubmittedNotice({ decision }: { decision: ReviewDecision }) {
+/** Replaces the decision bar once a verdict is sent, so the reviewer knows it is safe to close. In a
+ * demo there is no agent waiting, so it explains what the decision would have done and points at Reset. */
+function SubmittedNotice({ decision, demo }: { decision: ReviewDecision; demo?: boolean }) {
   return (
     <div className='vp-review-done' data-decision={decision}>
       <IconCheck size={18} />
       <span>
-        Feedback submitted (<strong>{decision}</strong>). You can close this tab.
+        {demo ? (
+          <>
+            Demo: this would return <strong>{decision}</strong> to your agent. Press Reset to try
+            again.
+          </>
+        ) : (
+          <>
+            Feedback submitted (<strong>{decision}</strong>). You can close this tab.
+          </>
+        )}
       </span>
     </div>
   )

--- a/packages/runtime/components/review/feedback.ts
+++ b/packages/runtime/components/review/feedback.ts
@@ -10,6 +10,16 @@ export function isReviewMode(): boolean {
   return (globalThis as { __VP_REVIEW__?: boolean }).__VP_REVIEW__ === true
 }
 
+/**
+ * True when the page is a self-contained **demo** of review mode (the docs site), with no CLI server
+ * behind it. In demo mode the decision buttons are live but stay in-page: nothing is POSTed, the tab
+ * is never closed, and the beforeunload prompt and keepalive/draft server chatter are skipped. Set by
+ * the embedding page (`__VP_REVIEW_DEMO__`), mirroring how the CLI injects `__VP_REVIEW__`.
+ */
+export function isReviewDemo(): boolean {
+  return (globalThis as { __VP_REVIEW_DEMO__?: boolean }).__VP_REVIEW_DEMO__ === true
+}
+
 /** The plan revision number from the CLI's `--iteration` flag, or null when it was not passed. */
 export function reviewIteration(): number | null {
   const value = (globalThis as { __VP_REVIEW_ITERATION__?: number }).__VP_REVIEW_ITERATION__

--- a/skills/visual-plan/SKILL.md
+++ b/skills/visual-plan/SKILL.md
@@ -19,15 +19,13 @@ and tables, with prose only connecting the visuals, not carrying the plan itself
 
 ## Workflow
 
-1. Write the plan to a `.mdx` file. Start with a `# Title` heading (no frontmatter), then use
-   the components below. You never write `import` statements; the components are always in scope.
-2. Validate before showing the user: `vplan check <file>.mdx`. Fix any reported
-   `file:line:col` issues (it names the valid values for bad enums and flags unknown components).
-   Beyond syntax, `check` also runs an author-time **quality lint** that flags weak renders, an
-   all-prose plan, a wall-of-prose `Phase`, a wide left-to-right mermaid diagram, an over-long
-   `Matrix` cell, a `-- comment` on a `FileTree` move row, or a `Chart` with wildly mismatched
-   series scales (the Gotchas below). These surface as warnings and **a warning fails `check`**, so
-   fix them too; they are not advisory.
+1. Write the plan to a `.mdx` file, starting with a single `# Title` heading (it becomes the plan
+   title; no frontmatter). Then use the components below; you never write `import` statements, they
+   are always in scope.
+2. Validate before showing the user: `vplan check <file>.mdx`. Fix every reported `file:line:col`
+   issue (it names valid enum values and flags unknown components). `check` also runs a **quality
+   lint** that flags weak renders (the enforced Gotchas below); its warnings fail `check`, so fix
+   them too.
 3. **Present the plan with `vplan render --review <file>.mdx`. This is the default way to deliver a
    plan, not a special mode reserved for sign-off.** It opens the plan with a feedback layer where the
    user comments on whole sections or on selected text, **answers any `<Questions>` directly** (each
@@ -46,21 +44,14 @@ and tables, with prose only connecting the visuals, not carrying the plan itself
      `--no-diff` to suppress diffing (e.g. a clean first look).
    - **Deny** -> stop and reconsider; do not proceed.
 
-   **Default to `--review` for every non-trivial plan; treat it as the standard way to show a plan,
-   not an opt-in.** It is the loop for presenting and refining a plan together: the targeted comments
-   drive sharper revisions than back-and-forth chat, the user answers your open `<Questions>` in
-   place, and the loop ends in an explicit Approve so you know when it is settled. Reach for the plain
-   render in step 4 only in the narrow cases below.
-4. **Plain render is the fallback, for when the user only wants to look at a plan, not shape or decide
-   on it.** `vplan <file>.mdx` writes a self-contained `<file>.plan.html` next to the source and
-   **opens it in the browser** (`--out <path>` sets the output location). While iterating visually,
-   `vplan --watch <file>.mdx` starts a live-reloading dev server so edits show up without a re-run (a
-   long-running foreground server: run it in the background; it serves a local URL, writes no file,
-   and stops on Ctrl+C). The iteration diff shows on a plain render too, not just `--review`.
-
-   **Do not pass `--no-open`.** A plan the user never sees defeats the tool. Only suppress the browser
-   when the user has explicitly asked for the HTML file alone (e.g. for CI or a headless run); a plan
-   being generated for the user to read is never that case.
+   **Default to `--review` for every non-trivial plan.** Targeted comments and in-place `<Questions>`
+   answers drive sharper revisions than back-and-forth chat, and the loop ends in an explicit Approve
+   so you know it is settled. Use the plain render (step 4) only when the user just wants to look.
+4. **Plain render is the fallback, for when the user only wants to look, not shape or decide.**
+   `vplan <file>.mdx` writes `<file>.plan.html` next to the source and opens it (`--out <path>` sets
+   the location). While iterating visually, `vplan --watch <file>.mdx` starts a live-reloading dev
+   server (a long-running foreground server: run it in the background; it writes no file and stops on
+   Ctrl+C). The iteration diff shows on a plain render too, not just `--review`.
 5. **To export a plan as a static file**, run `vplan export <pdf|jpg> <file>.mdx`. It builds the
    same self-contained page and captures it headless: `pdf` prints a paginated A4 document, `jpg` a
    full-page hi-dpi screenshot. Output defaults to `<file>.pdf` / `<file>.jpg` (override with
@@ -70,14 +61,6 @@ and tables, with prose only connecting the visuals, not carrying the plan itself
    the interactive HTML page.
 
 Run `vplan components` anytime for the exact prop signatures.
-
-## Title
-
-Begin the file with a single `# Heading`; it becomes the plan title. There is no frontmatter.
-
-```mdx
-# Add rate limiting to the API
-```
 
 ## Components
 
@@ -114,20 +97,13 @@ brace errors that break a render.
   </FileTree>
   ```
 - `<Chart type="bar|line|area|scatter|radar|gauge|funnel|treemap|pie" title="...">` —
-  estimates/metrics. For a single series, one bullet per point, `- <label>: <value>` (value is a
-  number). For multiple series (`bar`/`line`/`area`/`radar`), write a table whose header is
-  `category | series1 | series2`; the header cells after the first name the series (they become the
-  legend), and the first column is the category axis. The new types take these shapes:
-  - `area` — like `line`: a single-series list or a multi-series table.
-  - `scatter` — a table with exactly **two** value columns, read as x and y: `| point | x | y |`.
-  - `radar` — a multi-series options-by-dimensions table, same shape as a multi-series `bar`.
-  - `gauge` — a single-series list of values on a 0-100 scale.
-  - `funnel` — a single-series list of descending stage values.
-  - `treemap` — a single-series list of `- <label>: <value>`.
-
-  `pie`/`gauge`/`funnel`/`treemap` are always single-series, so use the list form (a table is
-  rejected). Add the `stacked` attribute to a multi-series `bar` or `area`
-  (`<Chart type="bar" stacked>`) to stack the series instead of grouping them.
+  estimates/metrics. Single series: one bullet per point, `- <label>: <value>` (a number).
+  Multi-series (`bar`/`line`/`area`/`radar`): a table whose header is `category | series1 | series2`
+  (cells after the first name the series and become the legend; the first column is the category
+  axis). Specifics: `scatter` is a table with exactly **two** value columns read as x and y
+  (`| point | x | y |`); `pie`/`gauge`/`funnel`/`treemap` are always single-series, list form only (a
+  table is rejected), with `gauge` on a 0-100 scale and `funnel` descending. Add `stacked` to a
+  multi-series `bar`/`area` (`<Chart type="bar" stacked>`) to stack rather than group.
 
   ```mdx
   <Chart type="bar" title="Effort (days)">
@@ -140,10 +116,6 @@ brace errors that break a render.
   |-------|-----|-----|
   | Auth  | 12  | 30  |
   | DB    | 40  | 120 |
-  </Chart>
-
-  <Chart type="gauge" title="Error budget remaining (%)">
-  - Remaining: 78
   </Chart>
   ```
 - `<Compare>` — weigh approaches side by side as pros/cons cards. Each option is a `## Name`
@@ -240,9 +212,8 @@ it in paragraphs. Prose is the connective tissue between visuals, never the subs
 - **Right-size what you show.** A large effort opens with a diagram and several phases; a
   two-or-three-file change may need only a short `<FileTree>` and a `<Checklist>`. Do not add a
   diagram or phase that carries no information: an empty 2-node flowchart shows nothing and is worse
-  than one plain sentence. Show when there is structure to show; otherwise a tight sentence is fine.
-  The same applies to `<Stat>`: reach for it only when the plan has genuinely meaningful headline
-  numbers, not as a default header on every plan.
+  than one plain sentence. Show when there is structure to show; otherwise a tight sentence is fine
+  (this applies to `<Stat>` too, as its own entry notes).
 
 ## Composing a plan
 
@@ -256,11 +227,8 @@ it in paragraphs. Prose is the connective tissue between visuals, never the subs
 
 ## Rules
 
-- **Always `vplan check` before presenting, and fix every reported `file:line:col` issue first.**
-  The user should never see a broken render.
-- **Let the plan open; never pass `--no-open` for a user-facing plan.** The point of a visual plan
-  is that the user sees it. Use the plain render (which opens the page) to deliver, or `--watch`
-  while iterating. Reserve `--no-open` for an explicit headless/CI request only.
+- **Never pass `--no-open` for a user-facing plan.** The point is that the user sees it; the plain
+  render and `--watch` open automatically. Reserve `--no-open` for an explicit headless/CI request.
 - **No images or external assets.** The page is a single self-contained file, so a markdown image
   (`![](url)`) or any external asset cannot be embedded, and `check` rejects markdown images. Use a
   ` ```mermaid ` diagram for anything visual, or describe it in text.

--- a/skills/visual-plan/SKILL.md
+++ b/skills/visual-plan/SKILL.md
@@ -28,22 +28,10 @@ and tables, with prose only connecting the visuals, not carrying the plan itself
    `Matrix` cell, a `-- comment` on a `FileTree` move row, or a `Chart` with wildly mismatched
    series scales (the Gotchas below). These surface as warnings and **a warning fails `check`**, so
    fix them too; they are not advisory.
-3. Render: `vplan <file>.mdx` writes a self-contained `<file>.plan.html` next to the source and
-   **opens it in the browser**. Opening the rendered plan is the whole point of this tool, so let
-   it open by default. While you are iterating on the plan with the user, prefer
-   `vplan --watch <file>.mdx`: it starts a live-reloading dev server so your edits show up in the
-   open page without a re-run. `--watch` is a long-running foreground server (run it in the
-   background; it serves a local URL, writes no file, and only stops on Ctrl+C), so for a final
-   one-shot HTML output use the plain render, not `--watch`. `--out <path>` sets the output
-   location.
-
-   **Do not pass `--no-open`.** A plan the user never sees defeats the tool. Only suppress the
-   browser when the user has explicitly asked for the HTML file alone (e.g. for CI or a headless
-   run); a plan being generated for the user to read is never that case.
-4. **To get the user's decision on the plan** (a sign-off, not just a viewing), render with
-   `vplan render --review <file>.mdx`. It opens the plan with a feedback layer where the user comments
-   on whole sections or on selected text, **answers any `<Questions>` directly** (each question
-   becomes an inline answer field, printed back as `Answer to "<question>":`), then clicks
+3. **Present the plan with `vplan render --review <file>.mdx`. This is the default way to deliver a
+   plan, not a special mode reserved for sign-off.** It opens the plan with a feedback layer where the
+   user comments on whole sections or on selected text, **answers any `<Questions>` directly** (each
+   question becomes an inline answer field, printed back as `Answer to "<question>":`), then clicks
    Approve / Deny / Iterate. It **blocks** until they submit, prints the decision, comments, and
    answers to stdout, and exits: approve 0, deny 1, iterate 2, timeout 3 (`--timeout`, default 15m;
    closing the tab counts as deny). It is a long-running foreground server, so run it in the
@@ -55,15 +43,24 @@ and tables, with prose only connecting the visuals, not carrying the plan itself
      the file path), so the next render automatically marks what changed since the last view with a
      subtle git-gutter accent and a "N changed" summary, letting the user re-review only the delta.
      Pass `--diff <baseline.mdx>` to diff against an explicit file instead of the snapshot, or
-     `--no-diff` to suppress diffing (e.g. a clean first look). The diff also shows on a plain
-     `vplan render`, not just `--review`.
+     `--no-diff` to suppress diffing (e.g. a clean first look).
    - **Deny** -> stop and reconsider; do not proceed.
 
-   **Strongly prefer `--review` as the way to iterate on any non-trivial plan with the user.** It is
-   the default loop for refining a plan together: the targeted comments drive sharper revisions than
-   back-and-forth chat, and the loop ends in an explicit Approve so you know when it is settled. Fall
-   back to a plain render (or `--watch`) only when the user just wants to look at the plan, not shape
-   or decide on it.
+   **Default to `--review` for every non-trivial plan; treat it as the standard way to show a plan,
+   not an opt-in.** It is the loop for presenting and refining a plan together: the targeted comments
+   drive sharper revisions than back-and-forth chat, the user answers your open `<Questions>` in
+   place, and the loop ends in an explicit Approve so you know when it is settled. Reach for the plain
+   render in step 4 only in the narrow cases below.
+4. **Plain render is the fallback, for when the user only wants to look at a plan, not shape or decide
+   on it.** `vplan <file>.mdx` writes a self-contained `<file>.plan.html` next to the source and
+   **opens it in the browser** (`--out <path>` sets the output location). While iterating visually,
+   `vplan --watch <file>.mdx` starts a live-reloading dev server so edits show up without a re-run (a
+   long-running foreground server: run it in the background; it serves a local URL, writes no file,
+   and stops on Ctrl+C). The iteration diff shows on a plain render too, not just `--review`.
+
+   **Do not pass `--no-open`.** A plan the user never sees defeats the tool. Only suppress the browser
+   when the user has explicitly asked for the HTML file alone (e.g. for CI or a headless run); a plan
+   being generated for the user to read is never that case.
 5. **To export a plan as a static file**, run `vplan export <pdf|jpg> <file>.mdx`. It builds the
    same self-contained page and captures it headless: `pdf` prints a paginated A4 document, `jpg` a
    full-page hi-dpi screenshot. Output defaults to `<file>.pdf` / `<file>.jpg` (override with

--- a/skills/visual-plan/SKILL.md
+++ b/skills/visual-plan/SKILL.md
@@ -23,6 +23,11 @@ and tables, with prose only connecting the visuals, not carrying the plan itself
    the components below. You never write `import` statements; the components are always in scope.
 2. Validate before showing the user: `vplan check <file>.mdx`. Fix any reported
    `file:line:col` issues (it names the valid values for bad enums and flags unknown components).
+   Beyond syntax, `check` also runs an author-time **quality lint** that flags weak renders, an
+   all-prose plan, a wall-of-prose `Phase`, a wide left-to-right mermaid diagram, an over-long
+   `Matrix` cell, a `-- comment` on a `FileTree` move row, or a `Chart` with wildly mismatched
+   series scales (the Gotchas below). These surface as warnings and **a warning fails `check`**, so
+   fix them too; they are not advisory.
 3. Render: `vplan <file>.mdx` writes a self-contained `<file>.plan.html` next to the source and
    **opens it in the browser**. Opening the rendered plan is the whole point of this tool, so let
    it open by default. While you are iterating on the plan with the user, prefer
@@ -264,6 +269,10 @@ it in paragraphs. Prose is the connective tissue between visuals, never the subs
   ` ```mermaid ` diagram for anything visual, or describe it in text.
 
 ## Gotchas
+
+Several of these (a wall-of-prose phase, a wide LR mermaid diagram, an over-long `Matrix` cell, a
+commented `FileTree` move row, a wildly-scaled `Chart`) are now enforced by the `check` quality lint
+and will fail it, so they are hard rules, not just style advice.
 
 - **`<`, `{`, and `}` are MDX syntax in prose.** A bare `<Thing>` or `{value}` can break the render.
   Wrap literal angle brackets, braces, generics (`List<T>`), or tag-like text in backticks or a code


### PR DESCRIPTION
## What

Documentation and examples pass covering the features shipped in the last few releases (PDF/JPG export, interactive review mode, iteration diffing, the author-time quality lint, `share`, and `config`), plus a new interactive Review mode docs page and seven new example plans. No product behavior change beyond a small, gated demo mode used only by the docs site.

## How

- Brought the README, the `visual-plan` skill, and the docs site up to date with the new commands and flags (new Exporting and Review mode pages; CLI reference and programmatic docs corrected). Reworked the skill so `--review` is the default workflow, then condensed it (4856 -> 4404 tokens) by removing duplication.
- New interactive Review mode demo: the real runtime review layer over a dummy plan, embedded in an iframe so its viewport-fixed chrome stays contained. A gated `__VP_REVIEW_DEMO__` global keeps decisions in-page (no server POST, no tab close, no beforeunload prompt) and is never set by the CLI. Added `vite.resolve.dedupe` so the workspace-source runtime hydrates in the dev server.
- Seven varied example plans (security, ops, ML, frontend, mobile, data engineering, design) that collectively exercise the full vocabulary: sequence/class/ER diagrams, math, every chart type plus stacking, Stat, all callout types, and FileTree move/delete/directory rows.

## Verification

Run at the repo root:

- `pnpm lint` -> 0 errors (7 pre-existing CSS-specificity warnings)
- `biome format .` -> no changes
- `pnpm typecheck` -> passes
- `pnpm build` -> succeeds
- `pnpm test` -> 358 passed (29 files)

Also: `vplan check` and render pass on all 10 example plans (0 errors/warnings, including the quality lint), the full app build renders every example, and headless-browser checks confirm the review demo and the chart/diagram/math-heavy examples paint with no console errors.

- [x] `pnpm lint` passes
- [x] `pnpm format` reports no changes (`biome format .`)
- [x] `pnpm typecheck` passes
- [x] `pnpm build` succeeds
- [x] `pnpm test` passes

## Notes

- The rendered `public/examples/*.html` are git-ignored and regenerated on every build (and in CI before deploy), so only the `.mdx` sources are committed.
- No breaking changes.
