### PR TITLE
feat: Review Queue (review multiple in-progress plans in one tab)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,6 +38,10 @@ polished, self-contained HTML page, so an AI agent can present plans as scannabl
   disconnects, denies every queued plan and exits when the tab closes, and lingers `daemonTimeout`
   (config, default 15m) after the queue empties so a re-plan reuses the warm tab. See
   `packages/cli/AGENTS.md` (daemon) and `packages/runtime/AGENTS.md` (shell).
+- `vplan open` opens the queue tab on its own (`ensureDaemon` + open the shell URL), starting the
+  daemon if needed and enqueuing nothing; it does not block. Use it to open or re-open the queue
+  without a plan, so later reviews join the tab. `--no-open` just starts the daemon and prints the
+  URL (e.g. to warm the daemon headlessly).
 - Iteration diffing: a render of a plan *file* snapshots its source (`~/.vplan/snapshots`, keyed by
   the absolute path), and the next render of that path diffs the new source against the snapshot,
   injecting `__VP_DIFF__` so the runtime marks added/edited sections git-gutter style. `--diff <path>`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,11 +6,15 @@ polished, self-contained HTML page, so an AI agent can present plans as scannabl
 
 ## What it does
 
-- `vplan <file.mdx>` (alias `render`) compiles a plan to a single self-contained
-  `<file>.plan.html` and opens it. Input is a file, `-`, or piped stdin; `--stdout` writes the HTML
-  to stdout instead (so it composes in a pipeline). `--watch` starts a hot-reloading dev server
-  instead (on `--port`, default 9140, auto-incrementing if taken; needs a real file, not stdin);
-  `--out <path>` sets the output; `--no-open` suppresses the browser.
+- `vplan <file.mdx>` (alias `render`) opens the plan in an **interactive review by default** (see
+  the review bullet below). A static output flag opts out into a one-shot artifact: `--static`
+  compiles a single self-contained `<file>.plan.html` and opens it (the pre-review default);
+  `--stdout` writes the HTML to stdout (so it composes in a pipeline); `--out <path>` sets a file
+  path; `--watch` starts a hot-reloading dev server (on `--port`, default 9140, auto-incrementing if
+  taken; needs a real file, not stdin). `--no-open` suppresses the browser. The mode is decided by
+  `rendersReview()`: review unless one of `--static`/`--watch`/`--stdout`/`--out` is set. `--review`
+  is kept as an explicit, now-redundant selector and conflicts with the static flags. Input is a
+  file, `-`, or piped stdin.
 - `vplan check <file.mdx>` validates a plan without rendering (the self-correction
   loop): MDX compile errors plus static component checks, printed as `file:line:col`.
 - `vplan share <file.mdx|->` prints a stateless `visualplan.dev/view?data=...` link encoding the

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,7 +20,20 @@ polished, self-contained HTML page, so an AI agent can present plans as scannabl
   comments on sections (or selected text) and clicks Approve / Deny / Iterate, and the CLI blocks
   until then, prints the feedback to stdout, and exits (approve 0, deny 1, iterate 2, timeout 3).
   `--timeout` (default 15m) bounds the wait; a closed tab resolves as Deny. `-i/--iteration N` shows
-  the revision number in the review bar (the agent increments it each re-review).
+  the revision number in the review bar (the agent increments it each re-review). By default the
+  review joins a shared **Review Queue daemon** (see below) so plans from many sessions land in one
+  tab; `--no-daemon` forces the legacy one-shot server (one tab per review, no queue).
+- `vplan review <files...>` queues several plans for review at once and prints each verdict: it
+  enqueues every file into the shared daemon, opens the queue tab (if not already open), and streams
+  each plan's feedback the instant it is decided (exit 0 iff all approved); `--json` prints one
+  record keyed by file path instead. The **Review Queue daemon** is a per-user background process the
+  first `--review`/`review` auto-starts (detached; an atomic `~/.vplan/review-daemon.json` lockfile
+  mutex collapses simultaneous launches to one). It owns one browser tab with a left sidebar of
+  queued plans (title + origin-dir basename + status), serves each plan as a same-origin review-mode
+  iframe, routes each plan's verdict back to the caller waiting on it, drops a plan whose caller
+  disconnects, denies every queued plan and exits when the tab closes, and lingers `daemonTimeout`
+  (config, default 15m) after the queue empties so a re-plan reuses the warm tab. See
+  `packages/cli/AGENTS.md` (daemon) and `packages/runtime/AGENTS.md` (shell).
 - Iteration diffing: a render of a plan *file* snapshots its source (`~/.vplan/snapshots`, keyed by
   the absolute path), and the next render of that path diffs the new source against the snapshot,
   injecting `__VP_DIFF__` so the runtime marks added/edited sections git-gutter style. `--diff <path>`
@@ -36,8 +49,9 @@ polished, self-contained HTML page, so an AI agent can present plans as scannabl
 - A programmatic API (`import { renderPlan, checkPlan } from 'vplan'`) renders/validates a plan from
   an in-memory MDX string, with a named export per catalog entry. See `packages/cli/src/api.ts`.
 - A persistent CLI config at `~/.vplan/config.json` (`packages/cli/src/config.ts`) sets the default
-  `theme` (`light`|`dark`|`system`) baked into a rendered plan; the plan's in-page cog overrides it
-  per-view via `localStorage`. `vplan config [get|set|path]` views and edits it.
+  `theme` (`light`|`dark`|`system`) baked into a rendered plan (the plan's in-page cog overrides it
+  per-view via `localStorage`) and `daemonTimeout` (the Review Queue daemon's idle TTL in ms, default
+  15m). `vplan config [get|set|path]` views and edits it.
 
 Plans use a fixed, tiny component vocabulary (`Phase`, `FileTree`, `Chart`, `Compare`, `Matrix`,
 `Callout`, `Questions`, `Checklist`, and ` ```mermaid ` / ` ```math ` fences) with no imports — the
@@ -142,6 +156,16 @@ A release is cut by creating a GitHub release; the tag is the published version 
 
 ## Key Decisions
 
+- 2026-06-28: The Review Queue is a single per-user **detached daemon process** (not a server hosted
+  inside the first caller). Why: a caller must return its own verdict to its agent promptly while the
+  queue keeps serving other sessions, which a caller-hosted server cannot do. One shared machine-wide
+  queue (the sidebar shows each plan's origin-dir basename to disambiguate projects), per the
+  approved plan; a `~/.vplan/review-daemon.json` `wx` lockfile is the start-race mutex.
+- 2026-06-28: Each queued plan keeps its review chrome **inside its own same-origin iframe** rather
+  than lifting commenting into the parent shell. Why: the plans are the user's own local plans (no
+  untrusted-input threat, unlike the docs site's sandboxed `/plan-frame`), so same-origin reuses the
+  existing `ReviewLayer` whole and avoids a cross-frame selection bridge. The shell owns only the
+  sidebar, navigation, and the `/__vp_events` SSE that doubles as the daemon's tab-close kill switch.
 - 2026-06-24: `vplan export` renders headless via `playwright-core` (a prod dep) and sources Chromium
   system-first, never bundling a browser binary. Why: a bundled `playwright` would add a huge
   postinstall to a CLI whose whole point is a small self-contained package; reusing a present Chrome

--- a/README.md
+++ b/README.md
@@ -39,9 +39,9 @@ npx vplan plan.mdx
 ## Usage
 
 ```bash
-vplan plan.mdx              # render to plan.plan.html and open it
+vplan plan.mdx              # open an interactive review session (the default), blocks for sign-off
+vplan plan.mdx --static     # render to plan.plan.html and open it, no review
 vplan plan.mdx --watch      # live-reloading dev server while you edit
-vplan plan.mdx --review     # interactive review session, blocks for sign-off
 vplan review a.mdx b.mdx    # queue several plans, review them in one tab, stream verdicts
 vplan check plan.mdx        # validate a plan (syntax + quality lint) without rendering
 vplan export pdf plan.mdx   # render to a static PDF or JPG via headless Chromium
@@ -91,10 +91,10 @@ flowchart LR
 
 ## Review mode
 
-To get a decision on a plan, not just show it, render with `--review`:
+Rendering a plan opens an interactive review by default, so you get a decision, not just a view:
 
 ```bash
-vplan render --review plan.mdx
+vplan plan.mdx          # interactive review (default); --static renders without it
 ```
 
 This opens the plan as an interactive session: the reviewer comments on any section, answers the

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ npx vplan plan.mdx
 vplan plan.mdx              # render to plan.plan.html and open it
 vplan plan.mdx --watch      # live-reloading dev server while you edit
 vplan plan.mdx --review     # interactive review session, blocks for sign-off
+vplan review a.mdx b.mdx    # queue several plans, review them in one tab, stream verdicts
 vplan check plan.mdx        # validate a plan (syntax + quality lint) without rendering
 vplan export pdf plan.mdx   # render to a static PDF or JPG via headless Chromium
 vplan share plan.mdx        # print a shareable visualplan.dev link
@@ -102,6 +103,17 @@ decide, prints the feedback to stdout, and exits with a decision-specific code (
 `1`, Iterate `2`), so an agent knows when the plan is settled and what to revise if it is not. On an
 Iterate, the next render diffs the revision against the last view so the reviewer re-reviews only the
 delta.
+
+### Review Queue
+
+When you have several plans in flight, queue them instead of reviewing one at a time. The first
+`--review` (or `vplan review a.mdx b.mdx ...`) starts a small background daemon that owns one browser
+tab with a left sidebar of every queued plan; reviews launched from any other session join the same
+tab. You clear the queue like an inbox: decide a plan and it is checked off and the next one opens.
+Each plan's verdict returns to whichever session queued it. Closing the tab denies everything still
+pending; the daemon lingers briefly (the `daemonTimeout` setting, default 15m) after the queue empties
+so a quick re-plan reuses the warm tab. Pass `--no-daemon` to opt out and use a one-shot tab per
+review.
 
 See the [Review mode guide](https://visualplan.dev/docs/review/) for a live, interactive demo.
 

--- a/packages/cli/AGENTS.md
+++ b/packages/cli/AGENTS.md
@@ -48,6 +48,29 @@ programmatic Node API at `dist/api.js` (the package's `import` entry, `exports["
   are added), and `GET /__vp_alive` (a connection the page holds open; its drop resolves Deny with the
   latest draft). Detecting that socket close server-side is what makes a real tab close reliable,
   where an unload-time `sendBeacon` is not (verified: the beacon survives navigation but not a close).
+- Review Queue daemon (`src/review/daemon.ts`, default path for `--review` and the `review` command;
+  `--no-daemon` keeps the one-shot `session.ts` path). One machine-wide, long-lived `http.createServer`
+  (NOT Vite) holding an in-memory queue: each enqueued plan is built once via `compile.ts buildHtml`
+  with `review: { planId, iteration }` and served from `/plan/<id>`; a browser "shell" lists the queue.
+  The HTTP/SSE contract is FROZEN (the runtime shell depends on exact endpoint/field/frame shapes):
+  `GET /__vp_ping` (liveness), `GET /` (shell, cached), `GET /plan/<id>`, `POST /__vp_enqueue`
+  (-> `{ id, shellConnected }`; cancel idle timer BEFORE the slow build or a short idleMs shuts the
+  daemon mid-enqueue), `GET /__vp_verdict?id` (long-held; caller disconnect drops the plan),
+  `POST /__vp_feedback` + `POST /__vp_draft` (both validated by `feedbackSchema`, routed by `planId`;
+  feedback is idempotent once settled), `GET /__vp_events` (SSE `event: queue` = `QueueEntry[]`; the
+  shell's liveness signal). Lifecycle: idle TTL fires when no `pending` plans remain (a new enqueue
+  cancels it); the LAST events client closing starts a 1500ms grace (survives a reload), after which
+  all still-pending plans are denied (with their draft) and the daemon shuts down. One idempotent
+  `shutdown()` ends every held connection so `close()` cannot hang on an SSE (the same regression the
+  one-shot server guards). `lockfile.ts` is discovery + the mutex: `~/.vplan/review-daemon.json`
+  (`{ port, pid }`), claimed via `writeFile`'s `wx` flag (atomic create-or-fail collapses racing
+  daemons), `isDaemonAlive` pings. `ensure-daemon.ts` reuses a live daemon or spawns the detached
+  `__review-daemon` process (`cli-entry.ts` derives the entry from `process.argv[1]`) and polls.
+  `commands/review-daemon.ts` owns the mutex (start -> `wx` claim; lost race or stale lock handled);
+  `commands/review.ts` is the `review <files...>` orchestration (stream each verdict as it resolves,
+  exit 0 iff all approved, `--json` for one keyed object). `client.ts` is `enqueuePlan`/`awaitVerdict`.
+  All of these take injectable seams so the routing/lifecycle is unit-tested in-process with a fake
+  shell and short idleMs; the real-spawn path has ONE `VP_DAEMON_E2E`-gated test.
 - `src/build/snapshots.ts` — the per-plan snapshot cache (`~/.vplan/snapshots`, keyed by a hash of
   the plan's absolute path) powering automatic iteration diffing. `render` reads a plan path's
   snapshot as the diff baseline, then overwrites it with the current source ("changes since you last

--- a/packages/cli/src/build/compile.ts
+++ b/packages/cli/src/build/compile.ts
@@ -297,6 +297,11 @@ export interface BuildOptions {
   /** A previous version of the plan's MDX source. When set, the section diff against it is injected
    * as `__VP_DIFF__` so the runtime marks added/edited sections. Omitted = no diff (the default). */
   baseline?: string
+  /** Bake the page into review mode (`__VP_REVIEW__`), so it mounts the feedback layer with no
+   * server behind it but the daemon serving it. `planId` tags the feedback so the Review Queue
+   * daemon can route the verdict; `iteration` shows the revision number in the bar. Omitted = a
+   * plain, non-review render (the default). Mirrors `reviewPlugin` on the dev-server path. */
+  review?: { planId?: string; iteration?: number }
 }
 
 /**
@@ -343,6 +348,8 @@ function baseConfig(paths: RuntimePaths, input: PlanInput, options: BuildOptions
   if (enableSharing) plugins.push(planSharePlugin(readSource))
   // Diff cues render only when a baseline is given, so omitting the plugin leaves a plain render.
   if (options.baseline !== undefined) plugins.push(planDiffPlugin(readSource, options.baseline))
+  // Review mode mounts the feedback layer; the plan iframe in the Review Queue is built this way.
+  if (options.review !== undefined) plugins.push(reviewInjectPlugin(options.review))
   return {
     root: paths.runtimeDir,
     configFile: false,
@@ -445,6 +452,42 @@ function readRequestBody(
     req.on('end', () => resolve(raw))
     req.on('error', reject)
   })
+}
+
+/**
+ * Inject the review-mode globals into a one-shot `buildHtml` page (the dev-server path uses
+ * `reviewPlugin` instead). `__VP_REVIEW__` mounts the feedback layer; `__VP_REVIEW_PLAN_ID__` tags
+ * every feedback/draft POST so the Review Queue daemon routes the verdict to the right caller; the
+ * optional iteration shows the revision number in the bar. `planId` and `iteration` are CLI-side
+ * values (a generated id, a validated number), so they are safe to inline as JSON.
+ */
+function reviewInjectPlugin(review: { planId?: string; iteration?: number }): Plugin {
+  return {
+    name: 'visualplan:review-inject',
+    transformIndexHtml: {
+      order: 'pre',
+      handler() {
+        const tags = [
+          { tag: 'script', injectTo: 'head' as const, children: 'globalThis.__VP_REVIEW__=true' },
+        ]
+        if (review.iteration !== undefined) {
+          tags.push({
+            tag: 'script',
+            injectTo: 'head' as const,
+            children: `globalThis.__VP_REVIEW_ITERATION__=${review.iteration}`,
+          })
+        }
+        if (review.planId !== undefined) {
+          tags.push({
+            tag: 'script',
+            injectTo: 'head' as const,
+            children: `globalThis.__VP_REVIEW_PLAN_ID__=${JSON.stringify(review.planId)}`,
+          })
+        }
+        return tags
+      },
+    },
+  }
 }
 
 /** Mutable holder for the payload to resolve with if the tab closes; kept current by `/__vp_draft`. */

--- a/packages/cli/src/build/queue-shell.ts
+++ b/packages/cli/src/build/queue-shell.ts
@@ -1,3 +1,37 @@
+import { existsSync } from 'node:fs'
+import { mkdtemp, readFile, rm } from 'node:fs/promises'
+import { createRequire } from 'node:module'
+import { tmpdir } from 'node:os'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { build } from 'vite'
+import { viteSingleFile } from 'vite-plugin-singlefile'
+
+const require = createRequire(import.meta.url)
+
+/**
+ * Locate the runtime source directory in both layouts (mirrors `findRuntimePaths` in compile.ts, but
+ * the shell needs only the runtime dir, not the core entry: it has no MDX plan to compile):
+ * - Published: the runtime is vendored next to dist/ (`<pkg>/runtime`, with `core/index.ts` beside it).
+ * - Dev (workspace): they are sibling packages, resolved via node module resolution.
+ * The presence of a sibling `core/index.ts` distinguishes the true vendored layout from the
+ * monorepo's own `packages/runtime` (whose core lives at `core/src/index.ts`).
+ */
+function findRuntimeDir(): { runtimeDir: string; coreEntry: string } {
+  let dir = dirname(fileURLToPath(import.meta.url))
+  for (let depth = 0; depth < 6; depth++) {
+    const runtimeDir = join(dir, 'runtime')
+    const coreEntry = join(dir, 'core', 'index.ts')
+    if (existsSync(join(runtimeDir, 'queue.html')) && existsSync(coreEntry)) {
+      return { runtimeDir, coreEntry }
+    }
+    dir = dirname(dir)
+  }
+  const runtimeDir = dirname(require.resolve('@visualplan/runtime/package.json'))
+  const coreDir = dirname(require.resolve('@visualplan/core/package.json'))
+  return { runtimeDir, coreEntry: join(coreDir, 'src', 'index.ts') }
+}
+
 /**
  * Builds the Review Queue **shell**: the single self-contained page the daemon serves at `/`. The
  * shell renders the left sidebar of queued plans and hosts the active plan in a same-origin iframe
@@ -5,41 +39,42 @@
  * `/__vp_events` SSE open, which doubles as the liveness signal (closing the tab tears the daemon
  * down).
  *
- * This is the integration seam between the daemon (which calls this to serve `/`) and the runtime
- * shell UI. The body below is a placeholder so the daemon is serveable and testable before the real
- * React shell lands; the runtime work replaces it with a Vite single-file build of the runtime
- * `queue.html` entry (analogous to `buildHtml`). The signature is the contract and must not change:
- * a zero-arg async function returning one self-contained HTML string.
+ * A Vite single-file build of the runtime `queue.html` entry, analogous to `buildHtml` in compile.ts
+ * but with NO plan: there is no `virtual:plan` (the shell renders only React chrome plus the iframes),
+ * so the plan-only plugins (virtual-plan, share, diff, review) are omitted. The same single-file
+ * plugin, esbuild automatic JSX, and `@visualplan/core` / react alias setup keep the bundle
+ * self-contained (inline JS/CSS) and `@vitejs/plugin-react`-free, per project rules. The signature is
+ * the contract and must not change: a zero-arg async function returning one self-contained HTML string.
  */
 export async function buildQueueShell(): Promise<string> {
-  // Placeholder shell: lists the queue from the SSE stream so the backend is exercisable end to end
-  // (curl/tests) before the styled React shell exists. Replaced by the real build.
-  return `<!doctype html>
-<html lang="en">
-<head><meta charset="utf-8"><title>Review Queue</title></head>
-<body>
-<h1>Review Queue</h1>
-<ul id="queue"></ul>
-<iframe id="plan" title="active plan" style="width:100%;height:80vh;border:0"></iframe>
-<script type="module">
-const list = document.getElementById('queue')
-const frame = document.getElementById('plan')
-const es = new EventSource('/__vp_events')
-es.addEventListener('queue', e => {
-  const entries = JSON.parse(e.data)
-  list.innerHTML = ''
-  for (const entry of entries) {
-    const li = document.createElement('li')
-    li.textContent = entry.dir + ' / ' + entry.title + ' [' + entry.status + ']'
-    li.style.cursor = 'pointer'
-    li.onclick = () => { frame.src = '/plan/' + entry.id }
-    list.appendChild(li)
+  const { runtimeDir, coreEntry } = findRuntimeDir()
+  const outDir = await mkdtemp(join(tmpdir(), 'visualplan-queue-'))
+  try {
+    await build({
+      root: runtimeDir,
+      configFile: false,
+      logLevel: 'silent',
+      resolve: {
+        alias: {
+          '@visualplan/core': coreEntry,
+          // The shell imports no plan, but theme.ts and the components still pull react; resolve the
+          // JSX runtimes from the CLI's own install so a vendored runtime with no node_modules works.
+          'react/jsx-runtime': require.resolve('react/jsx-runtime'),
+          'react/jsx-dev-runtime': require.resolve('react/jsx-dev-runtime'),
+        },
+      },
+      esbuild: { jsx: 'automatic', jsxImportSource: 'react' },
+      plugins: [viteSingleFile()],
+      build: {
+        outDir,
+        emptyOutDir: true,
+        rollupOptions: { input: join(runtimeDir, 'queue.html') },
+      },
+    })
+    // Vite emits the page under its input basename, so a `queue.html` entry yields `queue.html`
+    // (not `index.html`); the single-file plugin only inlines assets, it does not rename the page.
+    return await readFile(join(outDir, 'queue.html'), 'utf8')
+  } finally {
+    await rm(outDir, { recursive: true, force: true })
   }
-  const pending = entries.find(en => en.status === 'pending')
-  if (pending && !frame.src) frame.src = '/plan/' + pending.id
-})
-</script>
-</body>
-</html>
-`
 }

--- a/packages/cli/src/build/queue-shell.ts
+++ b/packages/cli/src/build/queue-shell.ts
@@ -1,0 +1,45 @@
+/**
+ * Builds the Review Queue **shell**: the single self-contained page the daemon serves at `/`. The
+ * shell renders the left sidebar of queued plans and hosts the active plan in a same-origin iframe
+ * (`/plan/<id>`); each plan iframe carries its own review chrome. The shell holds the daemon's
+ * `/__vp_events` SSE open, which doubles as the liveness signal (closing the tab tears the daemon
+ * down).
+ *
+ * This is the integration seam between the daemon (which calls this to serve `/`) and the runtime
+ * shell UI. The body below is a placeholder so the daemon is serveable and testable before the real
+ * React shell lands; the runtime work replaces it with a Vite single-file build of the runtime
+ * `queue.html` entry (analogous to `buildHtml`). The signature is the contract and must not change:
+ * a zero-arg async function returning one self-contained HTML string.
+ */
+export async function buildQueueShell(): Promise<string> {
+  // Placeholder shell: lists the queue from the SSE stream so the backend is exercisable end to end
+  // (curl/tests) before the styled React shell exists. Replaced by the real build.
+  return `<!doctype html>
+<html lang="en">
+<head><meta charset="utf-8"><title>Review Queue</title></head>
+<body>
+<h1>Review Queue</h1>
+<ul id="queue"></ul>
+<iframe id="plan" title="active plan" style="width:100%;height:80vh;border:0"></iframe>
+<script type="module">
+const list = document.getElementById('queue')
+const frame = document.getElementById('plan')
+const es = new EventSource('/__vp_events')
+es.addEventListener('queue', e => {
+  const entries = JSON.parse(e.data)
+  list.innerHTML = ''
+  for (const entry of entries) {
+    const li = document.createElement('li')
+    li.textContent = entry.dir + ' / ' + entry.title + ' [' + entry.status + ']'
+    li.style.cursor = 'pointer'
+    li.onclick = () => { frame.src = '/plan/' + entry.id }
+    list.appendChild(li)
+  }
+  const pending = entries.find(en => en.status === 'pending')
+  if (pending && !frame.src) frame.src = '/plan/' + pending.id
+})
+</script>
+</body>
+</html>
+`
+}

--- a/packages/cli/src/commands/config.ts
+++ b/packages/cli/src/commands/config.ts
@@ -1,3 +1,4 @@
+import ms from 'ms'
 import {
   type Config,
   type Theme,
@@ -8,8 +9,8 @@ import {
   writeConfig,
 } from '../config.js'
 
-/** The settable config keys. `theme` is the only one today. */
-const KEYS = ['theme'] as const
+/** The settable config keys. */
+const KEYS = ['theme', 'daemonTimeout'] as const
 type Key = (typeof KEYS)[number]
 
 function assertKey(key: string): asserts key is Key {
@@ -18,10 +19,29 @@ function assertKey(key: string): asserts key is Key {
   }
 }
 
+/** Parse a `daemonTimeout` value (a duration like `15m`, or a bare ms count) to a positive integer
+ * of milliseconds, throwing on anything unparseable or non-positive. */
+function parseDaemonTimeout(value: string): number {
+  // ms's typed overload only accepts its template literal type, but at runtime it parses any string
+  // (a bare number is read as milliseconds) and returns undefined for an unparseable one.
+  const millis = (ms as (input: string) => number | undefined)(value)
+  if (typeof millis !== 'number' || !Number.isInteger(millis) || millis <= 0) {
+    throw new Error(
+      `Invalid daemonTimeout "${value}". Use a positive duration like 15m, 30s, or 1h.`,
+    )
+  }
+  return millis
+}
+
 /** `vplan config` — print the current settings and where they live. */
 export async function runConfigShow(dir: string = configDir): Promise<void> {
   const config = await readConfig(dir)
-  const lines = [`Config: ${configFilePath(dir)}`, '', `  theme = ${config.theme}`]
+  const lines = [
+    `Config: ${configFilePath(dir)}`,
+    '',
+    `  theme = ${config.theme}`,
+    `  daemonTimeout = ${config.daemonTimeout}`,
+  ]
   process.stdout.write(`${lines.join('\n')}\n`)
 }
 
@@ -39,13 +59,27 @@ export async function runConfigSet(
   dir: string = configDir,
 ): Promise<void> {
   assertKey(key)
-  // `theme` is the only key, so its value rules are the only ones to enforce.
-  if (!(THEMES as readonly string[]).includes(value)) {
-    throw new Error(`Invalid theme "${value}". Valid values: ${THEMES.join(' | ')}`)
+  const current = await readConfig(dir)
+  let next: Config
+  let stored: string
+  switch (key) {
+    case 'theme': {
+      if (!(THEMES as readonly string[]).includes(value)) {
+        throw new Error(`Invalid theme "${value}". Valid values: ${THEMES.join(' | ')}`)
+      }
+      next = { ...current, theme: value as Theme }
+      stored = value
+      break
+    }
+    case 'daemonTimeout': {
+      const millis = parseDaemonTimeout(value)
+      next = { ...current, daemonTimeout: millis }
+      stored = String(millis)
+      break
+    }
   }
-  const next: Config = { ...(await readConfig(dir)), theme: value as Theme }
   await writeConfig(next, dir)
-  process.stdout.write(`Set ${key} = ${value}\n`)
+  process.stdout.write(`Set ${key} = ${stored}\n`)
 }
 
 /** `vplan config path` — print the config file path. */

--- a/packages/cli/src/commands/open.ts
+++ b/packages/cli/src/commands/open.ts
@@ -1,0 +1,43 @@
+/**
+ * `vplan open` — open the Review Queue tab, starting the background daemon if it is not already
+ * running. Unlike `render --review` / `review`, it enqueues no plan and does not block: it just
+ * ensures the daemon (a detached process) is up and opens its shell at `/`, so the user can open or
+ * re-open the queue tab on its own. Reviews launched afterward join this tab.
+ *
+ * Takes injectable `deps` so the wiring is unit-tested without a real daemon or browser.
+ */
+import open from 'open'
+import { readConfig } from '../config.js'
+import { ensureDaemon } from '../review/ensure-daemon.js'
+
+export interface OpenOptions {
+  /** `--no-open`: start the daemon and print the URL without launching a browser. */
+  open?: boolean
+}
+
+export interface OpenDeps {
+  ensureDaemon: (idleMs: number) => Promise<{ port: number }>
+  openBrowser: (url: string) => Promise<void>
+  stdout: NodeJS.WriteStream
+}
+
+function realDeps(): OpenDeps {
+  return {
+    ensureDaemon: idleMs => ensureDaemon({ idleMs }),
+    openBrowser: async url => {
+      await open(url)
+    },
+    stdout: process.stdout,
+  }
+}
+
+export async function runOpen(
+  options: OpenOptions = {},
+  deps: OpenDeps = realDeps(),
+): Promise<void> {
+  const { daemonTimeout } = await readConfig()
+  const { port } = await deps.ensureDaemon(daemonTimeout)
+  const url = `http://localhost:${port}/`
+  deps.stdout.write(`Review Queue at\n  ${url}\n`)
+  if (options.open !== false) await deps.openBrowser(url)
+}

--- a/packages/cli/src/commands/render.ts
+++ b/packages/cli/src/commands/render.ts
@@ -26,7 +26,11 @@ export interface RenderOptions {
   stdout?: boolean
   /** Port for the `--watch` dev server; ignored for a one-shot file render. */
   port?: number
-  /** Open the plan as an interactive review session and print the reviewer's feedback. */
+  /** Render a static HTML file and open it (the pre-review default). Opts out of the now-default
+   * review session; set by `--static`. */
+  static?: boolean
+  /** Open the plan as an interactive review session and print the reviewer's feedback. Review is now
+   * the default, so this flag is redundant; it is kept for backwards compatibility. */
   review?: boolean
   /** Bypass the shared Review Queue daemon and use the one-shot in-process review server instead.
    * Set by `--no-daemon`; keeps the legacy single-server path for environments where the daemon's
@@ -104,8 +108,18 @@ function defaultOutPath(absMdx: string): string {
 }
 
 /**
- * `vplan render [file]` — validate, then build a static page or start a watch server. Input comes
- * from a file, an explicit `-`, or piped stdin; output goes to a file (and opens) or to stdout.
+ * Whether a render should open an interactive review session. Review is the default; any static
+ * output flag (`--static`, `--watch`, `--stdout`, `--out`) opts out into a one-shot artifact render.
+ * `--review` explicitly selects the default and is kept only for backwards compatibility.
+ */
+export function rendersReview(options: RenderOptions): boolean {
+  return !(options.static || options.watch || options.stdout || options.out !== undefined)
+}
+
+/**
+ * `vplan render [file]` — validate, then open an interactive review session (the default) or, with a
+ * static flag, build a static page / start a watch server. Input comes from a file, an explicit `-`,
+ * or piped stdin; static output goes to a file (and opens) or to stdout.
  */
 export async function runRender(file: string | undefined, options: RenderOptions): Promise<void> {
   if (options.stdout && options.out) {
@@ -116,15 +130,15 @@ export async function runRender(file: string | undefined, options: RenderOptions
       '--stdout cannot be combined with --watch; the watch server has no file output.',
     )
   }
-  if (options.review && (options.watch || options.stdout || options.out)) {
-    throw new Error('--review cannot be combined with --watch, --stdout, or --out.')
+  if (options.review && !rendersReview(options)) {
+    throw new Error('--review cannot be combined with --static, --watch, --stdout, or --out.')
   }
 
   const { theme } = await readConfig()
 
-  // Review is a one-shot server that blocks on human feedback; it accepts a file or piped stdin
+  // Review (the default) is a server that blocks on human feedback; it accepts a file or piped stdin
   // because it serves a snapshot read once (no watching), unlike --watch.
-  if (options.review) {
+  if (rendersReview(options)) {
     const { source, label, fromStdin } = await readPlanSource(file)
     const issues = await checkSource(source)
     if (issues.length > 0) {

--- a/packages/cli/src/commands/render.ts
+++ b/packages/cli/src/commands/render.ts
@@ -156,6 +156,9 @@ export async function runRender(file: string | undefined, options: RenderOptions
           iteration: options.iteration,
           dir: reviewDir(file, fromStdin),
           baseline,
+          // Key by file path so a requeued iteration replaces the prior one in the sidebar; stdin
+          // has no stable path, so it always enqueues a fresh entry.
+          key: !fromStdin && file && file !== '-' ? resolve(file) : undefined,
         }),
       awaitVerdict,
       openBrowser: async (port: number) => {

--- a/packages/cli/src/commands/render.ts
+++ b/packages/cli/src/commands/render.ts
@@ -3,10 +3,14 @@ import { basename, dirname, extname, join, resolve } from 'node:path'
 import { InvalidArgumentError } from 'commander'
 import ms from 'ms'
 import open from 'open'
+import type { Feedback } from '@visualplan/core'
 import { checkPlan, checkSource } from '../build/check.js'
 import { buildHtml, startDevServer } from '../build/compile.js'
 import { readSnapshot, writeSnapshot } from '../build/snapshots.js'
 import { readConfig } from '../config.js'
+import { awaitVerdict, type EnqueueResponse, enqueuePlan } from '../review/client.js'
+import { ensureDaemon } from '../review/ensure-daemon.js'
+import { exitCodeFor, formatFeedback } from '../review/format.js'
 import { runReview } from '../review/session.js'
 import { printIssues, resolvePlanFile } from './check.js'
 import { readPlanSource } from './input.js'
@@ -24,6 +28,10 @@ export interface RenderOptions {
   port?: number
   /** Open the plan as an interactive review session and print the reviewer's feedback. */
   review?: boolean
+  /** Bypass the shared Review Queue daemon and use the one-shot in-process review server instead.
+   * Set by `--no-daemon`; keeps the legacy single-server path for environments where the daemon's
+   * detached process or lock cannot be used. */
+  noDaemon?: boolean
   /** Max wait (ms) for review feedback before timing out; parsed from a duration by `parseTimeout`. */
   timeout?: number
   /** Iteration number shown in the review bar (the agent sets it as it revises the plan). */
@@ -125,14 +133,36 @@ export async function runRender(file: string | undefined, options: RenderOptions
       return
     }
     const baseline = await resolveBaseline(options, source, snapshotKey(file, fromStdin))
-    await runReview(
-      source,
-      theme,
-      options.timeout ?? DEFAULT_REVIEW_TIMEOUT_MS,
-      options.open !== false,
-      options.iteration,
-      baseline,
-    )
+    // Default: route through the shared Review Queue daemon so several plans in a session share one
+    // warm tab. `--no-daemon` keeps the legacy one-shot in-process review server.
+    if (options.noDaemon) {
+      await runReview(
+        source,
+        theme,
+        options.timeout ?? DEFAULT_REVIEW_TIMEOUT_MS,
+        options.open !== false,
+        options.iteration,
+        baseline,
+      )
+      return
+    }
+    const { daemonTimeout } = await readConfig()
+    await runReviewViaDaemon(source, reviewDir(file, fromStdin), options, {
+      ensureDaemon: () => ensureDaemon({ idleMs: daemonTimeout }),
+      enqueue: (port, src) =>
+        enqueuePlan(port, {
+          source: src,
+          theme,
+          iteration: options.iteration,
+          dir: reviewDir(file, fromStdin),
+          baseline,
+        }),
+      awaitVerdict,
+      openBrowser: async (port: number) => {
+        await open(`http://localhost:${port}/`)
+      },
+      stdout: process.stdout,
+    })
     return
   }
 
@@ -186,4 +216,66 @@ export async function runRender(file: string | undefined, options: RenderOptions
   await writeFile(out, html)
   process.stdout.write(`Rendered ${out}\n`)
   if (options.open !== false) await open(out)
+}
+
+/** The `dir` label for a reviewed plan: the basename of its directory, or `cwd` for piped stdin
+ * (which has no originating file). Shown beside the title in the queue sidebar. */
+function reviewDir(file: string | undefined, fromStdin: boolean): string {
+  if (fromStdin || file === undefined || file === '-') return basename(process.cwd())
+  return basename(dirname(resolve(file)))
+}
+
+/** Injectable collaborators for the single-plan daemon review flow, so it is unit-testable without a
+ * real daemon, build, or browser. */
+export interface DaemonReviewDeps {
+  ensureDaemon: () => Promise<{ port: number }>
+  enqueue: (port: number, source: string) => Promise<EnqueueResponse>
+  awaitVerdict: (port: number, id: string, signal?: AbortSignal) => Promise<Feedback>
+  openBrowser: (port: number) => Promise<void>
+  stdout: NodeJS.WriteStream
+}
+
+/**
+ * Review a single plan through the shared Review Queue daemon: enqueue it, open the browser only if
+ * no shell tab is already connected, then wait for its verdict (bounded by `--timeout`, exit code 3
+ * on timeout). Prints the formatted feedback to stdout and sets the exit code from the decision,
+ * matching the one-shot `runReview` contract so the daemon path is a drop-in for it.
+ */
+export async function runReviewViaDaemon(
+  source: string,
+  _dir: string,
+  options: RenderOptions,
+  deps: DaemonReviewDeps,
+): Promise<void> {
+  const { port } = await deps.ensureDaemon()
+  const { id, shellConnected } = await deps.enqueue(port, source)
+  if (!shellConnected && options.open !== false) await deps.openBrowser(port)
+
+  // The caller may time out waiting for ITS verdict even though the daemon lives on; aborting the
+  // long-poll lets the daemon drop the abandoned plan.
+  const controller = new AbortController()
+  const timeoutMs = options.timeout ?? DEFAULT_REVIEW_TIMEOUT_MS
+  let timer: ReturnType<typeof setTimeout> | undefined
+  const timeout = new Promise<'timeout'>(resolve => {
+    timer = setTimeout(() => {
+      controller.abort()
+      resolve('timeout')
+    }, timeoutMs)
+  })
+
+  try {
+    const result = await Promise.race([
+      deps.awaitVerdict(port, id, controller.signal).catch(() => 'timeout' as const),
+      timeout,
+    ])
+    if (result === 'timeout') {
+      process.stderr.write(`\nReview timed out after ${ms(timeoutMs, { long: true })}.\n`)
+      process.exitCode = exitCodeFor('timeout')
+      return
+    }
+    deps.stdout.write(`${formatFeedback(result)}\n`)
+    process.exitCode = exitCodeFor(result.decision)
+  } finally {
+    clearTimeout(timer)
+  }
 }

--- a/packages/cli/src/commands/review-daemon.ts
+++ b/packages/cli/src/commands/review-daemon.ts
@@ -1,0 +1,97 @@
+/**
+ * The hidden `__review-daemon` command: the body of the detached daemon process that `ensureDaemon`
+ * spawns. It owns the lock mutex. It starts the HTTP daemon, then atomically claims the lock; if
+ * another daemon won the race it closes and exits, and if it finds only a stale lock (present but
+ * pointing at a dead daemon) it clears it and retries once. While the daemon runs, its HTTP server
+ * keeps the event loop alive; on idle/shell-close shutdown it removes the lock and exits.
+ */
+import { mkdir } from 'node:fs/promises'
+import { type DaemonInstance, startDaemon } from '../review/daemon.js'
+import { isDaemonAlive, readLock, removeLock, writeLockExclusive } from '../review/lockfile.js'
+import { buildQueueShell } from '../build/queue-shell.js'
+import { configDir as defaultConfigDir } from '../config.js'
+
+export interface RunReviewDaemonOptions {
+  port: number
+  idleMs: number
+}
+
+/** Injectable seams so the mutex/stale-lock logic is unit-testable without a real Vite build, a real
+ * port bind, or `process.exit`. Production uses the real implementations. */
+export interface ReviewDaemonDeps {
+  configDir?: string
+  startDaemon?: (port: number, idleMs: number, onIdle: () => void) => Promise<DaemonInstance>
+  isAlive?: (port: number) => Promise<boolean>
+}
+
+/** Start the real HTTP daemon on `port`, incrementing past a port taken by a non-daemon (EADDRINUSE)
+ * up to a few tries. Wires the real shell builder and the idle/shutdown callback. */
+async function startRealDaemon(
+  port: number,
+  idleMs: number,
+  onIdle: () => void,
+): Promise<DaemonInstance> {
+  let lastError: unknown
+  for (let attempt = 0; attempt < 5; attempt++) {
+    try {
+      return await startDaemon({
+        port: port + attempt,
+        idleMs,
+        getShellHtml: buildQueueShell,
+        onIdle,
+      })
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException)?.code === 'EADDRINUSE') {
+        lastError = error
+        continue
+      }
+      throw error
+    }
+  }
+  throw lastError ?? new Error('could not bind a daemon port')
+}
+
+export async function runReviewDaemon(
+  opts: RunReviewDaemonOptions,
+  deps: ReviewDaemonDeps = {},
+): Promise<void> {
+  // The detached daemon shares the lock/state dir with the `ensureDaemon` callers that spawn it. In
+  // production that is `~/.vplan` for both; `VPLAN_REVIEW_DIR` overrides it (the spawn passes it in)
+  // so a test can point a real daemon process and its caller at the same temp dir.
+  const dir = deps.configDir ?? process.env.VPLAN_REVIEW_DIR ?? defaultConfigDir
+  const start = deps.startDaemon ?? startRealDaemon
+  const isAlive = deps.isAlive ?? isDaemonAlive
+  // The lock dir must exist before the `wx` write; the daemon owns creating `~/.vplan`.
+  await mkdir(dir, { recursive: true })
+
+  // The daemon removes its lock on shutdown so the next invocation starts fresh.
+  const onIdle = () => {
+    void removeLock(dir)
+  }
+
+  const instance = await start(opts.port, opts.idleMs, onIdle)
+
+  // Claim the lock. If a live daemon already owns it, this process lost the race: close and bow out.
+  if (await acquireLock(dir, instance.port, isAlive)) return
+  await instance.close()
+}
+
+/**
+ * Try to atomically claim the lock for this daemon. Returns true on success. On a pre-existing lock,
+ * checks liveness: a live owner means we lost (false); a stale lock (dead owner) is cleared and the
+ * claim retried once.
+ */
+async function acquireLock(
+  dir: string,
+  port: number,
+  isAlive: (port: number) => Promise<boolean>,
+): Promise<boolean> {
+  if (await writeLockExclusive({ port, pid: process.pid }, dir)) return true
+
+  const existing = await readLock(dir)
+  if (existing && (await isAlive(existing.port))) return false
+
+  // Stale lock pointing at a dead daemon: clear it and retry the claim once.
+  await removeLock(dir)
+  return writeLockExclusive({ port, pid: process.pid }, dir)
+}

--- a/packages/cli/src/commands/review.ts
+++ b/packages/cli/src/commands/review.ts
@@ -1,0 +1,116 @@
+/**
+ * `vplan review <files...>` — enqueue several plans into the shared Review Queue daemon at once and
+ * stream each plan's verdict to stdout the instant it resolves, prefixed by a header naming the
+ * file. Exits 0 iff every plan was approved, else 1 (a deny, iterate, or tab-close Deny on any plan
+ * blocks). `--json` instead collects all verdicts and prints one object keyed by file path at the
+ * end. The daemon is started/reused via `ensureDaemon`; the browser opens only if no shell tab is
+ * already connected.
+ *
+ * The orchestration takes injectable `deps` so the streaming/exit-code logic is unit-tested without
+ * a real daemon, build, or browser; `index.ts` wires the real implementations.
+ */
+import { basename, dirname, resolve } from 'node:path'
+import { readFile } from 'node:fs/promises'
+import type { Feedback } from '@visualplan/core'
+import type { CheckIssue } from '../build/check.js'
+import { checkSource } from '../build/check.js'
+import { readConfig } from '../config.js'
+import { awaitVerdict, type EnqueueResponse, enqueuePlan } from '../review/client.js'
+import { ensureDaemon } from '../review/ensure-daemon.js'
+import { resolvePlanFile, printIssues } from './check.js'
+import { formatFeedback } from '../review/format.js'
+import open from 'open'
+
+export interface ReviewQueueOptions {
+  /** Emit one JSON object keyed by file path instead of streaming text blocks. */
+  json?: boolean
+  /** Do not open a browser even when no shell is connected. */
+  open?: boolean
+}
+
+/** Injectable collaborators so the orchestration is testable in isolation. */
+export interface ReviewQueueDeps {
+  readSource: (file: string) => Promise<string>
+  check: (source: string) => Promise<CheckIssue[]>
+  ensureDaemon: () => Promise<{ port: number }>
+  enqueue: (port: number, source: string, file: string) => Promise<EnqueueResponse>
+  awaitVerdict: (port: number, id: string) => Promise<Feedback>
+  openBrowser: (port: number) => Promise<void>
+  stdout: NodeJS.WriteStream
+}
+
+export async function runReviewQueue(
+  files: string[],
+  options: ReviewQueueOptions,
+  deps: ReviewQueueDeps,
+): Promise<void> {
+  // Read and check every plan up front; a single bad plan fails the whole run without enqueuing.
+  const sources: Array<{ file: string; source: string }> = []
+  for (const file of files) {
+    const source = await deps.readSource(file)
+    const issues = await deps.check(source)
+    if (issues.length > 0) {
+      printIssues(file, issues)
+      process.exitCode = 1
+      return
+    }
+    sources.push({ file, source })
+  }
+
+  const { port } = await deps.ensureDaemon()
+
+  // Enqueue all plans; open the browser once iff no shell tab was already connected for any enqueue.
+  const enqueued: Array<{ file: string; id: string }> = []
+  let anyShellConnected = false
+  for (const { file, source } of sources) {
+    const { id, shellConnected } = await deps.enqueue(port, source, file)
+    anyShellConnected = anyShellConnected || shellConnected
+    enqueued.push({ file, id })
+  }
+  if (!anyShellConnected && options.open !== false) await deps.openBrowser(port)
+
+  const collected: Record<string, Feedback> = {}
+  let allApproved = true
+
+  // Await each verdict concurrently; in streaming mode write each block the moment it resolves.
+  await Promise.all(
+    enqueued.map(async ({ file, id }) => {
+      const feedback = await deps.awaitVerdict(port, id)
+      collected[file] = feedback
+      if (feedback.decision !== 'approve') allApproved = false
+      if (!options.json) {
+        deps.stdout.write(`=== ${file} ===\n${formatFeedback(feedback)}\n\n`)
+      }
+    }),
+  )
+
+  if (options.json) {
+    deps.stdout.write(`${JSON.stringify(collected, null, 2)}\n`)
+  }
+
+  process.exitCode = allApproved ? 0 : 1
+}
+
+/** The default `dir` for a plan file: the basename of its directory (shown beside the title in the
+ * queue so plans from different projects stay distinguishable). */
+function planDir(file: string): string {
+  return basename(dirname(resolve(file)))
+}
+
+/** Wire the real collaborators and run the queue review for the given files. */
+export async function runReview(files: string[], options: ReviewQueueOptions): Promise<void> {
+  const { theme, daemonTimeout } = await readConfig()
+  const deps: ReviewQueueDeps = {
+    readSource: async (file: string) =>
+      (await readFile(resolvePlanFile(file), 'utf8')).replace(/^﻿/, ''),
+    check: checkSource,
+    ensureDaemon: () => ensureDaemon({ idleMs: daemonTimeout }),
+    enqueue: (port, source, file) => enqueuePlan(port, { source, theme, dir: planDir(file) }),
+    awaitVerdict: (port, id) => awaitVerdict(port, id),
+    openBrowser: async (port: number) => {
+      await open(`http://localhost:${port}/`)
+    },
+    stdout: process.stdout,
+  }
+  await runReviewQueue(files, options, deps)
+}

--- a/packages/cli/src/commands/review.ts
+++ b/packages/cli/src/commands/review.ts
@@ -105,7 +105,8 @@ export async function runReview(files: string[], options: ReviewQueueOptions): P
       (await readFile(resolvePlanFile(file), 'utf8')).replace(/^﻿/, ''),
     check: checkSource,
     ensureDaemon: () => ensureDaemon({ idleMs: daemonTimeout }),
-    enqueue: (port, source, file) => enqueuePlan(port, { source, theme, dir: planDir(file) }),
+    enqueue: (port, source, file) =>
+      enqueuePlan(port, { source, theme, dir: planDir(file), key: resolve(file) }),
     awaitVerdict: (port, id) => awaitVerdict(port, id),
     openBrowser: async (port: number) => {
       await open(`http://localhost:${port}/`)

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -12,11 +12,22 @@ export type Theme = 'light' | 'dark' | 'system'
 
 export interface Config {
   theme: Theme
+  /**
+   * Idle TTL in milliseconds that the Review Queue daemon lingers after its queue empties before
+   * exiting. A re-plan during a planning session within this window reuses the warm tab instead of
+   * paying a cold daemon start. Default 15 minutes. This is distinct from a single review's
+   * `--timeout` (how long one caller waits for its own plan's verdict).
+   */
+  daemonTimeout: number
 }
 
 /** The valid `theme` values, in menu order. */
 export const THEMES: readonly Theme[] = ['light', 'dark', 'system']
-const DEFAULT_CONFIG: Config = { theme: 'system' }
+
+/** Default Review Queue daemon idle TTL: 15 minutes (matches the default review `--timeout`). */
+export const DEFAULT_DAEMON_TIMEOUT_MS = 15 * 60 * 1000
+
+const DEFAULT_CONFIG: Config = { theme: 'system', daemonTimeout: DEFAULT_DAEMON_TIMEOUT_MS }
 
 /** `~/.vplan` — the config directory. */
 export const configDir = join(homedir(), '.vplan')
@@ -30,16 +41,29 @@ function isTheme(value: unknown): value is Theme {
   return typeof value === 'string' && (THEMES as readonly string[]).includes(value)
 }
 
+/** A valid `daemonTimeout` is a positive, finite integer count of milliseconds. */
+function isDaemonTimeout(value: unknown): value is number {
+  return typeof value === 'number' && Number.isInteger(value) && value > 0
+}
+
 /**
  * Read the persisted config. Returns defaults when the file is missing or malformed (an absent or
- * hand-broken config must never break a render), and ignores an unknown `theme` value. `dir`
- * overrides the config directory for tests; production calls it with the default `~/.vplan`.
+ * hand-broken config must never break a render), and ignores an unknown `theme` or a non-positive
+ * `daemonTimeout` value, falling back to the default for each field independently. `dir` overrides
+ * the config directory for tests; production calls it with the default `~/.vplan`.
  */
 export async function readConfig(dir: string = configDir): Promise<Config> {
   try {
-    const parsed: unknown = JSON.parse(await readFile(configFilePath(dir), 'utf8'))
-    const theme = (parsed as { theme?: unknown } | null)?.theme
-    return { theme: isTheme(theme) ? theme : DEFAULT_CONFIG.theme }
+    const parsed = JSON.parse(await readFile(configFilePath(dir), 'utf8')) as {
+      theme?: unknown
+      daemonTimeout?: unknown
+    } | null
+    return {
+      theme: isTheme(parsed?.theme) ? parsed.theme : DEFAULT_CONFIG.theme,
+      daemonTimeout: isDaemonTimeout(parsed?.daemonTimeout)
+        ? parsed.daemonTimeout
+        : DEFAULT_CONFIG.daemonTimeout,
+    }
   } catch {
     return DEFAULT_CONFIG
   }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -85,15 +85,15 @@ const config = program
 
 config
   .command('get')
-  .description('Print a setting (theme)')
+  .description('Print a setting (theme, daemonTimeout)')
   .argument('<key>', 'the setting to read')
   .action((key: string) => runConfigGet(key))
 
 config
   .command('set')
   .description('Change a setting and persist it')
-  .argument('<key>', 'the setting to change (theme)')
-  .argument('<value>', 'the new value (theme: light | dark | system)')
+  .argument('<key>', 'the setting to change (theme, daemonTimeout)')
+  .argument('<value>', 'the new value (theme: light | dark | system; daemonTimeout: 15m, 30s, 1h)')
   .action((key: string, value: string) => runConfigSet(key, value))
 
 config

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -24,13 +24,17 @@ const program = new Command('vplan')
 
 program
   .command('render', { isDefault: true })
-  .description('Compile a plan .mdx to a self-contained HTML page (default command)')
+  .description('Review a plan .mdx interactively (default), or render it to a static page')
   .argument('[file]', 'the plan .mdx file; - or omit to read from stdin')
+  .option('--static', 'render a static HTML page and open it, instead of the review session')
   .option('--watch', 'start a hot-reloading dev server instead of writing a file')
   .option('--port <number>', 'port for the --watch dev server', parsePort, DEFAULT_DEV_PORT)
-  .option('--out <path>', 'output HTML path (defaults to <file>.plan.html)')
-  .option('--stdout', 'write the rendered HTML to stdout instead of a file')
-  .option('--review', 'open an interactive review session and print the reviewer feedback')
+  .option('--out <path>', 'output HTML path (defaults to <file>.plan.html; implies --static)')
+  .option('--stdout', 'write the rendered HTML to stdout instead of a file (implies --static)')
+  .option(
+    '--review',
+    'open the interactive review session (now the default; kept for compatibility)',
+  )
   .option(
     '-i, --iteration <number>',
     'plan revision number shown in the review bar',

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -14,6 +14,8 @@ import {
   runRender,
   type RenderOptions,
 } from './commands/render.js'
+import { type ReviewQueueOptions, runReview } from './commands/review.js'
+import { runReviewDaemon } from './commands/review-daemon.js'
 import { runShare } from './commands/share.js'
 
 const program = new Command('vplan')
@@ -45,8 +47,32 @@ program
     'diff this render against a baseline plan .mdx (overrides the snapshot cache)',
   )
   .option('--no-diff', 'skip iteration diffing (do not read or write the snapshot cache)')
+  .option('--no-daemon', 'review without the shared Review Queue daemon (one-shot server)')
   .option('--no-open', 'do not open the result in a browser')
   .action((file: string | undefined, options: RenderOptions) => runRender(file, options))
+
+program
+  .command('review')
+  .description('Queue one or more plans for review in the shared Review Queue and print verdicts')
+  .argument('<files...>', 'the plan .mdx files to review')
+  .option('--json', 'print one JSON object keyed by file path instead of streaming text')
+  .option('--no-open', 'do not open the queue in a browser')
+  .action((files: string[], options: ReviewQueueOptions) => runReview(files, options))
+
+interface ReviewDaemonCliOptions {
+  port: number
+  idle: number
+}
+
+// Hidden: the detached daemon process `ensureDaemon` spawns. Not for direct human use.
+program
+  .command('__review-daemon', { hidden: true })
+  .description('internal: run the Review Queue daemon process')
+  .option('--port <number>', 'port to bind', parsePort, 9151)
+  .option('--idle <ms>', 'idle TTL in milliseconds', value => Number.parseInt(value, 10), 900_000)
+  .action((options: ReviewDaemonCliOptions) =>
+    runReviewDaemon({ port: options.port, idleMs: options.idle }),
+  )
 
 program
   .command('export')

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -14,6 +14,7 @@ import {
   runRender,
   type RenderOptions,
 } from './commands/render.js'
+import { type OpenOptions, runOpen } from './commands/open.js'
 import { type ReviewQueueOptions, runReview } from './commands/review.js'
 import { runReviewDaemon } from './commands/review-daemon.js'
 import { runShare } from './commands/share.js'
@@ -62,6 +63,12 @@ program
   .option('--json', 'print one JSON object keyed by file path instead of streaming text')
   .option('--no-open', 'do not open the queue in a browser')
   .action((files: string[], options: ReviewQueueOptions) => runReview(files, options))
+
+program
+  .command('open')
+  .description('Open the Review Queue tab, starting the background daemon if needed')
+  .option('--no-open', 'just start the daemon and print the URL, without opening a browser')
+  .action((options: OpenOptions) => runOpen(options))
 
 interface ReviewDaemonCliOptions {
   port: number

--- a/packages/cli/src/review/cli-entry.ts
+++ b/packages/cli/src/review/cli-entry.ts
@@ -1,0 +1,17 @@
+/**
+ * Resolve the path to this CLI's own entry script, so the detached daemon can be launched as
+ * `node <entry> __review-daemon ...`. This is environment-sensitive: in production the CLI runs from
+ * the built `dist/index.js`, in dev from `tsx src/index.ts`. `process.argv[1]` is the script Node
+ * was started with in both cases (the bin shim resolves to dist/index.js when installed), so it is
+ * the most robust single source; the `import.meta.url` of this module is the fallback when argv[1]
+ * is somehow absent (it points into the same build, so resolving `../index.js` from here lands on
+ * the CLI entry next to the compiled output).
+ */
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+export function resolveCliEntry(): string {
+  const fromArgv = process.argv[1]
+  if (fromArgv) return fromArgv
+  return join(dirname(fileURLToPath(import.meta.url)), '..', 'index.js')
+}

--- a/packages/cli/src/review/client.ts
+++ b/packages/cli/src/review/client.ts
@@ -13,6 +13,9 @@ export interface EnqueueRequest {
   iteration?: number
   dir: string
   baseline?: string
+  /** The plan's stable identity (its file path); a requeue with the same key replaces the prior
+   * version in the queue, so a plan and its iterations appear once. Omitted for stdin. */
+  key?: string
 }
 
 /** The daemon's enqueue response: the assigned plan id and whether a shell tab is already connected

--- a/packages/cli/src/review/client.ts
+++ b/packages/cli/src/review/client.ts
@@ -1,0 +1,52 @@
+/**
+ * Client-side helpers a `vplan review`/`render --review` invocation uses to talk to the Review Queue
+ * daemon over its frozen HTTP contract: enqueue a plan, then long-poll its verdict. These run in the
+ * foreground CLI process (the daemon is a separate detached process).
+ */
+import type { Feedback } from '@visualplan/core'
+import type { Theme } from '../config.js'
+
+/** The enqueue request body the daemon's `/__vp_enqueue` validates. */
+export interface EnqueueRequest {
+  source: string
+  theme?: Theme
+  iteration?: number
+  dir: string
+  baseline?: string
+}
+
+/** The daemon's enqueue response: the assigned plan id and whether a shell tab is already connected
+ * (the CLI opens a browser only when none is). */
+export interface EnqueueResponse {
+  id: string
+  shellConnected: boolean
+}
+
+/** POST a plan to the daemon's queue. Rejects on any non-200 so the caller never proceeds on a
+ * failed enqueue. */
+export async function enqueuePlan(port: number, req: EnqueueRequest): Promise<EnqueueResponse> {
+  const res = await fetch(`http://localhost:${port}/__vp_enqueue`, {
+    method: 'POST',
+    body: JSON.stringify(req),
+  })
+  if (res.status !== 200) throw new Error(`enqueue failed: HTTP ${res.status}`)
+  return res.json() as Promise<EnqueueResponse>
+}
+
+/**
+ * Long-poll the daemon for a queued plan's verdict. The daemon holds the connection open until the
+ * plan settles (decision or tab-close Deny), then responds with the Feedback. An optional `signal`
+ * lets the caller abort (e.g. its own `--timeout`), which rejects and tears the connection down so
+ * the daemon sees the disconnect and drops the abandoned plan. Rejects on a 404 (unknown id).
+ */
+export async function awaitVerdict(
+  port: number,
+  id: string,
+  signal?: AbortSignal,
+): Promise<Feedback> {
+  const res = await fetch(`http://localhost:${port}/__vp_verdict?id=${encodeURIComponent(id)}`, {
+    signal,
+  })
+  if (res.status !== 200) throw new Error(`verdict failed: HTTP ${res.status}`)
+  return res.json() as Promise<Feedback>
+}

--- a/packages/cli/src/review/daemon.ts
+++ b/packages/cli/src/review/daemon.ts
@@ -65,6 +65,16 @@ function titleFromSource(source: string): string {
   return source.replace(/^﻿/, '').match(/^# (.+?)\s*$/m)?.[1] ?? ''
 }
 
+/**
+ * Inject the decided verdict into a re-served plan page (`__VP_REVIEW_DECIDED__`), so re-opening a
+ * plan the reviewer already decided locks into the submitted state instead of showing live controls.
+ * A plain head script runs before the deferred runtime module that reads the global.
+ */
+function withDecided(html: string, feedback: Feedback): string {
+  const tag = `<script>globalThis.__VP_REVIEW_DECIDED__=${JSON.stringify(feedback.decision)}</script>`
+  return html.includes('</head>') ? html.replace('</head>', `${tag}</head>`) : `${tag}${html}`
+}
+
 /** One queued plan's full server-side state. */
 interface QueuedPlan {
   entry: QueueEntry
@@ -194,7 +204,12 @@ export async function startDaemon(opts: StartDaemonOptions): Promise<DaemonInsta
         return
       }
       res.writeHead(200, { 'content-type': 'text/html; charset=utf-8' })
-      res.end(plan.html)
+      // A decided plan re-served carries its verdict so the page opens locked into the submitted bar.
+      res.end(
+        plan.settled && plan.settledFeedback
+          ? withDecided(plan.html, plan.settledFeedback)
+          : plan.html,
+      )
       return
     }
 

--- a/packages/cli/src/review/daemon.ts
+++ b/packages/cli/src/review/daemon.ts
@@ -68,6 +68,9 @@ function titleFromSource(source: string): string {
 /** One queued plan's full server-side state. */
 interface QueuedPlan {
   entry: QueueEntry
+  /** A stable identity for the plan across iterations (the originating file path), so a requeued
+   * version replaces its predecessor in the queue. Undefined for stdin (no stable key). */
+  key?: string
   /** The plan's self-contained HTML, served from `/plan/<id>`. */
   html: string
   /** Resolvers of held `/__vp_verdict` connections waiting on this plan's decision. */
@@ -86,6 +89,8 @@ interface EnqueueBody {
   iteration?: number
   dir: string
   baseline?: string
+  /** The plan's stable identity (its file path); a new enqueue with the same key replaces the old. */
+  key?: string
 }
 
 export async function startDaemon(opts: StartDaemonOptions): Promise<DaemonInstance> {
@@ -130,6 +135,9 @@ export async function startDaemon(opts: StartDaemonOptions): Promise<DaemonInsta
     plan.settled = true
     plan.settledFeedback = feedback
     plan.entry.status = 'done'
+    // Record the verdict so the sidebar shows the matching icon (approve/deny/iterate), not a
+    // generic "done" mark.
+    plan.entry.decision = feedback.decision
     for (const resolve of plan.waiters) resolve(feedback)
     plan.waiters = []
     broadcast()
@@ -234,6 +242,16 @@ export async function startDaemon(opts: StartDaemonOptions): Promise<DaemonInsta
     // Cancel the idle timer up front: the build below can take longer than a short idleMs, and the
     // daemon must not shut down mid-enqueue. The enqueue itself proves the daemon is wanted.
     cancelIdle()
+    // A requeue (same key) replaces its predecessor, so a plan and its iterations appear once. Drop
+    // the prior version, unblocking any caller still waiting on it (deny) so it cannot hang.
+    if (body.key !== undefined) {
+      for (const [oldId, oldPlan] of plans) {
+        if (oldPlan.key !== body.key) continue
+        for (const resolve of oldPlan.waiters) resolve(oldPlan.draft)
+        oldPlan.waiters = []
+        plans.delete(oldId)
+      }
+    }
     counter += 1
     const id = `p${counter}`
     const html = await buildHtml(body.source, {
@@ -246,8 +264,16 @@ export async function startDaemon(opts: StartDaemonOptions): Promise<DaemonInsta
       title: titleFromSource(body.source),
       dir: body.dir,
       status: 'pending',
+      iteration: body.iteration,
     }
-    plans.set(id, { entry, html, waiters: [], draft: { ...DEFAULT_DENY }, settled: false })
+    plans.set(id, {
+      entry,
+      key: body.key,
+      html,
+      waiters: [],
+      draft: { ...DEFAULT_DENY },
+      settled: false,
+    })
     broadcast()
     res.writeHead(200, { 'content-type': 'application/json; charset=utf-8' })
     res.end(JSON.stringify({ id, shellConnected: eventClients.size > 0 }))

--- a/packages/cli/src/review/daemon.ts
+++ b/packages/cli/src/review/daemon.ts
@@ -1,0 +1,352 @@
+/**
+ * The Review Queue daemon: a single long-lived localhost HTTP server that holds an in-memory queue
+ * of plans awaiting review and a browser "shell" page that lists them. A `vplan review`/`render
+ * --review` invocation enqueues its plan here and waits (via `/__vp_verdict`) for the reviewer's
+ * decision; the shell (held open over SSE on `/__vp_events`) renders the queue and embeds each
+ * plan's page in an iframe served from `/plan/<id>`. Reusing one warm daemon across a planning
+ * session is the whole point: the second plan of a session reuses the open tab instead of paying a
+ * cold start.
+ *
+ * The HTTP/SSE contract here is FROZEN: the runtime shell page depends on the exact endpoints,
+ * field names, and SSE frame shape. See the task's contract section before changing anything.
+ *
+ * `startDaemon` is deliberately a plain `http.createServer` (not Vite) and is directly testable
+ * in-process, like `startReviewServer`: no child process is required to exercise the routing.
+ */
+import { createServer, type IncomingMessage, type ServerResponse } from 'node:http'
+import { type Feedback, feedbackSchema, type QueueEntry } from '@visualplan/core'
+import type { Theme } from '../config.js'
+import { buildHtml } from '../build/compile.js'
+import { buildQueueShell } from '../build/queue-shell.js'
+
+export interface DaemonInstance {
+  port: number
+  close: () => Promise<void>
+}
+
+export interface StartDaemonOptions {
+  /** Port to bind; 0 picks a free port (tests). */
+  port: number
+  /** Idle TTL: ms the daemon lingers after its queue has no pending plans before shutting down. */
+  idleMs: number
+  /** Builds the shell page served at `/`; defaults to the real `buildQueueShell`. Injectable so
+   * tests avoid the slow Vite build. The result is cached after the first call. */
+  getShellHtml?: () => Promise<string>
+  /** Called once when the daemon shuts down (idle TTL or shell close), so the owner can clean up
+   * its lock and exit the process. */
+  onIdle?: () => void
+}
+
+/** The default Deny resolved for a pending plan that is abandoned (tab/shell closed) with no draft. */
+const DEFAULT_DENY: Feedback = { decision: 'deny', comments: [], answers: [] }
+
+/** Grace window after the last events (shell) connection closes before denying pending plans, so a
+ * page reload that briefly drops then reconnects survives. */
+const SHELL_GRACE_MS = 1500
+
+/** Max request body size, mirroring compile.ts's cap so a malformed client cannot stream unbounded. */
+const MAX_BODY_BYTES = 1_000_000
+
+/** Read a request body to a string, capped so a malformed client cannot stream unbounded data. */
+function readBody(req: IncomingMessage): Promise<string> {
+  return new Promise((resolve, reject) => {
+    let raw = ''
+    req.on('data', (chunk: Buffer) => {
+      raw += chunk
+      if (raw.length > MAX_BODY_BYTES) reject(new Error('request body too large'))
+    })
+    req.on('end', () => resolve(raw))
+    req.on('error', reject)
+  })
+}
+
+/** The plan's title is its first `# ` heading line, trimmed; empty string if there is none. */
+function titleFromSource(source: string): string {
+  return source.replace(/^﻿/, '').match(/^# (.+?)\s*$/m)?.[1] ?? ''
+}
+
+/** One queued plan's full server-side state. */
+interface QueuedPlan {
+  entry: QueueEntry
+  /** The plan's self-contained HTML, served from `/plan/<id>`. */
+  html: string
+  /** Resolvers of held `/__vp_verdict` connections waiting on this plan's decision. */
+  waiters: Array<(feedback: Feedback) => void>
+  /** The Deny-on-close payload kept current by `/__vp_draft`. */
+  draft: Feedback
+  /** The feedback this plan settled with, set once it settles; a verdict requested late returns it. */
+  settledFeedback?: Feedback
+  /** True once a decision (or deny) has settled this plan; further feedback is an idempotent no-op. */
+  settled: boolean
+}
+
+interface EnqueueBody {
+  source: string
+  theme?: Theme
+  iteration?: number
+  dir: string
+  baseline?: string
+}
+
+export async function startDaemon(opts: StartDaemonOptions): Promise<DaemonInstance> {
+  const getShellHtml = opts.getShellHtml ?? buildQueueShell
+  const plans = new Map<string, QueuedPlan>()
+  /** Held SSE responses for the shell(s); each gets every queue change. */
+  const eventClients = new Set<ServerResponse>()
+  let counter = 0
+  let shellHtml: string | null = null
+  let idleTimer: ReturnType<typeof setTimeout> | undefined
+  let graceTimer: ReturnType<typeof setTimeout> | undefined
+  let shuttingDown = false
+
+  const queueSnapshot = (): QueueEntry[] => [...plans.values()].map(p => p.entry)
+
+  const broadcast = (): void => {
+    const frame = `event: queue\ndata: ${JSON.stringify(queueSnapshot())}\n\n`
+    for (const res of eventClients) res.write(frame)
+  }
+
+  const hasPending = (): boolean => [...plans.values()].some(p => p.entry.status === 'pending')
+
+  const cancelIdle = (): void => {
+    if (idleTimer) {
+      clearTimeout(idleTimer)
+      idleTimer = undefined
+    }
+  }
+
+  /** Start the idle-shutdown timer when nothing is pending; a new enqueue cancels it. Never re-arms
+   * once shutdown has begun (a late verdict-close during teardown must not resurrect the timer). */
+  const maybeStartIdle = (): void => {
+    if (shuttingDown || hasPending()) return
+    cancelIdle()
+    idleTimer = setTimeout(() => void shutdown(), opts.idleMs)
+  }
+
+  /** Settle a plan exactly once: resolve its waiters, mark it done, broadcast, and arm the idle TTL
+   * if nothing is pending. */
+  const settle = (plan: QueuedPlan, feedback: Feedback): void => {
+    if (plan.settled) return
+    plan.settled = true
+    plan.settledFeedback = feedback
+    plan.entry.status = 'done'
+    for (const resolve of plan.waiters) resolve(feedback)
+    plan.waiters = []
+    broadcast()
+    maybeStartIdle()
+  }
+
+  /** Idempotent shutdown: ends all held connections so the event loop drains, closes the server,
+   * and notifies the owner. Shared by the idle-TTL and shell-close paths. */
+  const shutdown = async (): Promise<void> => {
+    if (shuttingDown) return
+    shuttingDown = true
+    cancelIdle()
+    if (graceTimer) clearTimeout(graceTimer)
+    // End every held connection (SSE shells, long-held verdicts) or close() hangs on them.
+    for (const res of eventClients) res.end()
+    eventClients.clear()
+    await new Promise<void>(resolve => server.close(() => resolve()))
+    opts.onIdle?.()
+  }
+
+  /** Deny all still-pending plans (used when the shell goes away past the grace), then shut down. */
+  const denyAllAndShutdown = async (): Promise<void> => {
+    for (const plan of plans.values()) {
+      if (!plan.settled) settle(plan, plan.draft)
+    }
+    await shutdown()
+  }
+
+  const server = createServer((req, res) => {
+    void route(req, res)
+  })
+
+  async function route(req: IncomingMessage, res: ServerResponse): Promise<void> {
+    const { pathname, searchParams } = new URL(req.url ?? '/', 'http://localhost')
+
+    if (pathname === '/__vp_ping') {
+      res.writeHead(200, { 'content-type': 'text/plain; charset=utf-8' })
+      res.end('ok')
+      return
+    }
+
+    if (pathname === '/') {
+      if (shellHtml === null) shellHtml = await getShellHtml()
+      res.writeHead(200, { 'content-type': 'text/html; charset=utf-8' })
+      res.end(shellHtml)
+      return
+    }
+
+    if (pathname.startsWith('/plan/')) {
+      const plan = plans.get(pathname.slice('/plan/'.length))
+      if (!plan) {
+        res.writeHead(404)
+        res.end('unknown plan')
+        return
+      }
+      res.writeHead(200, { 'content-type': 'text/html; charset=utf-8' })
+      res.end(plan.html)
+      return
+    }
+
+    if (pathname === '/__vp_enqueue') {
+      await handleEnqueue(req, res)
+      return
+    }
+
+    if (pathname === '/__vp_verdict') {
+      handleVerdict(searchParams.get('id'), req, res)
+      return
+    }
+
+    if (pathname === '/__vp_feedback') {
+      await handleSettleRoute(req, res, /* draftOnly */ false)
+      return
+    }
+
+    if (pathname === '/__vp_draft') {
+      await handleSettleRoute(req, res, /* draftOnly */ true)
+      return
+    }
+
+    if (pathname === '/__vp_events') {
+      handleEvents(res)
+      return
+    }
+
+    res.writeHead(404)
+    res.end('not found')
+  }
+
+  async function handleEnqueue(req: IncomingMessage, res: ServerResponse): Promise<void> {
+    let body: EnqueueBody
+    try {
+      body = JSON.parse(await readBody(req)) as EnqueueBody
+      if (typeof body.source !== 'string' || typeof body.dir !== 'string') {
+        throw new Error('source and dir are required')
+      }
+    } catch {
+      res.writeHead(400)
+      res.end('invalid enqueue body')
+      return
+    }
+    // Cancel the idle timer up front: the build below can take longer than a short idleMs, and the
+    // daemon must not shut down mid-enqueue. The enqueue itself proves the daemon is wanted.
+    cancelIdle()
+    counter += 1
+    const id = `p${counter}`
+    const html = await buildHtml(body.source, {
+      theme: body.theme,
+      baseline: body.baseline,
+      review: { planId: id, iteration: body.iteration },
+    })
+    const entry: QueueEntry = {
+      id,
+      title: titleFromSource(body.source),
+      dir: body.dir,
+      status: 'pending',
+    }
+    plans.set(id, { entry, html, waiters: [], draft: { ...DEFAULT_DENY }, settled: false })
+    broadcast()
+    res.writeHead(200, { 'content-type': 'application/json; charset=utf-8' })
+    res.end(JSON.stringify({ id, shellConnected: eventClients.size > 0 }))
+  }
+
+  function handleVerdict(id: string | null, req: IncomingMessage, res: ServerResponse): void {
+    const plan = id ? plans.get(id) : undefined
+    if (!plan) {
+      res.writeHead(404)
+      res.end('unknown plan')
+      return
+    }
+    if (plan.settled) {
+      // Already decided: answer immediately with the feedback it settled with (its waiters were
+      // already resolved at settle time), not the deny-on-close draft.
+      res.writeHead(200, { 'content-type': 'application/json; charset=utf-8' })
+      res.end(JSON.stringify(plan.settledFeedback ?? plan.draft))
+      return
+    }
+    let responded = false
+    plan.waiters.push((feedback: Feedback) => {
+      if (responded) return
+      responded = true
+      res.writeHead(200, { 'content-type': 'application/json; charset=utf-8' })
+      res.end(JSON.stringify(feedback))
+    })
+    // If the caller disconnects before the plan settles, they abandoned it: drop the plan, broadcast,
+    // and arm the idle timer if the queue is now empty. A plan no one awaits is dead weight.
+    req.on('close', () => {
+      if (responded || plan.settled) return
+      plans.delete(plan.entry.id)
+      broadcast()
+      maybeStartIdle()
+    })
+  }
+
+  async function handleSettleRoute(
+    req: IncomingMessage,
+    res: ServerResponse,
+    draftOnly: boolean,
+  ): Promise<void> {
+    let feedback: Feedback
+    try {
+      feedback = feedbackSchema.parse(JSON.parse(await readBody(req)))
+    } catch {
+      res.writeHead(400)
+      res.end('invalid body')
+      return
+    }
+    const plan = feedback.planId ? plans.get(feedback.planId) : undefined
+    if (!plan) {
+      res.writeHead(404)
+      res.end('unknown plan')
+      return
+    }
+    if (draftOnly) {
+      plan.draft = feedback
+    } else {
+      // Feedback for an already-settled plan is an idempotent no-op (the first decision won).
+      settle(plan, feedback)
+    }
+    res.writeHead(200, { 'content-type': 'text/plain; charset=utf-8' })
+    res.end('ok')
+  }
+
+  function handleEvents(res: ServerResponse): void {
+    res.writeHead(200, {
+      'content-type': 'text/event-stream',
+      'cache-control': 'no-cache',
+      connection: 'keep-alive',
+    })
+    // A new shell cancels any in-flight grace shutdown: the shell is back.
+    if (graceTimer) {
+      clearTimeout(graceTimer)
+      graceTimer = undefined
+    }
+    eventClients.add(res)
+    res.write(`event: queue\ndata: ${JSON.stringify(queueSnapshot())}\n\n`)
+    res.on('close', () => {
+      eventClients.delete(res)
+      // When the LAST shell closes, wait a grace window; if still none reconnect, deny all pending
+      // plans and shut down. The events stream is the shell's liveness signal.
+      if (eventClients.size === 0 && !shuttingDown) {
+        if (graceTimer) clearTimeout(graceTimer)
+        graceTimer = setTimeout(() => {
+          if (eventClients.size === 0) void denyAllAndShutdown()
+        }, SHELL_GRACE_MS)
+      }
+    })
+  }
+
+  await new Promise<void>(resolve => server.listen(opts.port, resolve))
+  const address = server.address()
+  const port = typeof address === 'object' && address ? address.port : opts.port
+  // Arm the idle timer from an empty start so a daemon nobody enqueues to does not linger forever.
+  maybeStartIdle()
+
+  return {
+    port,
+    close: () => shutdown(),
+  }
+}

--- a/packages/cli/src/review/daemon.ts
+++ b/packages/cli/src/review/daemon.ts
@@ -66,12 +66,15 @@ function titleFromSource(source: string): string {
 }
 
 /**
- * Inject the decided verdict into a re-served plan page (`__VP_REVIEW_DECIDED__`), so re-opening a
- * plan the reviewer already decided locks into the submitted state instead of showing live controls.
- * A plain head script runs before the deferred runtime module that reads the global.
+ * Inject the decided verdict and the reviewer's answers into a re-served plan page
+ * (`__VP_REVIEW_DECIDED__`, `__VP_REVIEW_ANSWERS__`), so re-opening a plan the reviewer already
+ * decided locks into the submitted state (no live controls) and still shows the answers they gave.
+ * A plain head script runs before the deferred runtime module that reads the globals.
  */
 function withDecided(html: string, feedback: Feedback): string {
-  const tag = `<script>globalThis.__VP_REVIEW_DECIDED__=${JSON.stringify(feedback.decision)}</script>`
+  const tag =
+    `<script>globalThis.__VP_REVIEW_DECIDED__=${JSON.stringify(feedback.decision)};` +
+    `globalThis.__VP_REVIEW_ANSWERS__=${JSON.stringify(feedback.answers ?? [])}</script>`
   return html.includes('</head>') ? html.replace('</head>', `${tag}</head>`) : `${tag}${html}`
 }
 

--- a/packages/cli/src/review/ensure-daemon.ts
+++ b/packages/cli/src/review/ensure-daemon.ts
@@ -1,0 +1,68 @@
+/**
+ * Client-side "connect or start" for the Review Queue daemon. A `vplan review`/`render --review`
+ * invocation calls this to obtain a daemon port: if a lock points at a live daemon, reuse it;
+ * otherwise spawn the daemon as a detached background process and poll until it answers. Racing
+ * callers may both spawn, but the daemon's lock mutex collapses them to one; after spawning, a lock
+ * for a different alive port is adopted.
+ */
+import { spawn as spawnChild } from 'node:child_process'
+import { configDir as defaultConfigDir } from '../config.js'
+import { isDaemonAlive, readLock } from './lockfile.js'
+import { resolveCliEntry } from './cli-entry.js'
+
+/** Default daemon port, distinct from the dev/review server's 9140 so a daemon and a one-shot
+ * `--watch`/`--no-daemon` review can coexist. The daemon increments from here if the port is taken. */
+export const DEFAULT_DAEMON_PORT = 9151
+
+export interface EnsureDaemonOptions {
+  /** Config/lock directory; defaults to the real `~/.vplan`. */
+  configDir?: string
+  /** Idle TTL passed to a freshly spawned daemon. */
+  idleMs: number
+  /** Port to ask a freshly spawned daemon to bind; defaults to `DEFAULT_DAEMON_PORT`. */
+  defaultPort?: number
+  /** Max time to poll for a spawned daemon to come alive before giving up. */
+  pollTimeoutMs?: number
+  /** Spawns the detached daemon process; injectable for tests. Defaults to the real spawn. */
+  spawn?: (port: number, idleMs: number) => void | Promise<void>
+}
+
+/** Default spawn: launch this CLI's own entry as a detached `__review-daemon` process and unref it
+ * so the foreground CLI can exit independently. */
+function spawnDaemonProcess(port: number, idleMs: number): void {
+  const entry = resolveCliEntry()
+  spawnChild(
+    process.execPath,
+    [entry, '__review-daemon', '--port', String(port), '--idle', String(idleMs)],
+    { detached: true, stdio: 'ignore' },
+  ).unref()
+}
+
+/** Resolve the daemon's port, starting it if necessary. */
+export async function ensureDaemon(opts: EnsureDaemonOptions): Promise<{ port: number }> {
+  const dir = opts.configDir ?? defaultConfigDir
+  const port = opts.defaultPort ?? DEFAULT_DAEMON_PORT
+  const pollTimeoutMs = opts.pollTimeoutMs ?? 10_000
+  const spawn = opts.spawn ?? spawnDaemonProcess
+
+  // Fast path: a lock pointing at a live daemon means reuse it, no spawn.
+  const existing = await readLock(dir)
+  if (existing && (await isDaemonAlive(existing.port))) {
+    return { port: existing.port }
+  }
+
+  // No live daemon: start one (best-effort; a racing caller may also spawn, the lock mutex resolves
+  // it) and poll until the lock names an alive daemon. The winning daemon's port may differ from the
+  // one we asked for (another caller won, or the daemon incremented past a taken port).
+  await spawn(port, opts.idleMs)
+
+  const deadline = Date.now() + pollTimeoutMs
+  while (Date.now() < deadline) {
+    const lock = await readLock(dir)
+    if (lock && (await isDaemonAlive(lock.port))) {
+      return { port: lock.port }
+    }
+    await new Promise(resolve => setTimeout(resolve, 100))
+  }
+  throw new Error('Review Queue daemon did not come alive in time')
+}

--- a/packages/cli/src/review/lockfile.ts
+++ b/packages/cli/src/review/lockfile.ts
@@ -1,0 +1,80 @@
+/**
+ * Discovery + mutex for the single machine-wide Review Queue daemon. The lock file at
+ * `~/.vplan/review-daemon.json` is how a fresh CLI invocation finds an already-running daemon (read
+ * the port, ping it) and how two racing invocations agree on one daemon: `writeLockExclusive` uses
+ * the `wx` open flag so the write itself is the atomic claim. `dir` overrides the directory for
+ * tests, mirroring `config.ts`.
+ */
+import { readFile, rm, writeFile } from 'node:fs/promises'
+import { join } from 'node:path'
+import { configDir } from '../config.js'
+
+/** The daemon's advertised endpoint: the port it serves on and the pid that owns it. */
+export interface DaemonLock {
+  port: number
+  pid: number
+}
+
+/** Path to the lock file within `dir` (defaults to the real `~/.vplan`). */
+function lockPath(dir: string = configDir): string {
+  return join(dir, 'review-daemon.json')
+}
+
+/**
+ * Read the daemon lock, or null when it is absent or unparseable. A garbage lock (a half-written
+ * file, a leftover from a crash) must read as "no daemon" so discovery falls through to starting a
+ * fresh one rather than crashing.
+ */
+export async function readLock(dir: string = configDir): Promise<DaemonLock | null> {
+  try {
+    const parsed = JSON.parse(await readFile(lockPath(dir), 'utf8')) as Partial<DaemonLock>
+    if (typeof parsed?.port === 'number' && typeof parsed?.pid === 'number') {
+      return { port: parsed.port, pid: parsed.pid }
+    }
+    return null
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Atomically claim the daemon lock. Returns true if this writer created the file, false if it
+ * already existed (another daemon won). The `wx` flag makes the create-or-fail a single syscall, so
+ * two daemons racing to start collapse to one without a separate check-then-write window. The dir is
+ * not created here: the daemon writes the lock only after `~/.vplan` exists (the daemon process
+ * ensures it), and tests pass a real temp dir.
+ */
+export async function writeLockExclusive(
+  lock: DaemonLock,
+  dir: string = configDir,
+): Promise<boolean> {
+  try {
+    await writeFile(lockPath(dir), `${JSON.stringify(lock)}\n`, { flag: 'wx' })
+    return true
+  } catch {
+    return false
+  }
+}
+
+/** Remove the lock if present; a no-op when it is already gone (force). */
+export async function removeLock(dir: string = configDir): Promise<void> {
+  await rm(lockPath(dir), { force: true })
+}
+
+/**
+ * Probe whether a daemon is actually listening on `port` by hitting its liveness endpoint, true iff
+ * it answers 200. A short timeout via AbortController keeps discovery snappy and treats a dead or
+ * stale port (connection refused, no response) as not-alive rather than hanging.
+ */
+export async function isDaemonAlive(port: number, timeoutMs = 500): Promise<boolean> {
+  const controller = new AbortController()
+  const timer = setTimeout(() => controller.abort(), timeoutMs)
+  try {
+    const res = await fetch(`http://localhost:${port}/__vp_ping`, { signal: controller.signal })
+    return res.status === 200
+  } catch {
+    return false
+  } finally {
+    clearTimeout(timer)
+  }
+}

--- a/packages/cli/tests/config-command.test.ts
+++ b/packages/cli/tests/config-command.test.ts
@@ -23,18 +23,31 @@ afterEach(async () => {
   await rm(dir, { recursive: true, force: true })
 })
 
+const DAEMON_15M = 15 * 60 * 1000
+
 describe('config set', () => {
   it('persists a valid theme and confirms it (golden)', async () => {
     await runConfigSet('theme', 'dark', dir)
-    expect(await readConfig(dir)).toEqual({ theme: 'dark' })
+    expect(await readConfig(dir)).toEqual({ theme: 'dark', daemonTimeout: DAEMON_15M })
     expect(out.join('')).toContain('Set theme = dark')
+  })
+
+  it('persists daemonTimeout as parsed milliseconds, preserving theme (golden)', async () => {
+    await runConfigSet('theme', 'light', dir)
+    out = []
+    await runConfigSet('daemonTimeout', '30m', dir)
+    expect(await readConfig(dir)).toEqual({ theme: 'light', daemonTimeout: 30 * 60 * 1000 })
+    expect(out.join('')).toContain(`Set daemonTimeout = ${30 * 60 * 1000}`)
   })
 
   it('rejects an invalid value or unknown key without writing (error)', async () => {
     await expect(runConfigSet('theme', 'neon', dir)).rejects.toThrow(/Invalid theme "neon"/)
     await expect(runConfigSet('color', 'dark', dir)).rejects.toThrow(/Unknown config key "color"/)
-    // Nothing was written, so a read still returns the default.
-    expect(await readConfig(dir)).toEqual({ theme: 'system' })
+    await expect(runConfigSet('daemonTimeout', 'soon', dir)).rejects.toThrow(
+      /Invalid daemonTimeout "soon"/,
+    )
+    // Nothing was written, so a read still returns the defaults.
+    expect(await readConfig(dir)).toEqual({ theme: 'system', daemonTimeout: DAEMON_15M })
   })
 })
 
@@ -52,11 +65,21 @@ describe('config get', () => {
 })
 
 describe('config show', () => {
-  it('prints the default theme and the path when no file exists yet (edge)', async () => {
+  it('prints the default settings and the path when no file exists yet (edge)', async () => {
     await runConfigShow(dir)
     const text = out.join('')
     expect(text).toContain('theme = system')
+    expect(text).toContain(`daemonTimeout = ${DAEMON_15M}`)
     expect(text).toContain(join(dir, 'config.json'))
+  })
+})
+
+describe('config get', () => {
+  it('prints daemonTimeout in milliseconds (golden)', async () => {
+    await runConfigSet('daemonTimeout', '1h', dir)
+    out = []
+    await runConfigGet('daemonTimeout', dir)
+    expect(out.join('')).toBe(`${60 * 60 * 1000}\n`)
   })
 })
 

--- a/packages/cli/tests/config.test.ts
+++ b/packages/cli/tests/config.test.ts
@@ -15,35 +15,53 @@ afterEach(async () => {
   await rm(dir, { recursive: true, force: true })
 })
 
+const DAEMON_15M = 15 * 60 * 1000
+
 describe('readConfig', () => {
-  it('reads a stored theme (golden)', async () => {
-    await writeFile(join(dir, 'config.json'), JSON.stringify({ theme: 'dark' }))
-    expect(await readConfig(dir)).toEqual({ theme: 'dark' })
+  it('reads a stored theme and daemonTimeout (golden)', async () => {
+    await writeFile(
+      join(dir, 'config.json'),
+      JSON.stringify({ theme: 'dark', daemonTimeout: 60000 }),
+    )
+    expect(await readConfig(dir)).toEqual({ theme: 'dark', daemonTimeout: 60000 })
   })
 
-  it('defaults to system on malformed JSON or an unknown theme (error)', async () => {
+  it('defaults each field on malformed JSON or an unknown theme (error)', async () => {
     await writeFile(join(dir, 'config.json'), '{ not json')
-    expect(await readConfig(dir)).toEqual({ theme: 'system' })
+    expect(await readConfig(dir)).toEqual({ theme: 'system', daemonTimeout: DAEMON_15M })
 
     await writeFile(join(dir, 'config.json'), JSON.stringify({ theme: 'neon' }))
-    expect(await readConfig(dir)).toEqual({ theme: 'system' })
+    expect(await readConfig(dir)).toEqual({ theme: 'system', daemonTimeout: DAEMON_15M })
   })
 
-  it('defaults to system when the file is absent (edge)', async () => {
-    expect(await readConfig(dir)).toEqual({ theme: 'system' })
+  it('falls back to the default daemonTimeout for a non-positive or non-integer value (edge)', async () => {
+    // A stored theme is kept while only the bad daemonTimeout falls back, proving the fields are
+    // validated independently rather than the whole file being rejected.
+    await writeFile(join(dir, 'config.json'), JSON.stringify({ theme: 'light', daemonTimeout: -5 }))
+    expect(await readConfig(dir)).toEqual({ theme: 'light', daemonTimeout: DAEMON_15M })
+
+    await writeFile(
+      join(dir, 'config.json'),
+      JSON.stringify({ theme: 'light', daemonTimeout: 1.5 }),
+    )
+    expect(await readConfig(dir)).toEqual({ theme: 'light', daemonTimeout: DAEMON_15M })
+  })
+
+  it('defaults both fields when the file is absent (edge)', async () => {
+    expect(await readConfig(dir)).toEqual({ theme: 'system', daemonTimeout: DAEMON_15M })
   })
 })
 
 describe('writeConfig', () => {
   it('persists a config that readConfig round-trips (golden)', async () => {
-    await writeConfig({ theme: 'light' }, dir)
-    expect(await readConfig(dir)).toEqual({ theme: 'light' })
+    await writeConfig({ theme: 'light', daemonTimeout: 90000 }, dir)
+    expect(await readConfig(dir)).toEqual({ theme: 'light', daemonTimeout: 90000 })
   })
 
   it('creates the config directory if it does not exist (edge)', async () => {
     const nested = join(dir, 'does', 'not', 'exist')
-    await writeConfig({ theme: 'dark' }, nested)
+    await writeConfig({ theme: 'dark', daemonTimeout: DAEMON_15M }, nested)
     const written = JSON.parse(await readFile(join(nested, 'config.json'), 'utf8'))
-    expect(written).toEqual({ theme: 'dark' })
+    expect(written).toEqual({ theme: 'dark', daemonTimeout: DAEMON_15M })
   })
 })

--- a/packages/cli/tests/io.test.ts
+++ b/packages/cli/tests/io.test.ts
@@ -1,5 +1,5 @@
 // @vitest-environment node
-import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { Readable } from 'node:stream'
@@ -130,6 +130,14 @@ describe('runRender output routing', () => {
     const out = capture('stdout')
     await runRender(path, { stdout: true, open: false })
     const html = out()
+    expect(html.startsWith('<!doctype html>')).toBe(true)
+    expect(html).toContain('id="root"')
+  }, 60_000)
+
+  it('writes <file>.plan.html with --static (the pre-review default) (golden)', async () => {
+    const path = await writePlan('render-static.mdx', VALID_PLAN)
+    await runRender(path, { static: true, open: false })
+    const html = await readFile(path.replace(/\.mdx$/, '.plan.html'), 'utf8')
     expect(html.startsWith('<!doctype html>')).toBe(true)
     expect(html).toContain('id="root"')
   }, 60_000)

--- a/packages/cli/tests/open-command.test.ts
+++ b/packages/cli/tests/open-command.test.ts
@@ -1,0 +1,63 @@
+// @vitest-environment node
+import { describe, expect, it } from 'vitest'
+import { type OpenDeps, runOpen } from '../src/commands/open.js'
+
+/** A deps double that records the daemon idleMs, the opened URL, and stdout writes. */
+function fakeDeps(port = 9151): {
+  deps: OpenDeps
+  calls: { idleMs?: number; opened: string[]; out: string[] }
+} {
+  const calls = {
+    idleMs: undefined as number | undefined,
+    opened: [] as string[],
+    out: [] as string[],
+  }
+  const deps: OpenDeps = {
+    ensureDaemon: async idleMs => {
+      calls.idleMs = idleMs
+      return { port }
+    },
+    openBrowser: async url => {
+      calls.opened.push(url)
+    },
+    stdout: {
+      write: (chunk: string | Uint8Array) => calls.out.push(String(chunk)),
+    } as unknown as NodeJS.WriteStream,
+  }
+  return { deps, calls }
+}
+
+describe('runOpen', () => {
+  it('starts/reuses the daemon and opens its queue URL (golden)', async () => {
+    const { deps, calls } = fakeDeps(9151)
+    await runOpen({}, deps)
+    expect(calls.opened).toEqual(['http://localhost:9151/'])
+    expect(calls.out.join('')).toContain('http://localhost:9151/')
+  })
+
+  it('passes the configured daemon idle TTL through to ensureDaemon (golden)', async () => {
+    const { deps, calls } = fakeDeps()
+    await runOpen({}, deps)
+    // readConfig supplies daemonTimeout (default 15m when unset); it must be a positive ms value.
+    expect(typeof calls.idleMs).toBe('number')
+    expect(calls.idleMs).toBeGreaterThan(0)
+  })
+
+  it('prints the URL but does not open a browser with --no-open (edge)', async () => {
+    const { deps, calls } = fakeDeps(9152)
+    await runOpen({ open: false }, deps)
+    expect(calls.opened).toEqual([])
+    expect(calls.out.join('')).toContain('http://localhost:9152/')
+  })
+
+  it('rejects when the daemon cannot be started (error)', async () => {
+    const deps: OpenDeps = {
+      ensureDaemon: async () => {
+        throw new Error('daemon did not come alive')
+      },
+      openBrowser: async () => {},
+      stdout: { write: () => true } as unknown as NodeJS.WriteStream,
+    }
+    await expect(runOpen({}, deps)).rejects.toThrow(/daemon did not come alive/)
+  })
+})

--- a/packages/cli/tests/queue-shell.test.ts
+++ b/packages/cli/tests/queue-shell.test.ts
@@ -1,0 +1,31 @@
+// @vitest-environment node
+import { describe, expect, it } from 'vitest'
+import { buildQueueShell } from '../src/build/queue-shell.js'
+
+describe('buildQueueShell', () => {
+  let html: string
+
+  it('builds a self-contained shell page with a mount root (golden)', async () => {
+    html = await buildQueueShell()
+    expect(html).toContain('<!doctype html>')
+    expect(html).toContain('id="root"')
+    expect(html).toContain('Review Queue')
+  })
+
+  it('inlines all JS and CSS so the daemon serves one string (golden)', async () => {
+    html ??= await buildQueueShell()
+    // A negative scan for external <script src>/<link href> is unreliable: those strings appear as
+    // JS literals inside the bundle. Assert the positive instead (matching compile.test.ts): the app
+    // ships as an inline module script and the CSS as an inline <style> with content.
+    expect(html).toMatch(/<script type="module"[^>]*>\s*\S/)
+    expect(html).toMatch(/<style[^>]*>\s*\S/)
+  })
+
+  it('does not inject any plan/virtual:plan content (edge)', async () => {
+    html ??= await buildQueueShell()
+    // The shell has no MDX plan, only the React shell app; the plan-only injected globals must be
+    // absent so the shell never tries to mount plan content.
+    expect(html).not.toContain('__VP_SHARE__')
+    expect(html).not.toContain('virtual:plan')
+  })
+}, 60_000)

--- a/packages/cli/tests/review-client.test.ts
+++ b/packages/cli/tests/review-client.test.ts
@@ -1,0 +1,67 @@
+// @vitest-environment node
+import { afterEach, describe, expect, it } from 'vitest'
+import { type DaemonInstance, startDaemon } from '../src/review/daemon.js'
+import { awaitVerdict, enqueuePlan } from '../src/review/client.js'
+
+const SHELL = '<!doctype html><title>shell</title>'
+
+async function fakeDaemon(idleMs = 60_000): Promise<DaemonInstance> {
+  return startDaemon({ port: 0, idleMs, getShellHtml: async () => SHELL })
+}
+
+describe('enqueuePlan', () => {
+  let d: DaemonInstance
+  afterEach(async () => {
+    await d?.close()
+  })
+
+  it('enqueues and returns the assigned id and shellConnected (golden)', async () => {
+    d = await fakeDaemon()
+    const res = await enqueuePlan(d.port, { source: '# T\n\nx\n', dir: 'proj' })
+    expect(res.id).toBe('p1')
+    expect(res.shellConnected).toBe(false)
+  }, 60_000)
+
+  it('rejects when the daemon refuses the body (error)', async () => {
+    d = await fakeDaemon()
+    // The daemon requires a string `source`; passing none yields a 400 the client must surface as a
+    // rejection rather than silently returning a bad value.
+    await expect(
+      enqueuePlan(d.port, { dir: 'proj' } as { source: string; dir: string }),
+    ).rejects.toThrow()
+  }, 60_000)
+})
+
+describe('awaitVerdict', () => {
+  let d: DaemonInstance
+  afterEach(async () => {
+    await d?.close()
+  })
+
+  it('resolves with the Feedback once the plan settles (golden)', async () => {
+    d = await fakeDaemon()
+    const { id } = await enqueuePlan(d.port, { source: '# T\n\nx\n', dir: 'proj' })
+    const verdictP = awaitVerdict(d.port, id)
+    await new Promise(r => setTimeout(r, 50))
+    await fetch(`http://localhost:${d.port}/__vp_feedback`, {
+      method: 'POST',
+      body: JSON.stringify({ decision: 'approve', planId: id }),
+    })
+    await expect(verdictP).resolves.toMatchObject({ decision: 'approve' })
+  }, 60_000)
+
+  it('rejects for an unknown plan id (error)', async () => {
+    d = await fakeDaemon()
+    await expect(awaitVerdict(d.port, 'ghost')).rejects.toThrow()
+  }, 60_000)
+
+  it('rejects and aborts the request when the signal fires (edge)', async () => {
+    d = await fakeDaemon()
+    const { id } = await enqueuePlan(d.port, { source: '# T\n\nx\n', dir: 'proj' })
+    const controller = new AbortController()
+    const verdictP = awaitVerdict(d.port, id, controller.signal)
+    await new Promise(r => setTimeout(r, 50))
+    controller.abort()
+    await expect(verdictP).rejects.toThrow()
+  }, 60_000)
+})

--- a/packages/cli/tests/review-daemon-command.test.ts
+++ b/packages/cli/tests/review-daemon-command.test.ts
@@ -1,0 +1,66 @@
+// @vitest-environment node
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { runReviewDaemon } from '../src/commands/review-daemon.js'
+import { readLock, writeLockExclusive } from '../src/review/lockfile.js'
+import type { DaemonInstance } from '../src/review/daemon.js'
+
+let dir: string
+
+beforeEach(async () => {
+  dir = await mkdtemp(join(tmpdir(), 'visualplan-daemon-cmd-test-'))
+})
+
+afterEach(async () => {
+  await rm(dir, { recursive: true, force: true })
+})
+
+/** A fake daemon that records close() and lets the test control its bound port. */
+function fakeInstance(port: number): DaemonInstance & { closed: boolean } {
+  const inst = {
+    port,
+    closed: false,
+    close: async () => {
+      inst.closed = true
+    },
+  }
+  return inst
+}
+
+describe('runReviewDaemon', () => {
+  it('starts the daemon and writes the lock with the bound port and pid (golden)', async () => {
+    const inst = fakeInstance(9151)
+    await runReviewDaemon(
+      { port: 9151, idleMs: 1000 },
+      { configDir: dir, startDaemon: async () => inst, isAlive: async () => false },
+    )
+    expect(await readLock(dir)).toEqual({ port: 9151, pid: process.pid })
+    expect(inst.closed).toBe(false)
+  })
+
+  it('closes the daemon and does not overwrite the lock when it loses the mutex race (error)', async () => {
+    // Another daemon already owns the lock with a DIFFERENT port; the loser must close and leave it.
+    await writeLockExclusive({ port: 8000, pid: 111 }, dir)
+    const inst = fakeInstance(9151)
+    await runReviewDaemon(
+      { port: 9151, idleMs: 1000 },
+      { configDir: dir, startDaemon: async () => inst, isAlive: async () => true },
+    )
+    expect(inst.closed).toBe(true)
+    expect(await readLock(dir)).toEqual({ port: 8000, pid: 111 })
+  })
+
+  it('clears a stale lock then acquires it on retry (edge)', async () => {
+    // A leftover lock points at a dead daemon (isAlive false); the daemon clears it and wins.
+    await writeLockExclusive({ port: 8000, pid: 111 }, dir)
+    const inst = fakeInstance(9151)
+    await runReviewDaemon(
+      { port: 9151, idleMs: 1000 },
+      { configDir: dir, startDaemon: async () => inst, isAlive: async () => false },
+    )
+    expect(inst.closed).toBe(false)
+    expect(await readLock(dir)).toEqual({ port: 9151, pid: process.pid })
+  })
+})

--- a/packages/cli/tests/review-daemon.test.ts
+++ b/packages/cli/tests/review-daemon.test.ts
@@ -1,0 +1,352 @@
+// @vitest-environment node
+import { afterEach, describe, expect, it } from 'vitest'
+import { type DaemonInstance, startDaemon } from '../src/review/daemon.js'
+
+const SHELL = '<!doctype html><title>shell</title>'
+const PLAN = '# My Plan\n\nbody text\n'
+
+/** A daemon with a fake shell (no slow Vite build) and a fast idle TTL for tests. */
+async function fakeDaemon(
+  overrides: Partial<Parameters<typeof startDaemon>[0]> = {},
+): Promise<DaemonInstance> {
+  return startDaemon({
+    port: 0,
+    idleMs: 200,
+    getShellHtml: async () => SHELL,
+    ...overrides,
+  })
+}
+
+function url(d: DaemonInstance, path: string): string {
+  return `http://localhost:${d.port}${path}`
+}
+
+/** Enqueue a tiny plan; the real buildHtml runs, so callers allow a generous timeout. */
+async function enqueue(
+  d: DaemonInstance,
+  body: Record<string, unknown> = {},
+): Promise<{ id: string; shellConnected: boolean }> {
+  const res = await fetch(url(d, '/__vp_enqueue'), {
+    method: 'POST',
+    body: JSON.stringify({ source: PLAN, dir: 'proj', ...body }),
+  })
+  expect(res.status).toBe(200)
+  return res.json() as Promise<{ id: string; shellConnected: boolean }>
+}
+
+/** Read one SSE `event: queue` frame's parsed data from a held events connection. */
+async function firstQueueEvent(d: DaemonInstance, signal: AbortSignal): Promise<unknown> {
+  const res = await fetch(url(d, '/__vp_events'), {
+    signal,
+    headers: { accept: 'text/event-stream' },
+  })
+  const reader = res.body!.getReader()
+  const decoder = new TextDecoder()
+  let buffer = ''
+  while (true) {
+    const { value, done } = await reader.read()
+    if (done) throw new Error('events stream ended before a frame')
+    buffer += decoder.decode(value, { stream: true })
+    const frame = buffer.match(/event: queue\ndata: (.*)\n\n/)
+    if (frame) return JSON.parse(frame[1])
+  }
+}
+
+describe('daemon liveness and shell', () => {
+  let d: DaemonInstance
+  afterEach(async () => {
+    await d?.close()
+  })
+
+  it('answers /__vp_ping with 200 ok (golden)', async () => {
+    d = await fakeDaemon()
+    const res = await fetch(url(d, '/__vp_ping'))
+    expect(res.status).toBe(200)
+    expect(await res.text()).toBe('ok')
+  })
+
+  it('serves the shell html at / (golden)', async () => {
+    d = await fakeDaemon()
+    const res = await fetch(url(d, '/'))
+    expect(res.status).toBe(200)
+    expect(res.headers.get('content-type')).toContain('text/html')
+    expect(await res.text()).toBe(SHELL)
+  })
+
+  it('404s an unknown plan id (error)', async () => {
+    d = await fakeDaemon()
+    const res = await fetch(url(d, '/plan/nope'))
+    expect(res.status).toBe(404)
+  })
+})
+
+describe('daemon enqueue', () => {
+  let d: DaemonInstance
+  afterEach(async () => {
+    await d?.close()
+  })
+
+  it('enqueues a plan, assigns an id, and serves its html (golden)', async () => {
+    d = await fakeDaemon()
+    const { id } = await enqueue(d)
+    expect(id).toBe('p1')
+    const res = await fetch(url(d, `/plan/${id}`))
+    expect(res.status).toBe(200)
+    expect(res.headers.get('content-type')).toContain('text/html')
+    expect((await res.text()).length).toBeGreaterThan(0)
+  }, 60_000)
+
+  it('extracts the title from the first # heading into the queue entry (golden)', async () => {
+    d = await fakeDaemon()
+    const controller = new AbortController()
+    const eventP = firstQueueEvent(d, controller.signal)
+    await new Promise(r => setTimeout(r, 50))
+    await enqueue(d)
+    // The queue event after enqueue carries the extracted title.
+    let queue = (await eventP) as Array<{ title: string }>
+    if (queue.length === 0) {
+      // The connect frame may arrive empty before enqueue; read the next.
+      queue = (await firstQueueEvent(d, controller.signal)) as Array<{ title: string }>
+    }
+    controller.abort()
+    expect(queue[0]?.title).toBe('My Plan')
+  }, 60_000)
+
+  it('reports shellConnected=true when an events client is connected (edge)', async () => {
+    // Generous idleMs so the start-empty idle timer cannot fire during the build below.
+    d = await fakeDaemon({ idleMs: 60_000 })
+    const controller = new AbortController()
+    // Await the first SSE frame so the connection is provably registered before enqueuing (a fixed
+    // sleep is racy under load): the daemon writes the connect frame synchronously on accept.
+    await firstQueueEvent(d, controller.signal)
+    const { shellConnected } = await enqueue(d)
+    controller.abort()
+    expect(shellConnected).toBe(true)
+  }, 60_000)
+
+  it('rejects an unparseable body with 400 (error)', async () => {
+    d = await fakeDaemon()
+    const res = await fetch(url(d, '/__vp_enqueue'), { method: 'POST', body: '{ not json' })
+    expect(res.status).toBe(400)
+  })
+})
+
+describe('daemon enqueue -> verdict roundtrip', () => {
+  let d: DaemonInstance
+  afterEach(async () => {
+    await d?.close()
+  })
+
+  it('routes a /__vp_feedback POST to the waiting verdict by planId (golden)', async () => {
+    d = await fakeDaemon()
+    const { id } = await enqueue(d)
+    const verdictP = fetch(url(d, `/__vp_verdict?id=${id}`)).then(r => r.json())
+    await new Promise(r => setTimeout(r, 50))
+    const res = await fetch(url(d, '/__vp_feedback'), {
+      method: 'POST',
+      body: JSON.stringify({ decision: 'approve', planId: id }),
+    })
+    expect(res.status).toBe(200)
+    await expect(verdictP).resolves.toMatchObject({ decision: 'approve' })
+  }, 60_000)
+
+  it('routes feedback to the correct plan when two are queued (edge)', async () => {
+    d = await fakeDaemon()
+    const a = await enqueue(d, { source: '# A\n\nx\n' })
+    const b = await enqueue(d, { source: '# B\n\ny\n' })
+    const verdictA = fetch(url(d, `/__vp_verdict?id=${a.id}`)).then(r => r.json())
+    const verdictB = fetch(url(d, `/__vp_verdict?id=${b.id}`)).then(r => r.json())
+    await new Promise(r => setTimeout(r, 50))
+    await fetch(url(d, '/__vp_feedback'), {
+      method: 'POST',
+      body: JSON.stringify({
+        decision: 'iterate',
+        planId: b.id,
+        comments: [{ section: 'B', body: 'fix' }],
+      }),
+    })
+    await fetch(url(d, '/__vp_feedback'), {
+      method: 'POST',
+      body: JSON.stringify({ decision: 'approve', planId: a.id }),
+    })
+    await expect(verdictA).resolves.toMatchObject({ decision: 'approve' })
+    await expect(verdictB).resolves.toMatchObject({ decision: 'iterate' })
+  }, 60_000)
+
+  it('404s a verdict for an unknown id (error)', async () => {
+    d = await fakeDaemon()
+    const res = await fetch(url(d, '/__vp_verdict?id=ghost'))
+    expect(res.status).toBe(404)
+  }, 60_000)
+
+  it('404s feedback for an unknown planId (error)', async () => {
+    d = await fakeDaemon()
+    const res = await fetch(url(d, '/__vp_feedback'), {
+      method: 'POST',
+      body: JSON.stringify({ decision: 'approve', planId: 'ghost' }),
+    })
+    expect(res.status).toBe(404)
+  }, 60_000)
+
+  it('400s an invalid feedback body (error)', async () => {
+    d = await fakeDaemon()
+    const { id } = await enqueue(d)
+    const res = await fetch(url(d, '/__vp_feedback'), {
+      method: 'POST',
+      body: JSON.stringify({ decision: 'nope', planId: id }),
+    })
+    expect(res.status).toBe(400)
+  }, 60_000)
+
+  it('returns the actual decision (not the deny draft) when the plan is already settled (edge)', async () => {
+    d = await fakeDaemon({ idleMs: 60_000 })
+    const { id } = await enqueue(d)
+    await fetch(url(d, '/__vp_feedback'), {
+      method: 'POST',
+      body: JSON.stringify({ decision: 'approve', planId: id }),
+    })
+    // A verdict requested after settling must reflect the recorded approve, not the deny-on-close draft.
+    const late = await fetch(url(d, `/__vp_verdict?id=${id}`)).then(r => r.json())
+    expect(late).toMatchObject({ decision: 'approve' })
+  }, 60_000)
+
+  it('treats a second feedback for a settled plan as an idempotent 200 (edge)', async () => {
+    d = await fakeDaemon({ idleMs: 60_000 })
+    const { id } = await enqueue(d)
+    const first = await fetch(url(d, '/__vp_feedback'), {
+      method: 'POST',
+      body: JSON.stringify({ decision: 'approve', planId: id }),
+    })
+    expect(first.status).toBe(200)
+    const second = await fetch(url(d, '/__vp_feedback'), {
+      method: 'POST',
+      body: JSON.stringify({ decision: 'deny', planId: id }),
+    })
+    expect(second.status).toBe(200)
+  }, 60_000)
+})
+
+describe('daemon caller-disconnect', () => {
+  let d: DaemonInstance
+  afterEach(async () => {
+    await d?.close()
+  })
+
+  it('drops the plan from the queue when the verdict caller disconnects (golden)', async () => {
+    d = await fakeDaemon()
+    const { id } = await enqueue(d)
+    const controller = new AbortController()
+    void fetch(url(d, `/__vp_verdict?id=${id}`), { signal: controller.signal }).catch(() => {})
+    await new Promise(r => setTimeout(r, 100))
+    controller.abort()
+    await new Promise(r => setTimeout(r, 100))
+    // The dropped plan is gone: its html 404s now.
+    const res = await fetch(url(d, `/plan/${id}`))
+    expect(res.status).toBe(404)
+  }, 60_000)
+})
+
+describe('daemon draft', () => {
+  let d: DaemonInstance
+  afterEach(async () => {
+    await d?.close()
+  })
+
+  it('accepts a valid draft for a known plan (golden)', async () => {
+    d = await fakeDaemon()
+    const { id } = await enqueue(d)
+    const res = await fetch(url(d, '/__vp_draft'), {
+      method: 'POST',
+      body: JSON.stringify({
+        decision: 'deny',
+        planId: id,
+        comments: [{ section: 'X', body: 'wip' }],
+      }),
+    })
+    expect(res.status).toBe(200)
+  }, 60_000)
+
+  it('404s a draft for an unknown plan (error)', async () => {
+    d = await fakeDaemon()
+    const res = await fetch(url(d, '/__vp_draft'), {
+      method: 'POST',
+      body: JSON.stringify({ decision: 'deny', planId: 'ghost' }),
+    })
+    expect(res.status).toBe(404)
+  }, 60_000)
+
+  it('400s an invalid draft body (error)', async () => {
+    d = await fakeDaemon()
+    const { id } = await enqueue(d)
+    const res = await fetch(url(d, '/__vp_draft'), {
+      method: 'POST',
+      body: JSON.stringify({ decision: 'nope', planId: id }),
+    })
+    expect(res.status).toBe(400)
+  }, 60_000)
+})
+
+describe('daemon idle TTL', () => {
+  it('shuts down after idleMs with an empty queue and calls onIdle (golden)', async () => {
+    let idled = false
+    const d = await fakeDaemon({ idleMs: 200, onIdle: () => (idled = true) })
+    // Queue never had a pending entry; the idle timer should fire from start-empty.
+    await new Promise(r => setTimeout(r, 400))
+    expect(idled).toBe(true)
+    // The server is closed: the port is dead.
+    await expect(
+      fetch(url(d, '/__vp_ping')).then(
+        () => 'up',
+        () => 'down',
+      ),
+    ).resolves.toBe('down')
+  }, 60_000)
+
+  it('is cancelled by a new enqueue, keeping the daemon alive (edge)', async () => {
+    let idled = false
+    const d = await fakeDaemon({ idleMs: 300, onIdle: () => (idled = true) })
+    await new Promise(r => setTimeout(r, 100))
+    await enqueue(d)
+    await new Promise(r => setTimeout(r, 300))
+    // The enqueue cancelled the start-empty idle timer; with a pending plan it must not have idled.
+    expect(idled).toBe(false)
+    expect((await fetch(url(d, '/__vp_ping'))).status).toBe(200)
+    await d.close()
+  }, 60_000)
+})
+
+describe('daemon shell-close deny-all', () => {
+  it('denies still-pending plans when the last events client closes past the grace (golden)', async () => {
+    const d = await fakeDaemon({ idleMs: 60_000 })
+    const { id } = await enqueue(d)
+    // A caller awaits the verdict; it should resolve to the deny when the shell closes.
+    const verdictP = fetch(url(d, `/__vp_verdict?id=${id}`)).then(r => r.json())
+    // Open and then close the events (shell) connection.
+    const controller = new AbortController()
+    void fetch(url(d, '/__vp_events'), { signal: controller.signal }).catch(() => {})
+    await new Promise(r => setTimeout(r, 100))
+    controller.abort()
+    // Past the 1500ms grace, the pending plan is denied with its default draft.
+    await expect(verdictP).resolves.toMatchObject({ decision: 'deny' })
+  }, 60_000)
+
+  it('survives a brief events reconnect within the grace without denying (edge)', async () => {
+    const d = await fakeDaemon({ idleMs: 60_000 })
+    const { id } = await enqueue(d)
+    const c1 = new AbortController()
+    void fetch(url(d, '/__vp_events'), { signal: c1.signal }).catch(() => {})
+    await new Promise(r => setTimeout(r, 100))
+    c1.abort()
+    // Reconnect well within the 1500ms grace window.
+    await new Promise(r => setTimeout(r, 200))
+    const c2 = new AbortController()
+    void fetch(url(d, '/__vp_events'), { signal: c2.signal }).catch(() => {})
+    // Wait past when the grace would have fired had it not been cancelled.
+    await new Promise(r => setTimeout(r, 1600))
+    // The plan must still be live (not denied): its html still serves.
+    const res = await fetch(url(d, `/plan/${id}`))
+    expect(res.status).toBe(200)
+    c2.abort()
+    await d.close()
+  }, 60_000)
+})

--- a/packages/cli/tests/review-daemon.test.ts
+++ b/packages/cli/tests/review-daemon.test.ts
@@ -350,3 +350,74 @@ describe('daemon shell-close deny-all', () => {
     await d.close()
   }, 60_000)
 })
+
+describe('daemon queue entries: version, decision, requeue dedupe', () => {
+  let d: DaemonInstance
+  afterEach(async () => {
+    await d?.close()
+  })
+
+  it('carries the iteration onto the queued entry (golden)', async () => {
+    d = await fakeDaemon()
+    await enqueue(d, { iteration: 3, key: '/p/a.mdx' })
+    const ctrl = new AbortController()
+    const queue = (await firstQueueEvent(d, ctrl.signal)) as Array<{ iteration?: number }>
+    ctrl.abort()
+    expect(queue).toHaveLength(1)
+    expect(queue[0].iteration).toBe(3)
+  }, 60_000)
+
+  it('records the locked-in decision on the entry once settled (golden)', async () => {
+    d = await fakeDaemon()
+    const { id } = await enqueue(d)
+    await fetch(url(d, '/__vp_feedback'), {
+      method: 'POST',
+      body: JSON.stringify({ decision: 'deny', planId: id }),
+    })
+    const ctrl = new AbortController()
+    const queue = (await firstQueueEvent(d, ctrl.signal)) as Array<{
+      status: string
+      decision?: string
+    }>
+    ctrl.abort()
+    expect(queue[0].status).toBe('done')
+    expect(queue[0].decision).toBe('deny')
+  }, 60_000)
+
+  it('replaces the prior version when requeued with the same key (golden)', async () => {
+    d = await fakeDaemon()
+    const first = await enqueue(d, { key: '/p/a.mdx', iteration: 1 })
+    const second = await enqueue(d, { key: '/p/a.mdx', iteration: 2 })
+    const ctrl = new AbortController()
+    const queue = (await firstQueueEvent(d, ctrl.signal)) as Array<{
+      id: string
+      iteration?: number
+    }>
+    ctrl.abort()
+    expect(queue).toHaveLength(1)
+    expect(queue[0].id).toBe(second.id)
+    expect(queue[0].id).not.toBe(first.id)
+    expect(queue[0].iteration).toBe(2)
+  }, 60_000)
+
+  it('keeps plans with distinct keys as separate entries (edge)', async () => {
+    d = await fakeDaemon()
+    await enqueue(d, { key: '/p/a.mdx' })
+    await enqueue(d, { key: '/p/b.mdx' })
+    const ctrl = new AbortController()
+    const queue = (await firstQueueEvent(d, ctrl.signal)) as unknown[]
+    ctrl.abort()
+    expect(queue).toHaveLength(2)
+  }, 60_000)
+
+  it('unblocks a caller still waiting on the superseded version with a deny (edge)', async () => {
+    d = await fakeDaemon()
+    const first = await enqueue(d, { key: '/p/a.mdx' })
+    const verdict = fetch(url(d, `/__vp_verdict?id=${first.id}`)).then(
+      r => r.json() as Promise<{ decision: string }>,
+    )
+    await new Promise(resolve => setTimeout(resolve, 50))
+    await enqueue(d, { key: '/p/a.mdx' })
+    expect((await verdict).decision).toBe('deny')
+  }, 60_000)
+})

--- a/packages/cli/tests/review-daemon.test.ts
+++ b/packages/cli/tests/review-daemon.test.ts
@@ -421,3 +421,26 @@ describe('daemon queue entries: version, decision, requeue dedupe', () => {
     expect((await verdict).decision).toBe('deny')
   }, 60_000)
 })
+
+describe('daemon /plan decided-verdict injection', () => {
+  let d: DaemonInstance
+  afterEach(async () => {
+    await d?.close()
+  })
+
+  it('injects the verdict into a re-served decided plan, not a pending one (golden)', async () => {
+    d = await fakeDaemon()
+    const { id } = await enqueue(d)
+    // The bundled runtime *reads* the global, so the bare name appears either way; the injected
+    // *assignment* is what marks a decided plan apart from a pending one.
+    const assign = 'globalThis.__VP_REVIEW_DECIDED__="deny"'
+    const pending = await (await fetch(url(d, `/plan/${id}`))).text()
+    expect(pending).not.toContain(assign)
+    await fetch(url(d, '/__vp_feedback'), {
+      method: 'POST',
+      body: JSON.stringify({ decision: 'deny', planId: id }),
+    })
+    const decided = await (await fetch(url(d, `/plan/${id}`))).text()
+    expect(decided).toContain(assign)
+  }, 60_000)
+})

--- a/packages/cli/tests/review-daemon.test.ts
+++ b/packages/cli/tests/review-daemon.test.ts
@@ -438,9 +438,16 @@ describe('daemon /plan decided-verdict injection', () => {
     expect(pending).not.toContain(assign)
     await fetch(url(d, '/__vp_feedback'), {
       method: 'POST',
-      body: JSON.stringify({ decision: 'deny', planId: id }),
+      body: JSON.stringify({
+        decision: 'deny',
+        planId: id,
+        answers: [{ question: 'TTL ok?', answer: 'Yes' }],
+      }),
     })
     const decided = await (await fetch(url(d, `/plan/${id}`))).text()
     expect(decided).toContain(assign)
+    // The reviewer's answers ride along so a re-opened plan still shows them.
+    expect(decided).toContain('__VP_REVIEW_ANSWERS__')
+    expect(decided).toContain('TTL ok?')
   }, 60_000)
 })

--- a/packages/cli/tests/review-ensure-daemon.test.ts
+++ b/packages/cli/tests/review-ensure-daemon.test.ts
@@ -1,0 +1,176 @@
+// @vitest-environment node
+import { spawn as spawnChild } from 'node:child_process'
+import { createServer, type Server } from 'node:http'
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { ensureDaemon } from '../src/review/ensure-daemon.js'
+import { readLock, removeLock, writeLockExclusive } from '../src/review/lockfile.js'
+
+let dir: string
+let servers: Server[]
+
+beforeEach(async () => {
+  dir = await mkdtemp(join(tmpdir(), 'visualplan-ensure-test-'))
+  servers = []
+})
+
+afterEach(async () => {
+  for (const s of servers) await new Promise<void>(resolve => s.close(() => resolve()))
+  await rm(dir, { recursive: true, force: true })
+})
+
+/** A bare server that answers /__vp_ping 200, standing in for a live daemon on a real port. */
+async function pingServer(): Promise<number> {
+  const server = createServer((req, res) => {
+    if (req.url === '/__vp_ping') {
+      res.writeHead(200)
+      res.end('ok')
+      return
+    }
+    res.writeHead(404)
+    res.end()
+  })
+  servers.push(server)
+  await new Promise<void>(resolve => server.listen(0, resolve))
+  return (server.address() as { port: number }).port
+}
+
+describe('ensureDaemon', () => {
+  it('reuses an existing alive daemon without spawning (golden)', async () => {
+    const port = await pingServer()
+    await writeLockExclusive({ port, pid: 999 }, dir)
+    let spawned = false
+    const result = await ensureDaemon({
+      configDir: dir,
+      idleMs: 1000,
+      spawn: () => {
+        spawned = true
+      },
+    })
+    expect(result.port).toBe(port)
+    expect(spawned).toBe(false)
+  })
+
+  it('spawns and polls when no lock exists, then returns the new daemon port (golden)', async () => {
+    const port = await pingServer()
+    const result = await ensureDaemon({
+      configDir: dir,
+      idleMs: 1000,
+      defaultPort: port,
+      // The "spawn" writes the lock the way the real detached daemon would, so polling discovers it.
+      spawn: async (p: number) => {
+        await writeLockExclusive({ port: p, pid: 123 }, dir)
+      },
+    })
+    expect(result.port).toBe(port)
+  })
+
+  it('throws when the spawned daemon never comes alive (error)', async () => {
+    // Bind then immediately free a port so connections are refused; a spawn that does nothing leaves
+    // the daemon dead, so polling times out and ensureDaemon gives up.
+    const probe = createServer()
+    await new Promise<void>(resolve => probe.listen(0, resolve))
+    const deadPort = (probe.address() as { port: number }).port
+    await new Promise<void>(resolve => probe.close(() => resolve()))
+    await expect(
+      ensureDaemon({
+        configDir: dir,
+        idleMs: 1000,
+        defaultPort: deadPort,
+        pollTimeoutMs: 600,
+        spawn: () => {
+          /* spawn does nothing: the daemon never starts */
+        },
+      }),
+    ).rejects.toThrow(/daemon/i)
+  })
+
+  it('uses a different alive port discovered in the lock after a race (edge)', async () => {
+    // Simulate another caller's daemon winning: spawn writes a lock pointing at a DIFFERENT alive
+    // port than the one we asked for, and ensureDaemon adopts it.
+    const winner = await pingServer()
+    const result = await ensureDaemon({
+      configDir: dir,
+      idleMs: 1000,
+      defaultPort: winner + 1, // we asked for a port nobody is on
+      spawn: async () => {
+        await writeLockExclusive({ port: winner, pid: 7 }, dir)
+      },
+    })
+    expect(result.port).toBe(winner)
+  })
+})
+
+// Gated off by default (deterministic suite): set VP_DAEMON_E2E=1 to spawn REAL detached daemon
+// processes from the built `dist/index.js` and prove ensureDaemon starts one and connects end to
+// end, AND that two simultaneous launches collapse to a single surviving daemon (the lock mutex).
+// This is the race the design hinges on, so it is exercised against the real process, not a stub.
+// Requires `pnpm build` first (the detached child runs the compiled CLI entry); the human runs it
+// with VP_DAEMON_E2E=1. A short idle TTL means any orphan self-exits; we also kill by lock pid.
+describe.skipIf(!process.env.VP_DAEMON_E2E)('ensureDaemon real spawn (gated)', () => {
+  // The built CLI entry the detached daemon runs. Under vitest process.argv[1] is the test runner,
+  // not vplan, so we point the spawn at dist/index.js explicitly (in a real install argv[1] is the
+  // bin shim, which resolves there on its own).
+  const builtEntry = join(dirname(fileURLToPath(import.meta.url)), '..', 'dist', 'index.js')
+  const IDLE_MS = 4000
+
+  function realSpawn(port: number, idleMs: number): void {
+    spawnChild(
+      process.execPath,
+      [builtEntry, '__review-daemon', '--port', String(port), '--idle', String(idleMs)],
+      // Point the daemon's lock/state dir at this test's temp dir so it and ensureDaemon agree.
+      { detached: true, stdio: 'ignore', env: { ...process.env, VPLAN_REVIEW_DIR: dir } },
+    ).unref()
+  }
+
+  /** Kill whatever daemon the lock points at and clear the lock, so a test never leaks a process. */
+  async function killDaemon(): Promise<void> {
+    const lock = await readLock(dir)
+    if (!lock) return
+    try {
+      process.kill(lock.pid)
+    } catch {
+      // Already gone (lost the race and exited, or self-exited on idle); nothing to kill.
+    }
+    await removeLock(dir)
+  }
+
+  afterEach(killDaemon)
+
+  it('spawns the actual detached daemon and connects to it', async () => {
+    const { port } = await ensureDaemon({
+      configDir: dir,
+      idleMs: IDLE_MS,
+      defaultPort: 9171,
+      spawn: realSpawn,
+    })
+    const res = await fetch(`http://localhost:${port}/__vp_ping`)
+    expect(res.status).toBe(200)
+  }, 30_000)
+
+  it('collapses two simultaneous launches to one surviving daemon (race)', async () => {
+    // Both callers see no lock and each spawns a real daemon on the same preferred port. The OS lets
+    // only one bind it; the other increments, loses the lock mutex, and exits. Both callers must end
+    // up pointed at the SAME surviving daemon, and exactly one lock must remain.
+    const [a, b] = await Promise.all([
+      ensureDaemon({ configDir: dir, idleMs: IDLE_MS, defaultPort: 9181, spawn: realSpawn }),
+      ensureDaemon({ configDir: dir, idleMs: IDLE_MS, defaultPort: 9181, spawn: realSpawn }),
+    ])
+    expect(a.port).toBe(b.port)
+    const res = await fetch(`http://localhost:${a.port}/__vp_ping`)
+    expect(res.status).toBe(200)
+
+    // The lock names the survivor, and the loser must have exited: only one daemon answers across
+    // the small port window the loser might have transiently bound.
+    const lock = await readLock(dir)
+    expect(lock?.port).toBe(a.port)
+    const loserAlive = await fetch(`http://localhost:${a.port + 1}/__vp_ping`).then(
+      r => r.ok,
+      () => false,
+    )
+    expect(loserAlive).toBe(false)
+  }, 30_000)
+})

--- a/packages/cli/tests/review-lockfile.test.ts
+++ b/packages/cli/tests/review-lockfile.test.ts
@@ -1,0 +1,111 @@
+// @vitest-environment node
+import { createServer } from 'node:http'
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { isDaemonAlive, readLock, removeLock, writeLockExclusive } from '../src/review/lockfile.js'
+
+let dir: string
+
+beforeEach(async () => {
+  dir = await mkdtemp(join(tmpdir(), 'visualplan-lock-test-'))
+})
+
+afterEach(async () => {
+  await rm(dir, { recursive: true, force: true })
+})
+
+describe('writeLockExclusive', () => {
+  it('writes the lock and round-trips via readLock (golden)', async () => {
+    expect(await writeLockExclusive({ port: 9151, pid: 42 }, dir)).toBe(true)
+    expect(await readLock(dir)).toEqual({ port: 9151, pid: 42 })
+  })
+
+  it('refuses a second write when the lock already exists (error: the mutex)', async () => {
+    expect(await writeLockExclusive({ port: 9151, pid: 1 }, dir)).toBe(true)
+    expect(await writeLockExclusive({ port: 9152, pid: 2 }, dir)).toBe(false)
+    // The first writer's value is preserved; the loser did not clobber it.
+    expect(await readLock(dir)).toEqual({ port: 9151, pid: 1 })
+  })
+
+  it('lets exactly one of two concurrent writers win the race (edge)', async () => {
+    const results = await Promise.all([
+      writeLockExclusive({ port: 9151, pid: 1 }, dir),
+      writeLockExclusive({ port: 9152, pid: 2 }, dir),
+    ])
+    expect(results.filter(Boolean)).toHaveLength(1)
+  })
+})
+
+describe('readLock', () => {
+  it('returns null when no lock exists (edge)', async () => {
+    expect(await readLock(dir)).toBeNull()
+  })
+
+  it('returns null for a malformed lock file (error)', async () => {
+    await writeLockExclusive({ port: 9151, pid: 1 }, dir)
+    await removeLock(dir)
+    // A truncated/garbage lock must read as absent, not crash discovery.
+    const { writeFile } = await import('node:fs/promises')
+    await writeFile(join(dir, 'review-daemon.json'), '{ not json')
+    expect(await readLock(dir)).toBeNull()
+  })
+})
+
+describe('removeLock', () => {
+  it('removes an existing lock so a fresh write succeeds (golden)', async () => {
+    await writeLockExclusive({ port: 9151, pid: 1 }, dir)
+    await removeLock(dir)
+    expect(await readLock(dir)).toBeNull()
+    expect(await writeLockExclusive({ port: 9152, pid: 2 }, dir)).toBe(true)
+  })
+
+  it('is a no-op when there is no lock (edge)', async () => {
+    await expect(removeLock(dir)).resolves.toBeUndefined()
+  })
+})
+
+describe('isDaemonAlive', () => {
+  it('returns true when /__vp_ping answers 200 (golden)', async () => {
+    const server = createServer((req, res) => {
+      if (req.url === '/__vp_ping') {
+        res.writeHead(200)
+        res.end('ok')
+        return
+      }
+      res.writeHead(404)
+      res.end()
+    })
+    await new Promise<void>(resolve => server.listen(0, resolve))
+    const port = (server.address() as { port: number }).port
+    try {
+      expect(await isDaemonAlive(port)).toBe(true)
+    } finally {
+      await new Promise<void>(resolve => server.close(() => resolve()))
+    }
+  })
+
+  it('returns false when nothing is listening on the port (error)', async () => {
+    // Bind a port, capture it, then release it so the connection is refused.
+    const probe = createServer()
+    await new Promise<void>(resolve => probe.listen(0, resolve))
+    const port = (probe.address() as { port: number }).port
+    await new Promise<void>(resolve => probe.close(() => resolve()))
+    expect(await isDaemonAlive(port)).toBe(false)
+  })
+
+  it('returns false when the endpoint answers non-200 (edge)', async () => {
+    const server = createServer((_req, res) => {
+      res.writeHead(500)
+      res.end()
+    })
+    await new Promise<void>(resolve => server.listen(0, resolve))
+    const port = (server.address() as { port: number }).port
+    try {
+      expect(await isDaemonAlive(port)).toBe(false)
+    } finally {
+      await new Promise<void>(resolve => server.close(() => resolve()))
+    }
+  })
+})

--- a/packages/cli/tests/review-queue-command.test.ts
+++ b/packages/cli/tests/review-queue-command.test.ts
@@ -1,0 +1,137 @@
+// @vitest-environment node
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { Feedback } from '@visualplan/core'
+import { type ReviewQueueDeps, runReviewQueue } from '../src/commands/review.js'
+
+/** Capture writes to a stream-like sink. */
+function sink(): { write: (s: string) => void; text: () => string } {
+  let buf = ''
+  return { write: (s: string) => (buf += s), text: () => buf }
+}
+
+const prevExit = process.exitCode
+
+afterEach(() => {
+  process.exitCode = prevExit
+})
+
+/** Deps that read fixed sources, enqueue to fake ids, and resolve fixed verdicts after a delay. */
+function deps(
+  verdicts: Record<string, { feedback: Feedback; delayMs: number }>,
+  out: { write: (s: string) => void },
+  opts: { shellConnected?: boolean; opened?: { count: number } } = {},
+): ReviewQueueDeps {
+  let n = 0
+  return {
+    readSource: async (file: string) => `# ${file}\n\nbody\n`,
+    check: async () => [],
+    ensureDaemon: async () => ({ port: 1234 }),
+    enqueue: async () => {
+      n += 1
+      return { id: `p${n}`, shellConnected: opts.shellConnected ?? false }
+    },
+    awaitVerdict: async (_port: number, id: string) => {
+      const v = verdicts[id]
+      await new Promise(r => setTimeout(r, v.delayMs))
+      return v.feedback
+    },
+    openBrowser: async () => {
+      if (opts.opened) opts.opened.count += 1
+    },
+    stdout: out as NodeJS.WriteStream,
+  }
+}
+
+describe('runReviewQueue', () => {
+  it('streams each verdict the instant it resolves, prefixed by its file (golden)', async () => {
+    const out = sink()
+    // b resolves before a, so b's block must appear first despite a being enqueued first.
+    const d = deps(
+      {
+        p1: { feedback: { decision: 'approve', comments: [], answers: [] }, delayMs: 200 },
+        p2: { feedback: { decision: 'iterate', comments: [], answers: [] }, delayMs: 20 },
+      },
+      out,
+    )
+    await runReviewQueue(['a.mdx', 'b.mdx'], {}, d)
+    const text = out.text()
+    expect(text).toContain('a.mdx')
+    expect(text).toContain('b.mdx')
+    expect(text).toContain('DECISION: approve')
+    expect(text).toContain('DECISION: iterate')
+    // b.mdx (faster) streamed before a.mdx.
+    expect(text.indexOf('b.mdx')).toBeLessThan(text.indexOf('a.mdx'))
+  })
+
+  it('exits 0 when all plans are approved and 1 otherwise (golden + error)', async () => {
+    const allApproved = deps(
+      {
+        p1: { feedback: { decision: 'approve', comments: [], answers: [] }, delayMs: 0 },
+        p2: { feedback: { decision: 'approve', comments: [], answers: [] }, delayMs: 0 },
+      },
+      sink(),
+    )
+    process.exitCode = 0
+    await runReviewQueue(['a.mdx', 'b.mdx'], {}, allApproved)
+    expect(process.exitCode ?? 0).toBe(0)
+
+    const oneDenied = deps(
+      {
+        p1: { feedback: { decision: 'approve', comments: [], answers: [] }, delayMs: 0 },
+        p2: { feedback: { decision: 'deny', comments: [], answers: [] }, delayMs: 0 },
+      },
+      sink(),
+    )
+    await runReviewQueue(['a.mdx', 'b.mdx'], {}, oneDenied)
+    expect(process.exitCode).toBe(1)
+  })
+
+  it('emits one JSON object keyed by file with --json (edge)', async () => {
+    const out = sink()
+    const d = deps(
+      {
+        p1: { feedback: { decision: 'approve', comments: [], answers: [] }, delayMs: 0 },
+        p2: { feedback: { decision: 'deny', comments: [], answers: [], note: 'no' }, delayMs: 0 },
+      },
+      out,
+    )
+    await runReviewQueue(['a.mdx', 'b.mdx'], { json: true }, d)
+    const parsed = JSON.parse(out.text())
+    expect(parsed['a.mdx'].decision).toBe('approve')
+    expect(parsed['b.mdx'].decision).toBe('deny')
+    expect(parsed['b.mdx'].note).toBe('no')
+  })
+
+  it('opens the browser only when no shell is connected (edge)', async () => {
+    const opened = { count: 0 }
+    const noShell = deps(
+      { p1: { feedback: { decision: 'approve', comments: [], answers: [] }, delayMs: 0 } },
+      sink(),
+      { shellConnected: false, opened },
+    )
+    await runReviewQueue(['a.mdx'], {}, noShell)
+    expect(opened.count).toBe(1)
+
+    const opened2 = { count: 0 }
+    const withShell = deps(
+      { p1: { feedback: { decision: 'approve', comments: [], answers: [] }, delayMs: 0 } },
+      sink(),
+      { shellConnected: true, opened: opened2 },
+    )
+    await runReviewQueue(['a.mdx'], {}, withShell)
+    expect(opened2.count).toBe(0)
+  })
+
+  it('reports check issues and exits 1 without enqueuing a bad plan (error)', async () => {
+    const out = sink()
+    const enqueue = vi.fn()
+    const d: ReviewQueueDeps = {
+      ...deps({}, out),
+      check: async () => [{ line: 1, column: 1, message: 'bad', severity: 'error' }],
+      enqueue: enqueue as never,
+    }
+    await runReviewQueue(['a.mdx'], {}, d)
+    expect(process.exitCode).toBe(1)
+    expect(enqueue).not.toHaveBeenCalled()
+  })
+})

--- a/packages/cli/tests/review-render-daemon.test.ts
+++ b/packages/cli/tests/review-render-daemon.test.ts
@@ -1,0 +1,88 @@
+// @vitest-environment node
+import { afterEach, describe, expect, it } from 'vitest'
+import type { Feedback } from '@visualplan/core'
+import { type DaemonReviewDeps, runReviewViaDaemon } from '../src/commands/render.js'
+
+const prevExit = process.exitCode
+afterEach(() => {
+  process.exitCode = prevExit
+})
+
+function sink(): { write: (s: string) => void; text: () => string } {
+  let buf = ''
+  return { write: (s: string) => (buf += s), text: () => buf }
+}
+
+function deps(
+  feedback: Feedback,
+  opts: {
+    delayMs?: number
+    shellConnected?: boolean
+    opened?: { count: number }
+    out?: { write: (s: string) => void }
+  } = {},
+): DaemonReviewDeps {
+  return {
+    ensureDaemon: async () => ({ port: 1234 }),
+    enqueue: async () => ({ id: 'p1', shellConnected: opts.shellConnected ?? false }),
+    awaitVerdict: async (_port, _id, signal) =>
+      new Promise<Feedback>((resolve, reject) => {
+        const t = setTimeout(() => resolve(feedback), opts.delayMs ?? 0)
+        signal?.addEventListener('abort', () => {
+          clearTimeout(t)
+          reject(new Error('aborted'))
+        })
+      }),
+    openBrowser: async () => {
+      if (opts.opened) opts.opened.count += 1
+    },
+    stdout: (opts.out ?? sink()) as NodeJS.WriteStream,
+  }
+}
+
+describe('runReviewViaDaemon', () => {
+  it('prints the feedback and sets the exit code from the decision (golden)', async () => {
+    const out = sink()
+    await runReviewViaDaemon(
+      '# P\n\nx\n',
+      'proj',
+      {},
+      deps({ decision: 'iterate', comments: [], answers: [] }, { out }),
+    )
+    expect(out.text()).toContain('DECISION: iterate')
+    expect(process.exitCode).toBe(2)
+  })
+
+  it('times out with exit code 3 when the verdict does not arrive in time (error)', async () => {
+    await runReviewViaDaemon(
+      '# P\n\nx\n',
+      'proj',
+      { timeout: 80 },
+      deps({ decision: 'approve', comments: [], answers: [] }, { delayMs: 5000 }),
+    )
+    expect(process.exitCode).toBe(3)
+  })
+
+  it('opens the browser only when no shell is connected (edge)', async () => {
+    const opened = { count: 0 }
+    await runReviewViaDaemon(
+      '# P\n\nx\n',
+      'proj',
+      {},
+      deps({ decision: 'approve', comments: [], answers: [] }, { shellConnected: true, opened }),
+    )
+    expect(opened.count).toBe(0)
+
+    const opened2 = { count: 0 }
+    await runReviewViaDaemon(
+      '# P\n\nx\n',
+      'proj',
+      {},
+      deps(
+        { decision: 'approve', comments: [], answers: [] },
+        { shellConnected: false, opened: opened2 },
+      ),
+    )
+    expect(opened2.count).toBe(1)
+  })
+})

--- a/packages/cli/tests/review.test.ts
+++ b/packages/cli/tests/review.test.ts
@@ -1,7 +1,7 @@
 // @vitest-environment node
 import { afterEach, describe, expect, it } from 'vitest'
 import { type ReviewServer, startReviewServer } from '../src/build/compile.js'
-import { parseIteration, parseTimeout, runRender } from '../src/commands/render.js'
+import { parseIteration, parseTimeout, rendersReview, runRender } from '../src/commands/render.js'
 import { exitCodeFor, formatFeedback } from '../src/review/format.js'
 
 const PLAN = '# Plan\n\ntext\n'
@@ -78,10 +78,35 @@ describe('parseIteration', () => {
   })
 })
 
+describe('rendersReview (review is the default)', () => {
+  it('defaults to review with no flags, and when --review is explicit (golden)', () => {
+    expect(rendersReview({})).toBe(true)
+    expect(rendersReview({ review: true })).toBe(true)
+  })
+
+  it('opts out of review for any static output flag (golden)', () => {
+    expect(rendersReview({ static: true })).toBe(false)
+    expect(rendersReview({ watch: true })).toBe(false)
+    expect(rendersReview({ stdout: true })).toBe(false)
+    expect(rendersReview({ out: 'plan.html' })).toBe(false)
+  })
+
+  it('keeps review when only review-adjacent flags are set (edge)', () => {
+    // --no-daemon, --iteration, --timeout, and --diff all refine a review; they do not opt out.
+    expect(rendersReview({ noDaemon: true, iteration: 2, timeout: 1000, diff: false })).toBe(true)
+  })
+})
+
 describe('runRender --review guards', () => {
   it('rejects --review combined with an output flag (error)', async () => {
     await expect(runRender('plan.mdx', { review: true, stdout: true })).rejects.toThrow(
       /--review cannot be combined/,
+    )
+  })
+
+  it('rejects --review combined with --static (error)', async () => {
+    await expect(runRender('plan.mdx', { review: true, static: true })).rejects.toThrow(
+      /--review cannot be combined with --static/,
     )
   })
 })

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -40,12 +40,35 @@ export const feedbackSchema = z.object({
   comments: z.array(reviewCommentSchema).default([]),
   answers: z.array(reviewAnswerSchema).default([]),
   note: z.string().optional(),
+  // The queued plan this feedback resolves, set only in Review Queue mode so the daemon can route
+  // the verdict to the caller waiting on this id. Absent for a standalone single `--review`, where
+  // there is exactly one plan and nothing to disambiguate. `formatFeedback` ignores it.
+  planId: z.string().min(1).optional(),
 })
 
 export type ReviewDecision = (typeof REVIEW_DECISION_VALUES)[number]
 export type ReviewComment = z.infer<typeof reviewCommentSchema>
 export type ReviewAnswer = z.infer<typeof reviewAnswerSchema>
 export type Feedback = z.infer<typeof feedbackSchema>
+
+/** The sidebar status of a queued plan in Review Queue mode: waiting, currently shown, or decided. */
+export const QUEUE_STATUS_VALUES = ['pending', 'active', 'done'] as const
+
+/**
+ * One plan in the Review Queue, as the daemon streams it to the sidebar shell. `dir` is the
+ * basename of the directory the plan originated from, shown beside the title so plans from
+ * different projects stay distinguishable in the single machine-wide queue. Isomorphic so the
+ * daemon (which emits entries) and the shell (which renders them) share one contract.
+ */
+export const queueEntrySchema = z.object({
+  id: z.string().min(1),
+  title: z.string(),
+  dir: z.string(),
+  status: z.enum(QUEUE_STATUS_VALUES).default('pending'),
+})
+
+export type QueueStatus = (typeof QUEUE_STATUS_VALUES)[number]
+export type QueueEntry = z.infer<typeof queueEntrySchema>
 
 export const STATUS_VALUES = ['planned', 'active', 'done'] as const
 export const CHANGE_VALUES = ['add', 'modify', 'delete', 'move'] as const

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -65,6 +65,12 @@ export const queueEntrySchema = z.object({
   title: z.string(),
   dir: z.string(),
   status: z.enum(QUEUE_STATUS_VALUES).default('pending'),
+  // The revision number when this plan is a re-review (`--iteration N`); the sidebar shows it as a
+  // `vN` chip for N >= 2. Absent on a first review.
+  iteration: z.number().int().positive().optional(),
+  // The locked-in verdict once the plan is `done`, so the sidebar shows the matching icon (check /
+  // cross / iterate) rather than a generic one. Absent while pending.
+  decision: z.enum(REVIEW_DECISION_VALUES).optional(),
 })
 
 export type QueueStatus = (typeof QUEUE_STATUS_VALUES)[number]

--- a/packages/core/tests/feedback.test.ts
+++ b/packages/core/tests/feedback.test.ts
@@ -31,3 +31,18 @@ describe('feedbackSchema answers', () => {
     expect(parsed.answers).toEqual([{ question: 'TTL ok?', answer: 'Yes, 15m' }])
   })
 })
+
+describe('feedbackSchema planId', () => {
+  it('carries a planId when the Review Queue tags the feedback (golden)', () => {
+    const parsed = feedbackSchema.parse({ decision: 'approve', planId: 'p-1' })
+    expect(parsed.planId).toBe('p-1')
+  })
+
+  it('omits planId for a standalone single review (edge)', () => {
+    expect(feedbackSchema.parse({ decision: 'approve' }).planId).toBeUndefined()
+  })
+
+  it('rejects an empty planId (error)', () => {
+    expect(() => feedbackSchema.parse({ decision: 'approve', planId: '' })).toThrow()
+  })
+})

--- a/packages/core/tests/queue.test.ts
+++ b/packages/core/tests/queue.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest'
+import { QUEUE_STATUS_VALUES, queueEntrySchema } from '../src/index.js'
+
+describe('queueEntrySchema', () => {
+  it('parses a full entry and keeps its fields (golden)', () => {
+    const entry = { id: 'p-1', title: 'Review Queue', dir: 'visualplan', status: 'active' }
+    expect(queueEntrySchema.parse(entry)).toEqual(entry)
+  })
+
+  it('defaults status to pending when omitted (edge)', () => {
+    const parsed = queueEntrySchema.parse({ id: 'p-1', title: 'Plan', dir: 'proj' })
+    expect(parsed.status).toBe('pending')
+  })
+
+  it('rejects an empty id or an unknown status (error)', () => {
+    expect(() => queueEntrySchema.parse({ id: '', title: 'Plan', dir: 'proj' })).toThrow()
+    expect(() =>
+      queueEntrySchema.parse({ id: 'p-1', title: 'Plan', dir: 'proj', status: 'archived' }),
+    ).toThrow()
+  })
+
+  it('allows an empty title and dir for an untitled plan from the cwd (edge)', () => {
+    // A plan need not start with a heading mid-compose, and the cwd basename can be empty at root;
+    // neither should block enqueueing, so only id and status are constrained.
+    const parsed = queueEntrySchema.parse({ id: 'p-1', title: '', dir: '' })
+    expect(parsed).toEqual({ id: 'p-1', title: '', dir: '', status: 'pending' })
+  })
+
+  it('exposes the three sidebar statuses (golden)', () => {
+    expect(QUEUE_STATUS_VALUES).toEqual(['pending', 'active', 'done'])
+  })
+})

--- a/packages/core/tests/queue.test.ts
+++ b/packages/core/tests/queue.test.ts
@@ -29,4 +29,26 @@ describe('queueEntrySchema', () => {
   it('exposes the three sidebar statuses (golden)', () => {
     expect(QUEUE_STATUS_VALUES).toEqual(['pending', 'active', 'done'])
   })
+
+  it('carries an optional iteration and decision for re-reviews (golden)', () => {
+    const parsed = queueEntrySchema.parse({
+      id: 'p-1',
+      title: 'Plan',
+      dir: 'proj',
+      status: 'done',
+      iteration: 2,
+      decision: 'deny',
+    })
+    expect(parsed.iteration).toBe(2)
+    expect(parsed.decision).toBe('deny')
+  })
+
+  it('rejects a zero/negative iteration or an unknown decision (error)', () => {
+    expect(() =>
+      queueEntrySchema.parse({ id: 'p-1', title: 'P', dir: 'd', iteration: 0 }),
+    ).toThrow()
+    expect(() =>
+      queueEntrySchema.parse({ id: 'p-1', title: 'P', dir: 'd', decision: 'maybe' }),
+    ).toThrow()
+  })
 })

--- a/packages/runtime/AGENTS.md
+++ b/packages/runtime/AGENTS.md
@@ -42,6 +42,26 @@ the root AGENTS.md for why Vite is configured without `@vitejs/plugin-react`.
   and stops instead of POSTing or calling `window.close()`, and the keepalive, draft, and `beforeunload`
   effects are all skipped, so the embedded preview is safe to click through and reset. It is never set
   by the CLI.
+- `components/queue/` is the **Review Queue shell**: a second runtime entry (`queue.html` +
+  `queue-main.tsx`, mirroring `index.html`/`main.tsx`) the daemon serves at `/`. It renders NO plan
+  content: just `QueueShell` (chrome) hosting each active plan in a same-origin `<iframe src="/plan/<id>">`.
+  `QueueShell` opens `new EventSource('/__vp_events')` and holds it open for the page lifetime (it is
+  the daemon's liveness signal: closing the tab tears the daemon down, so the stream is closed only on
+  unmount). The daemon emits `event: queue` with a JSON `QueueEntry[]`; the shell defaults the active
+  iframe to the first pending plan and auto-advances when the active one is marked `done`. j/k or
+  arrow keys navigate. `components/queue/logic.ts` holds the **pure**, unit-tested navigation helpers
+  (`firstPendingId`, `nextActiveId`, `moveSelection`, `reviewedCount`); `QueueSidebar.tsx` is the rail
+  (title + muted originating `dir` + Tabler status icon + "N of M reviewed"); `queue.css` is the
+  colocated chrome (the entry imports `theme.css` for the shared `--vp-*` tokens). Built by the CLI's
+  `buildQueueShell()` (`packages/cli/src/build/queue-shell.ts`), a Vite single-file build of `queue.html`
+  with NO plan plugins (no `virtual:plan`/share/diff/review), so the shell ships self-contained.
+  **Queue mode inside a plan iframe** is gated on `__VP_REVIEW_PLAN_ID__` (`isQueueMode()` in
+  `feedback.ts`): its PRESENCE means the plan is one of several in the queue. In queue mode
+  `postFeedback`/`postDraft` tag the POST body with `planId` so the daemon routes the verdict, and
+  `ReviewLayer` does NOT open the `/__vp_alive` keepalive, arm the `beforeunload` prompt, or call
+  `window.close()` on submit (the SHELL owns daemon lifecycle; swapping the iframe must not deny the
+  plan). Draft posting stays ON so a real tab close can still deny-with-draft. An empty id is treated
+  as absent (matches `feedbackSchema`'s `planId.min(1)`).
 - `components/DiffCues.tsx` renders iteration diff cues when the CLI injected `__VP_DIFF__` (any
   render/watch/review with a baseline, NOT review-gated). Always on: a change bar **flush to the left
   edge of the viewport** (`left: 0`, a dedicated lane clear of the content gutter so it never piles up

--- a/packages/runtime/components/Questions.tsx
+++ b/packages/runtime/components/Questions.tsx
@@ -35,30 +35,38 @@ export function Questions(props: QuestionsProps) {
   })
   const answers = useQuestionAnswers()
   const interactive = isReviewMode() && answers !== null
+  // Once the plan is decided the answer fields lock: an answered question stays visible (read-only),
+  // an unanswered one reverts to a plain question.
+  const locked = answers?.locked ?? false
   return (
     <section className='vp-questions'>
       <div className='vp-questions__title'>{title}</div>
       <ol className='vp-questions__list'>
-        {items.map((item, index) => (
-          <li key={item} className='vp-questions__item'>
-            <span className='vp-questions__num' aria-hidden='true'>
-              {index + 1}
-            </span>
-            <div className='vp-questions__body'>
-              <span className='vp-questions__text'>{item}</span>
-              {interactive && (
-                <AutoGrowTextarea
-                  className='vp-questions__answer'
-                  rows={1}
-                  placeholder='Answer this question…'
-                  aria-label={`Answer: ${item}`}
-                  value={answers.answers.get(item) ?? ''}
-                  onChange={event => answers.setAnswer(item, event.target.value)}
-                />
-              )}
-            </div>
-          </li>
-        ))}
+        {items.map((item, index) => {
+          const answer = answers?.answers.get(item) ?? ''
+          const showInput = interactive && (!locked || answer.trim() !== '')
+          return (
+            <li key={item} className='vp-questions__item'>
+              <span className='vp-questions__num' aria-hidden='true'>
+                {index + 1}
+              </span>
+              <div className='vp-questions__body'>
+                <span className='vp-questions__text'>{item}</span>
+                {showInput && answers && (
+                  <AutoGrowTextarea
+                    className='vp-questions__answer'
+                    rows={1}
+                    placeholder='Answer this question…'
+                    aria-label={`Answer: ${item}`}
+                    value={answer}
+                    readOnly={locked}
+                    onChange={event => answers.setAnswer(item, event.target.value)}
+                  />
+                )}
+              </div>
+            </li>
+          )
+        })}
       </ol>
     </section>
   )

--- a/packages/runtime/components/queue/QueueShell.tsx
+++ b/packages/runtime/components/queue/QueueShell.tsx
@@ -1,0 +1,90 @@
+import type { QueueEntry } from '@visualplan/core'
+import { IconChecklist } from '@tabler/icons-react'
+import { useEffect, useRef, useState } from 'react'
+import { firstPendingId, moveSelection, nextActiveId } from './logic.js'
+import { QueueSidebar } from './QueueSidebar.js'
+import './queue.css'
+
+/** The daemon's SSE endpoint, which doubles as the tab's liveness signal. */
+const EVENTS_ENDPOINT = '/__vp_events'
+
+/**
+ * The Review Queue shell the daemon serves at `/`: a left sidebar of queued plans and the active plan
+ * hosted in a same-origin iframe (`/plan/<id>`). It holds the daemon's `/__vp_events` SSE open for the
+ * page's lifetime, which is the daemon's liveness signal (closing the tab tears the daemon down), so
+ * the stream is closed only on unmount. The shell renders no plan content itself: it is pure chrome
+ * plus the iframe, and each plan iframe carries its own review chrome in queue mode.
+ */
+export function QueueShell() {
+  const [entries, setEntries] = useState<QueueEntry[]>([])
+  const [activeId, setActiveId] = useState<string | null>(null)
+
+  // The latest active id, read inside the stream handler without making it a dependency (re-opening
+  // the SSE on every selection would drop the daemon's liveness connection).
+  const activeRef = useRef<string | null>(activeId)
+  activeRef.current = activeId
+
+  useEffect(() => {
+    const source = new EventSource(EVENTS_ENDPOINT)
+    const onQueue = (event: MessageEvent) => {
+      const next = JSON.parse(event.data) as QueueEntry[]
+      setEntries(next)
+      // Default to the first pending plan, and auto-advance once the active plan is marked done.
+      setActiveId(nextActiveId(next, activeRef.current))
+    }
+    source.addEventListener('queue', onQueue)
+    return () => {
+      source.removeEventListener('queue', onQueue)
+      source.close()
+    }
+  }, [])
+
+  // j/k or arrow keys move the active selection; the in-iframe review UI handles every other key.
+  useEffect(() => {
+    const onKey = (event: KeyboardEvent) => {
+      const delta =
+        event.key === 'j' || event.key === 'ArrowDown'
+          ? 1
+          : event.key === 'k' || event.key === 'ArrowUp'
+            ? -1
+            : 0
+      if (delta === 0) return
+      event.preventDefault()
+      setActiveId(current => moveSelection(entries, current, delta))
+    }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [entries])
+
+  const hasPending = firstPendingId(entries) !== null
+
+  return (
+    <div className='vp-queue'>
+      <QueueSidebar entries={entries} activeId={activeId} onSelect={setActiveId} />
+      <main className='vp-queue__main'>
+        {activeId && hasPending ? (
+          <iframe
+            // Re-key on the active id so swapping plans remounts the iframe (a fresh review session)
+            // rather than navigating the same frame.
+            key={activeId}
+            className='vp-queue__frame'
+            src={`/plan/${activeId}`}
+            title='Active plan under review'
+          />
+        ) : (
+          <QueueEmpty hasEntries={entries.length > 0} />
+        )}
+      </main>
+    </div>
+  )
+}
+
+/** The resting state: all queued plans reviewed, or the queue is momentarily empty. */
+function QueueEmpty({ hasEntries }: { hasEntries: boolean }) {
+  return (
+    <div className='vp-queue__empty'>
+      <IconChecklist size={32} stroke={1.5} />
+      <p>{hasEntries ? 'All plans reviewed' : 'No plans in the queue'}</p>
+    </div>
+  )
+}

--- a/packages/runtime/components/queue/QueueShell.tsx
+++ b/packages/runtime/components/queue/QueueShell.tsx
@@ -1,7 +1,7 @@
 import type { QueueEntry } from '@visualplan/core'
 import { IconChecklist } from '@tabler/icons-react'
 import { useEffect, useRef, useState } from 'react'
-import { firstPendingId, moveSelection, nextActiveId } from './logic.js'
+import { firstPendingId, moveSelection, nextActiveId, reviewedCount } from './logic.js'
 import { QueueSidebar } from './QueueSidebar.js'
 import './queue.css'
 
@@ -23,6 +23,11 @@ export function QueueShell() {
   // the SSE on every selection would drop the daemon's liveness connection).
   const activeRef = useRef<string | null>(activeId)
   activeRef.current = activeId
+
+  const containerRef = useRef<HTMLDivElement>(null)
+  // Set when an active change came from keyboard nav (not an SSE-driven auto-advance), so focus
+  // follows the selection then but never gets yanked out from under the user on a background update.
+  const keyboardNavRef = useRef(false)
 
   useEffect(() => {
     const source = new EventSource(EVENTS_ENDPOINT)
@@ -50,19 +55,42 @@ export function QueueShell() {
             : 0
       if (delta === 0) return
       event.preventDefault()
+      keyboardNavRef.current = true
       setActiveId(current => moveSelection(entries, current, delta))
     }
     window.addEventListener('keydown', onKey)
     return () => window.removeEventListener('keydown', onKey)
   }, [entries])
 
+  // After a keyboard move, pull focus to the now-active row so focus and selection stay together
+  // (the roving tabindex makes it the only tabbable row). Skipped for SSE-driven auto-advances.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: refocus on every active-plan change
+  useEffect(() => {
+    if (!keyboardNavRef.current) return
+    keyboardNavRef.current = false
+    containerRef.current?.querySelector<HTMLElement>('.vp-queue__row[tabindex="0"]')?.focus()
+  }, [activeId])
+
   const hasPending = firstPendingId(entries) !== null
   // The sidebar is for navigating BETWEEN plans, so a lone plan shows none: it reads as an ordinary
   // single review. It appears the moment a second plan joins the queue (the SSE drives this live).
   const showSidebar = entries.length > 1
 
+  // Announced to assistive tech as the queue changes (a plan reviewed, the active plan advancing, a
+  // new plan arriving), which are otherwise silent visual updates.
+  const activeTitle = entries.find(entry => entry.id === activeId)?.title ?? null
+  const announcement =
+    entries.length === 0
+      ? ''
+      : `${reviewedCount(entries)} of ${entries.length} plans reviewed${
+          activeTitle ? `. Now reviewing ${activeTitle}` : '.'
+        }`
+
   return (
-    <div className={showSidebar ? 'vp-queue' : 'vp-queue vp-queue--solo'}>
+    <div ref={containerRef} className={showSidebar ? 'vp-queue' : 'vp-queue vp-queue--solo'}>
+      <div className='vp-sr-only' role='status' aria-live='polite'>
+        {announcement}
+      </div>
       {showSidebar && <QueueSidebar entries={entries} activeId={activeId} onSelect={setActiveId} />}
       <main className='vp-queue__main'>
         {activeId && hasPending ? (

--- a/packages/runtime/components/queue/QueueShell.tsx
+++ b/packages/runtime/components/queue/QueueShell.tsx
@@ -2,13 +2,7 @@ import type { QueueEntry } from '@visualplan/core'
 import { IconChecklist } from '@tabler/icons-react'
 import { useEffect, useRef, useState } from 'react'
 import { setActivityDot } from './favicon.js'
-import {
-  firstPendingId,
-  hasNewActivity,
-  moveSelection,
-  nextActiveId,
-  reviewedCount,
-} from './logic.js'
+import { hasNewActivity, moveSelection, nextActiveId, reviewedCount } from './logic.js'
 import { QueueSidebar } from './QueueSidebar.js'
 import './queue.css'
 
@@ -99,14 +93,17 @@ export function QueueShell() {
     containerRef.current?.querySelector<HTMLElement>('.vp-queue__row[tabindex="0"]')?.focus()
   }, [activeId])
 
-  const hasPending = firstPendingId(entries) !== null
   // The sidebar is for navigating BETWEEN plans, so a lone plan shows none: it reads as an ordinary
   // single review. It appears the moment a second plan joins the queue (the SSE drives this live).
   const showSidebar = entries.length > 1
 
+  // The plan to host in the iframe: whichever row is selected, pending or already decided (a decided
+  // plan re-opens locked into its verdict). The empty state shows only when nothing is selected.
+  const activeEntry = entries.find(entry => entry.id === activeId) ?? null
+
   // Announced to assistive tech as the queue changes (a plan reviewed, the active plan advancing, a
   // new plan arriving), which are otherwise silent visual updates.
-  const activeTitle = entries.find(entry => entry.id === activeId)?.title ?? null
+  const activeTitle = activeEntry?.title ?? null
 
   // The tab title tracks the plan being reviewed, so a backgrounded tab is identifiable; it falls
   // back to the queue name when nothing is active (empty or all reviewed).
@@ -127,13 +124,13 @@ export function QueueShell() {
       </div>
       {showSidebar && <QueueSidebar entries={entries} activeId={activeId} onSelect={setActiveId} />}
       <main className='vp-queue__main'>
-        {activeId && hasPending ? (
+        {activeEntry ? (
           <iframe
-            // Re-key on the active id so swapping plans remounts the iframe (a fresh review session)
-            // rather than navigating the same frame.
-            key={activeId}
+            // Re-key on the active id so swapping plans remounts the iframe (a fresh review session,
+            // or a decided plan locked into its verdict) rather than navigating the same frame.
+            key={activeEntry.id}
             className='vp-queue__frame'
-            src={`/plan/${activeId}`}
+            src={`/plan/${activeEntry.id}`}
             title='Active plan under review'
           />
         ) : (

--- a/packages/runtime/components/queue/QueueShell.tsx
+++ b/packages/runtime/components/queue/QueueShell.tsx
@@ -57,10 +57,13 @@ export function QueueShell() {
   }, [entries])
 
   const hasPending = firstPendingId(entries) !== null
+  // The sidebar is for navigating BETWEEN plans, so a lone plan shows none: it reads as an ordinary
+  // single review. It appears the moment a second plan joins the queue (the SSE drives this live).
+  const showSidebar = entries.length > 1
 
   return (
-    <div className='vp-queue'>
-      <QueueSidebar entries={entries} activeId={activeId} onSelect={setActiveId} />
+    <div className={showSidebar ? 'vp-queue' : 'vp-queue vp-queue--solo'}>
+      {showSidebar && <QueueSidebar entries={entries} activeId={activeId} onSelect={setActiveId} />}
       <main className='vp-queue__main'>
         {activeId && hasPending ? (
           <iframe

--- a/packages/runtime/components/queue/QueueShell.tsx
+++ b/packages/runtime/components/queue/QueueShell.tsx
@@ -1,7 +1,14 @@
 import type { QueueEntry } from '@visualplan/core'
 import { IconChecklist } from '@tabler/icons-react'
 import { useEffect, useRef, useState } from 'react'
-import { firstPendingId, moveSelection, nextActiveId, reviewedCount } from './logic.js'
+import { setActivityDot } from './favicon.js'
+import {
+  firstPendingId,
+  hasNewActivity,
+  moveSelection,
+  nextActiveId,
+  reviewedCount,
+} from './logic.js'
 import { QueueSidebar } from './QueueSidebar.js'
 import './queue.css'
 
@@ -29,10 +36,18 @@ export function QueueShell() {
   // follows the selection then but never gets yanked out from under the user on a background update.
   const keyboardNavRef = useRef(false)
 
+  // A favicon dot raised when the queue gains activity (a plan added or updated) while the tab is
+  // backgrounded, cleared when the user focuses the tab again; prevEntriesRef diffs against the
+  // last queue to tell new activity from a no-op redraw.
+  const [unseen, setUnseen] = useState(false)
+  const prevEntriesRef = useRef<QueueEntry[]>([])
+
   useEffect(() => {
     const source = new EventSource(EVENTS_ENDPOINT)
     const onQueue = (event: MessageEvent) => {
       const next = JSON.parse(event.data) as QueueEntry[]
+      if (document.hidden && hasNewActivity(prevEntriesRef.current, next)) setUnseen(true)
+      prevEntriesRef.current = next
       setEntries(next)
       // Default to the first pending plan, and auto-advance once the active plan is marked done.
       setActiveId(nextActiveId(next, activeRef.current))
@@ -43,6 +58,19 @@ export function QueueShell() {
       source.close()
     }
   }, [])
+
+  // Clear the activity dot once the tab is in the foreground again; reflect the flag on the favicon.
+  useEffect(() => {
+    const onVisible = () => {
+      if (!document.hidden) setUnseen(false)
+    }
+    document.addEventListener('visibilitychange', onVisible)
+    return () => document.removeEventListener('visibilitychange', onVisible)
+  }, [])
+
+  useEffect(() => {
+    setActivityDot(unseen)
+  }, [unseen])
 
   // j/k or arrow keys move the active selection; the in-iframe review UI handles every other key.
   useEffect(() => {
@@ -83,7 +111,7 @@ export function QueueShell() {
   // The tab title tracks the plan being reviewed, so a backgrounded tab is identifiable; it falls
   // back to the queue name when nothing is active (empty or all reviewed).
   useEffect(() => {
-    document.title = activeTitle || 'Plans to Review'
+    document.title = activeTitle || 'Visual Plan Review Queue'
   }, [activeTitle])
   const announcement =
     entries.length === 0

--- a/packages/runtime/components/queue/QueueShell.tsx
+++ b/packages/runtime/components/queue/QueueShell.tsx
@@ -79,6 +79,12 @@ export function QueueShell() {
   // Announced to assistive tech as the queue changes (a plan reviewed, the active plan advancing, a
   // new plan arriving), which are otherwise silent visual updates.
   const activeTitle = entries.find(entry => entry.id === activeId)?.title ?? null
+
+  // The tab title tracks the plan being reviewed, so a backgrounded tab is identifiable; it falls
+  // back to the queue name when nothing is active (empty or all reviewed).
+  useEffect(() => {
+    document.title = activeTitle || 'Plans to Review'
+  }, [activeTitle])
   const announcement =
     entries.length === 0
       ? ''

--- a/packages/runtime/components/queue/QueueSidebar.tsx
+++ b/packages/runtime/components/queue/QueueSidebar.tsx
@@ -1,0 +1,57 @@
+import type { QueueEntry } from '@visualplan/core'
+import { IconCircle, IconCircleCheckFilled } from '@tabler/icons-react'
+import { reviewedCount } from './logic.js'
+
+/**
+ * The left rail of the Review Queue shell: one row per queued plan with its title, the originating
+ * directory (muted, so plans from different projects stay distinguishable in the one machine-wide
+ * queue), and a status indicator (an open circle while pending, a filled check once reviewed). A
+ * progress count summarizes how many of the queue have been decided. Pure presentation: navigation
+ * and active state are owned by `QueueShell`.
+ */
+export function QueueSidebar({
+  entries,
+  activeId,
+  onSelect,
+}: {
+  entries: QueueEntry[]
+  activeId: string | null
+  onSelect: (id: string) => void
+}) {
+  const reviewed = reviewedCount(entries)
+  return (
+    <aside className='vp-queue__sidebar'>
+      <header className='vp-queue__head'>
+        <span className='vp-queue__title'>Review queue</span>
+        <span className='vp-queue__count'>
+          {reviewed} of {entries.length} reviewed
+        </span>
+      </header>
+      <ul className='vp-queue__list'>
+        {entries.map(entry => {
+          const done = entry.status === 'done'
+          return (
+            <li key={entry.id}>
+              <button
+                type='button'
+                className='vp-queue__row'
+                data-active={entry.id === activeId}
+                data-done={done}
+                aria-current={entry.id === activeId ? 'true' : undefined}
+                onClick={() => onSelect(entry.id)}
+              >
+                <span className='vp-queue__status' aria-hidden='true'>
+                  {done ? <IconCircleCheckFilled size={16} /> : <IconCircle size={16} />}
+                </span>
+                <span className='vp-queue__rowtext'>
+                  <span className='vp-queue__rowtitle'>{entry.title}</span>
+                  <span className='vp-queue__rowdir'>{entry.dir}</span>
+                </span>
+              </button>
+            </li>
+          )
+        })}
+      </ul>
+    </aside>
+  )
+}

--- a/packages/runtime/components/queue/QueueSidebar.tsx
+++ b/packages/runtime/components/queue/QueueSidebar.tsx
@@ -1,6 +1,29 @@
 import type { QueueEntry } from '@visualplan/core'
-import { IconCircle, IconCircleCheckFilled } from '@tabler/icons-react'
+import {
+  IconCircle,
+  IconCircleCheckFilled,
+  IconCircleXFilled,
+  IconRefresh,
+} from '@tabler/icons-react'
 import { reviewedCount } from './logic.js'
+
+/** The status indicator for a row: an open circle while pending, otherwise the icon for the verdict
+ * the reviewer locked in (matching the decision bar: check / cross / iterate). */
+function StatusIcon({ entry }: { entry: QueueEntry }) {
+  if (entry.status !== 'done') return <IconCircle size={16} />
+  if (entry.decision === 'deny') return <IconCircleXFilled size={16} />
+  if (entry.decision === 'iterate') return <IconRefresh size={16} />
+  return <IconCircleCheckFilled size={16} />
+}
+
+/** The reviewer-facing word for a row's state, used in its accessible name (status is otherwise
+ * conveyed only by an icon and color). */
+function statusLabel(entry: QueueEntry): string {
+  if (entry.status !== 'done') return 'to review'
+  if (entry.decision === 'deny') return 'denied'
+  if (entry.decision === 'iterate') return 'needs iteration'
+  return 'approved'
+}
 
 /**
  * The left rail of the Review Queue shell: one row per queued plan with its title, the originating
@@ -35,6 +58,9 @@ export function QueueSidebar({
           // so focus and the active plan stay in sync. When nothing is active yet, the first row is
           // the entry point so the list is never unreachable by keyboard.
           const tabbable = activeId ? isActive : index === 0
+          // v1 is the baseline (no chip); a re-review shows its revision so the version is visible.
+          const version = entry.iteration && entry.iteration >= 2 ? `v${entry.iteration}` : null
+          const label = `${entry.title}, ${entry.dir}${version ? `, ${version}` : ''}, ${statusLabel(entry)}`
           return (
             <li key={entry.id}>
               <button
@@ -42,20 +68,27 @@ export function QueueSidebar({
                 className='vp-queue__row'
                 data-active={isActive}
                 data-done={done}
+                data-decision={done ? entry.decision : undefined}
                 tabIndex={tabbable ? 0 : -1}
                 aria-current={isActive ? 'true' : undefined}
-                // The status icon is decorative (aria-hidden), so the row name carries it in words,
-                // and separates the title from the origin dir that otherwise ran together.
-                aria-label={`${entry.title}, ${entry.dir}, ${done ? 'reviewed' : 'to review'}`}
+                // The status icon and version chip are decorative (aria-hidden / from the label), so
+                // the row name carries the dir, version, and status in words, and separates the title
+                // from the origin dir that otherwise ran together.
+                aria-label={label}
                 onClick={() => onSelect(entry.id)}
               >
                 <span className='vp-queue__status' aria-hidden='true'>
-                  {done ? <IconCircleCheckFilled size={16} /> : <IconCircle size={16} />}
+                  <StatusIcon entry={entry} />
                 </span>
                 <span className='vp-queue__rowtext'>
                   <span className='vp-queue__rowtitle'>{entry.title}</span>
                   <span className='vp-queue__rowdir'>{entry.dir}</span>
                 </span>
+                {version && (
+                  <span className='vp-queue__chip' aria-hidden='true'>
+                    {version}
+                  </span>
+                )}
               </button>
             </li>
           )

--- a/packages/runtime/components/queue/QueueSidebar.tsx
+++ b/packages/runtime/components/queue/QueueSidebar.tsx
@@ -45,7 +45,7 @@ export function QueueSidebar({
   return (
     <aside className='vp-queue__sidebar'>
       <header className='vp-queue__head'>
-        <span className='vp-queue__title'>Review queue</span>
+        <span className='vp-queue__title'>Plans to Review</span>
         <span className='vp-queue__count'>
           {reviewed} of {entries.length} reviewed
         </span>

--- a/packages/runtime/components/queue/QueueSidebar.tsx
+++ b/packages/runtime/components/queue/QueueSidebar.tsx
@@ -28,16 +28,25 @@ export function QueueSidebar({
         </span>
       </header>
       <ul className='vp-queue__list'>
-        {entries.map(entry => {
+        {entries.map((entry, index) => {
           const done = entry.status === 'done'
+          const isActive = entry.id === activeId
+          // Roving tabindex: only the active row is in the tab order (arrow/j-k move between rows),
+          // so focus and the active plan stay in sync. When nothing is active yet, the first row is
+          // the entry point so the list is never unreachable by keyboard.
+          const tabbable = activeId ? isActive : index === 0
           return (
             <li key={entry.id}>
               <button
                 type='button'
                 className='vp-queue__row'
-                data-active={entry.id === activeId}
+                data-active={isActive}
                 data-done={done}
-                aria-current={entry.id === activeId ? 'true' : undefined}
+                tabIndex={tabbable ? 0 : -1}
+                aria-current={isActive ? 'true' : undefined}
+                // The status icon is decorative (aria-hidden), so the row name carries it in words,
+                // and separates the title from the origin dir that otherwise ran together.
+                aria-label={`${entry.title}, ${entry.dir}, ${done ? 'reviewed' : 'to review'}`}
                 onClick={() => onSelect(entry.id)}
               >
                 <span className='vp-queue__status' aria-hidden='true'>

--- a/packages/runtime/components/queue/favicon.ts
+++ b/packages/runtime/components/queue/favicon.ts
@@ -10,8 +10,8 @@ const GLYPH =
   '<path d="M15 21h-9a3 3 0 0 1 -3 -3v-1h10v2a2 2 0 0 0 4 0v-14a2 2 0 1 1 2 2h-2m2 -4h-11a3 3 0 0 0 -3 3v11"/>' +
   '<path d="M9 7l4 0"/><path d="M9 11l4 0"/>'
 
-// A filled yellow dot in the top-right corner; its own fill wins over the path stroke style above.
-const DOT = '<circle cx="17" cy="6" r="6" fill="#eab308"/>'
+// A filled blue dot in the bottom-right corner; its own fill wins over the path stroke style above.
+const DOT = '<circle cx="17" cy="17" r="6" fill="#2f6fed"/>'
 
 /** The favicon as an SVG data URI, with the activity dot when `withDot`. */
 export function faviconHref(withDot: boolean): string {

--- a/packages/runtime/components/queue/favicon.ts
+++ b/packages/runtime/components/queue/favicon.ts
@@ -1,0 +1,33 @@
+/**
+ * The tab favicon, with an optional yellow activity dot. The base glyph mirrors the static favicon
+ * in `queue.html`; the dot is shown while the tab is backgrounded and a plan is added or updated, so
+ * the user gets a passive cue that the queue changed without the tab in front.
+ */
+
+// The base report/checklist glyph (paths and the light/dark stroke style), matching queue.html.
+const GLYPH =
+  '<style>path{stroke:#1a1a1c}@media(prefers-color-scheme:dark){path{stroke:#e9e9e6}}</style>' +
+  '<path d="M15 21h-9a3 3 0 0 1 -3 -3v-1h10v2a2 2 0 0 0 4 0v-14a2 2 0 1 1 2 2h-2m2 -4h-11a3 3 0 0 0 -3 3v11"/>' +
+  '<path d="M9 7l4 0"/><path d="M9 11l4 0"/>'
+
+// A filled yellow dot in the top-right corner; its own fill wins over the path stroke style above.
+const DOT = '<circle cx="17" cy="6" r="6" fill="#eab308"/>'
+
+/** The favicon as an SVG data URI, with the activity dot when `withDot`. */
+export function faviconHref(withDot: boolean): string {
+  const svg =
+    '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke-width="2" ' +
+    `stroke-linecap="round" stroke-linejoin="round">${GLYPH}${withDot ? DOT : ''}</svg>`
+  return `data:image/svg+xml,${encodeURIComponent(svg)}`
+}
+
+/** Point the page's favicon at the dotted or plain glyph, creating the `<link>` if absent. */
+export function setActivityDot(withDot: boolean): void {
+  let link = document.querySelector<HTMLLinkElement>('link[rel="icon"]')
+  if (!link) {
+    link = document.createElement('link')
+    link.rel = 'icon'
+    document.head.appendChild(link)
+  }
+  link.href = faviconHref(withDot)
+}

--- a/packages/runtime/components/queue/logic.ts
+++ b/packages/runtime/components/queue/logic.ts
@@ -49,3 +49,15 @@ export function moveSelection(
 export function reviewedCount(entries: QueueEntry[]): number {
   return entries.filter(isDone).length
 }
+
+/**
+ * Whether `next` represents new queue activity versus `prev`: a plan was added (a new id) or an
+ * existing plan changed status or version (a re-review). A plan only being removed is not activity
+ * to flag. Used to badge the tab while it is backgrounded.
+ */
+export function hasNewActivity(prev: QueueEntry[], next: QueueEntry[]): boolean {
+  return next.some(entry => {
+    const before = prev.find(p => p.id === entry.id)
+    return !before || before.status !== entry.status || before.iteration !== entry.iteration
+  })
+}

--- a/packages/runtime/components/queue/logic.ts
+++ b/packages/runtime/components/queue/logic.ts
@@ -1,0 +1,51 @@
+import type { QueueEntry } from '@visualplan/core'
+
+/**
+ * Pure queue-navigation logic for the Review Queue shell, factored out of `QueueShell` so the
+ * active-plan and selection rules are unit-testable without rendering. A plan counts as "still to
+ * review" until its status is `done`; the daemon may surface a transient `active` status, which is
+ * treated the same as `pending` here (not yet reviewed).
+ */
+
+/** True once the daemon has resolved this plan; it is no longer a review target. */
+function isDone(entry: QueueEntry): boolean {
+  return entry.status === 'done'
+}
+
+/** The id of the first entry still awaiting review, or null when the whole queue is done/empty. */
+export function firstPendingId(entries: QueueEntry[]): string | null {
+  return entries.find(e => !isDone(e))?.id ?? null
+}
+
+/**
+ * The id the shell should show given the current `activeId`. The active plan stays put while it is
+ * still pending; once the daemon marks it done (observed via the SSE stream) the shell auto-advances
+ * to the next pending plan. An unknown active id (or none) falls back to the first pending plan.
+ */
+export function nextActiveId(entries: QueueEntry[], activeId: string | null): string | null {
+  const active = entries.find(e => e.id === activeId)
+  if (active && !isDone(active)) return active.id
+  return firstPendingId(entries)
+}
+
+/**
+ * Move the selection by `delta` rows (j/k or arrow keys), clamped to the queue bounds so paging past
+ * an end is a no-op. With nothing selected, a move selects the first entry. Selection is positional
+ * across every entry, done or not, since the reviewer may want to revisit a finished plan.
+ */
+export function moveSelection(
+  entries: QueueEntry[],
+  activeId: string | null,
+  delta: number,
+): string | null {
+  if (entries.length === 0) return null
+  const current = entries.findIndex(e => e.id === activeId)
+  if (current === -1) return entries[0]?.id ?? null
+  const next = Math.min(Math.max(current + delta, 0), entries.length - 1)
+  return entries[next]?.id ?? null
+}
+
+/** How many queued plans have been reviewed, for the "N of M reviewed" progress count. */
+export function reviewedCount(entries: QueueEntry[]): number {
+  return entries.filter(isDone).length
+}

--- a/packages/runtime/components/queue/queue.css
+++ b/packages/runtime/components/queue/queue.css
@@ -12,6 +12,11 @@
   font-family: var(--vp-font);
 }
 
+/* A single queued plan drops the sidebar, so the plan fills the tab like an ordinary review. */
+.vp-queue--solo {
+  grid-template-columns: 1fr;
+}
+
 .vp-queue__sidebar {
   display: flex;
   flex-direction: column;

--- a/packages/runtime/components/queue/queue.css
+++ b/packages/runtime/components/queue/queue.css
@@ -122,8 +122,17 @@
   color: var(--vp-muted);
 }
 
-.vp-queue__row[data-done="true"] .vp-queue__status {
+/* The decided icon takes the verdict's color, matching the in-plan review bar's done state. */
+.vp-queue__row[data-decision="approve"] .vp-queue__status {
   color: var(--vp-done);
+}
+
+.vp-queue__row[data-decision="deny"] .vp-queue__status {
+  color: var(--vp-risk);
+}
+
+.vp-queue__row[data-decision="iterate"] .vp-queue__status {
+  color: var(--vp-gold);
 }
 
 .vp-queue__rowtext {
@@ -139,6 +148,20 @@
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+}
+
+/* Revision chip (v2, v3, ...) pushed to the row's trailing edge; present only on re-reviews. */
+.vp-queue__chip {
+  flex: none;
+  margin-left: auto;
+  padding: 0.05rem 0.32rem;
+  border: 1px solid var(--vp-border-strong);
+  border-radius: 5px;
+  background: var(--vp-bg);
+  color: var(--vp-muted);
+  font-family: var(--vp-mono);
+  font-size: 0.64rem;
+  line-height: 1.4;
 }
 
 .vp-queue__rowdir {

--- a/packages/runtime/components/queue/queue.css
+++ b/packages/runtime/components/queue/queue.css
@@ -1,0 +1,139 @@
+/* Review Queue shell chrome. The design tokens (--vp-*) come from theme.css, which the queue entry
+ * imports alongside this file. Monochrome ink register matching the plan page: off-white/off-black
+ * surfaces, a 1px border rail, semantic green only for the reviewed-status check. */
+
+.vp-queue {
+  display: grid;
+  grid-template-columns: minmax(220px, 280px) 1fr;
+  height: 100vh;
+  width: 100vw;
+  background: var(--vp-bg);
+  color: var(--vp-text);
+  font-family: var(--vp-font);
+}
+
+.vp-queue__sidebar {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  border-right: 1px solid var(--vp-border);
+  background: var(--vp-surface);
+}
+
+.vp-queue__head {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+  padding: 0.85rem 0.9rem 0.7rem;
+  border-bottom: 1px solid var(--vp-border);
+}
+
+.vp-queue__title {
+  font-size: 0.82rem;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+}
+
+.vp-queue__count {
+  font-size: 0.72rem;
+  color: var(--vp-muted);
+}
+
+.vp-queue__list {
+  list-style: none;
+  margin: 0;
+  padding: 0.4rem;
+  overflow-y: auto;
+  flex: 1;
+  min-height: 0;
+}
+
+.vp-queue__row {
+  display: flex;
+  align-items: center;
+  gap: 0.55rem;
+  width: 100%;
+  padding: 0.5rem 0.55rem;
+  border: 1px solid transparent;
+  border-radius: 7px;
+  background: transparent;
+  color: inherit;
+  text-align: left;
+  cursor: pointer;
+  transition: background 0.12s var(--vp-ease);
+}
+
+.vp-queue__row:hover {
+  background: var(--vp-surface-2);
+}
+
+.vp-queue__row[data-active="true"] {
+  background: var(--vp-surface-2);
+  border-color: var(--vp-border-strong);
+}
+
+.vp-queue__row[data-done="true"] .vp-queue__rowtitle {
+  color: var(--vp-muted);
+}
+
+.vp-queue__status {
+  display: inline-flex;
+  flex: none;
+  color: var(--vp-faint);
+}
+
+.vp-queue__row[data-done="true"] .vp-queue__status {
+  color: var(--vp-done);
+}
+
+.vp-queue__rowtext {
+  display: flex;
+  flex-direction: column;
+  gap: 0.1rem;
+  min-width: 0;
+}
+
+.vp-queue__rowtitle {
+  font-size: 0.8rem;
+  font-weight: 500;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.vp-queue__rowdir {
+  font-size: 0.68rem;
+  color: var(--vp-faint);
+  font-family: var(--vp-mono);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.vp-queue__main {
+  position: relative;
+  min-width: 0;
+  background: var(--vp-bg);
+}
+
+.vp-queue__frame {
+  width: 100%;
+  height: 100%;
+  border: 0;
+  display: block;
+}
+
+.vp-queue__empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.6rem;
+  height: 100%;
+  color: var(--vp-muted);
+}
+
+.vp-queue__empty p {
+  margin: 0;
+  font-size: 0.9rem;
+}

--- a/packages/runtime/components/queue/queue.css
+++ b/packages/runtime/components/queue/queue.css
@@ -23,6 +23,32 @@
   min-height: 0;
   border-right: 1px solid var(--vp-border);
   background: var(--vp-surface);
+  /* The rail mounts when a second plan joins (solo -> queue); ease it in rather than popping. */
+  animation: vp-queue-sidebar-in 0.18s var(--vp-ease) both;
+}
+
+@keyframes vp-queue-sidebar-in {
+  from {
+    opacity: 0;
+    transform: translateX(-6px);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(0);
+  }
+}
+
+/* Visually-hidden but exposed to assistive tech: status labels and the live-region announcer. */
+.vp-sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
 }
 
 .vp-queue__head {
@@ -68,12 +94,15 @@
   transition: background 0.12s var(--vp-ease);
 }
 
-.vp-queue__row:hover {
+.vp-queue__row:hover:not([data-active="true"]) {
   background: var(--vp-surface-2);
 }
 
+/* The active plan is the one the main pane shows, so it gets the strongest weight in the rail: an
+ * ink-tinted fill (distinct from the plain-grey hover) plus a bolder, full-contrast title. No side
+ * accent bar (a design ban); the fill + weight carry it. */
 .vp-queue__row[data-active="true"] {
-  background: var(--vp-surface-2);
+  background: color-mix(in srgb, var(--vp-accent) 9%, var(--vp-surface));
   border-color: var(--vp-border-strong);
 }
 
@@ -81,10 +110,16 @@
   color: var(--vp-muted);
 }
 
+/* Placed after the done rule so a reopened (done) plan that is also active reads as active. */
+.vp-queue__row[data-active="true"] .vp-queue__rowtitle {
+  font-weight: 600;
+  color: var(--vp-text);
+}
+
 .vp-queue__status {
   display: inline-flex;
   flex: none;
-  color: var(--vp-faint);
+  color: var(--vp-muted);
 }
 
 .vp-queue__row[data-done="true"] .vp-queue__status {
@@ -108,7 +143,9 @@
 
 .vp-queue__rowdir {
   font-size: 0.68rem;
-  color: var(--vp-faint);
+  /* --vp-muted, not --vp-faint: this label disambiguates plans across projects, so it must clear the
+   * 4.5:1 AA text floor (--vp-faint measured ~3.1:1 at this size). */
+  color: var(--vp-muted);
   font-family: var(--vp-mono);
   white-space: nowrap;
   overflow: hidden;
@@ -141,4 +178,13 @@
 .vp-queue__empty p {
   margin: 0;
   font-size: 0.9rem;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .vp-queue__sidebar {
+    animation: none;
+  }
+  .vp-queue__row {
+    transition: none;
+  }
 }

--- a/packages/runtime/components/queue/queue.css
+++ b/packages/runtime/components/queue/queue.css
@@ -135,6 +135,17 @@
   color: var(--vp-gold);
 }
 
+/* The iterate verdict means another round is coming, so its icon spins to read as in-progress. */
+.vp-queue__row[data-decision="iterate"] .vp-queue__status svg {
+  animation: vp-queue-spin 1.5s linear infinite;
+}
+
+@keyframes vp-queue-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
 .vp-queue__rowtext {
   display: flex;
   flex-direction: column;
@@ -209,5 +220,8 @@
   }
   .vp-queue__row {
     transition: none;
+  }
+  .vp-queue__row[data-decision="iterate"] .vp-queue__status svg {
+    animation: none;
   }
 }

--- a/packages/runtime/components/review/ReviewAnswers.tsx
+++ b/packages/runtime/components/review/ReviewAnswers.tsx
@@ -1,9 +1,15 @@
 import { createContext, type ReactNode, useContext, useMemo, useState } from 'react'
+import { reviewAnswers, reviewDecided } from './feedback.js'
 
 /** Answers the reviewer typed into the plan's `Questions`, keyed by the question text. */
 interface ReviewAnswersValue {
   answers: Map<string, string>
   setAnswer: (question: string, answer: string) => void
+  /** True once the plan is decided: `Questions` then stop accepting edits (answered ones stay
+   * visible, read-only). Seeded true when re-opening an already-decided plan. */
+  locked: boolean
+  /** Lock answers when the reviewer submits a decision. */
+  lock: () => void
 }
 
 /**
@@ -14,15 +20,26 @@ interface ReviewAnswersValue {
  */
 const ReviewAnswersContext = createContext<ReviewAnswersValue | null>(null)
 
+/** Seed answers from the daemon's injection so a re-opened decided plan shows what was answered. */
+function seedAnswers(): Map<string, string> {
+  const map = new Map<string, string>()
+  for (const { question, answer } of reviewAnswers()) map.set(question, answer)
+  return map
+}
+
 export function ReviewAnswersProvider({ children }: { children: ReactNode }) {
-  const [answers, setAnswers] = useState<Map<string, string>>(() => new Map())
+  const [answers, setAnswers] = useState<Map<string, string>>(seedAnswers)
+  // A re-served decided plan opens locked; a fresh review locks when the reviewer submits.
+  const [locked, setLocked] = useState<boolean>(() => reviewDecided() !== null)
   // A fresh Map per write so reference-based effect deps in ReviewSession fire on every keystroke.
   const value = useMemo<ReviewAnswersValue>(
     () => ({
       answers,
       setAnswer: (question, answer) => setAnswers(prev => new Map(prev).set(question, answer)),
+      locked,
+      lock: () => setLocked(true),
     }),
-    [answers],
+    [answers, locked],
   )
   return <ReviewAnswersContext.Provider value={value}>{children}</ReviewAnswersContext.Provider>
 }

--- a/packages/runtime/components/review/ReviewLayer.tsx
+++ b/packages/runtime/components/review/ReviewLayer.tsx
@@ -178,6 +178,7 @@ function ReviewSession() {
     if (isReviewDemo()) {
       submittedRef.current = decision
       setSubmitted(decision)
+      questionAnswers?.lock()
       return
     }
     const feedback: Feedback = {
@@ -193,6 +194,7 @@ function ReviewSession() {
       // programmatic close (it still prompts on a manual browser close while undecided).
       submittedRef.current = decision
       setSubmitted(decision)
+      questionAnswers?.lock()
       // In queue mode the shell owns the tab and advances to the next plan once the daemon marks this
       // one done; the plan iframe must not close the tab (that would tear the whole queue down). The
       // submitted notice is shown instead. In standalone mode, best-effort close the now-done tab

--- a/packages/runtime/components/review/ReviewLayer.tsx
+++ b/packages/runtime/components/review/ReviewLayer.tsx
@@ -1,5 +1,5 @@
 import type { Feedback, ReviewAnswer, ReviewComment, ReviewDecision } from '@visualplan/core'
-import { IconCheck, IconMessagePlus } from '@tabler/icons-react'
+import { IconCheck, IconMessagePlus, IconRefresh, IconX } from '@tabler/icons-react'
 import { useEffect, useRef, useState } from 'react'
 import { CommentModal } from './CommentModal.js'
 import { CommentsPopover } from './CommentsPopover.js'
@@ -11,6 +11,7 @@ import {
   openKeepalive,
   postDraft,
   postFeedback,
+  reviewDecided,
 } from './feedback.js'
 import { useQuestionAnswers } from './ReviewAnswers.js'
 import {
@@ -62,7 +63,9 @@ function ReviewSession() {
   const [composing, setComposing] = useState<CommentTarget | null>(null)
   const [viewing, setViewing] = useState<Section | null>(null)
   const [note, setNote] = useState('')
-  const [submitted, setSubmitted] = useState<ReviewDecision | null>(null)
+  // A plan the daemon re-serves after it was decided carries its verdict, so it opens locked into the
+  // submitted state instead of showing live controls.
+  const [submitted, setSubmitted] = useState<ReviewDecision | null>(reviewDecided())
   const [busy, setBusy] = useState(false)
   const [hoveredMark, setHoveredMark] = useState<{
     body: string
@@ -201,7 +204,8 @@ function ReviewSession() {
     }
   }
 
-  if (submitted) return <SubmittedNotice decision={submitted} demo={isReviewDemo()} />
+  if (submitted)
+    return <SubmittedNotice decision={submitted} demo={isReviewDemo()} queue={isQueueMode()} />
 
   const viewingComments = viewing
     ? comments
@@ -309,18 +313,40 @@ function ReviewSession() {
   )
 }
 
-/** Replaces the decision bar once a verdict is sent, so the reviewer knows it is safe to close. In a
- * demo there is no agent waiting, so it explains what the decision would have done and points at Reset. */
-function SubmittedNotice({ decision, demo }: { decision: ReviewDecision; demo?: boolean }) {
+/** The verb each verdict locks in, shown on the bottom bar once decided. */
+const DECISION_LABEL: Record<ReviewDecision, string> = {
+  approve: 'Approved',
+  deny: 'Denied',
+  iterate: 'Iterate requested',
+}
+
+/**
+ * Replaces the decision bar once a verdict is sent (or when re-opening an already-decided plan),
+ * locking the verdict on the bottom bar with its matching icon. In the queue the tab stays open to
+ * review other plans, so it does not say to close it; a standalone one-shot review does (the CLI
+ * tries to close the tab and this is the fallback). A demo explains the no-op and points at Reset.
+ */
+function SubmittedNotice({
+  decision,
+  demo,
+  queue,
+}: {
+  decision: ReviewDecision
+  demo?: boolean
+  queue?: boolean
+}) {
+  const Icon = decision === 'deny' ? IconX : decision === 'iterate' ? IconRefresh : IconCheck
   return (
     <div className='vp-review-done' data-decision={decision}>
-      <IconCheck size={18} />
+      <Icon size={18} />
       <span>
         {demo ? (
           <>
             Demo: this would return <strong>{decision}</strong> to your agent. Press Reset to try
             again.
           </>
+        ) : queue ? (
+          <strong>{DECISION_LABEL[decision]}</strong>
         ) : (
           <>
             Feedback submitted (<strong>{decision}</strong>). You can close this tab.

--- a/packages/runtime/components/review/ReviewLayer.tsx
+++ b/packages/runtime/components/review/ReviewLayer.tsx
@@ -4,7 +4,14 @@ import { useEffect, useRef, useState } from 'react'
 import { CommentModal } from './CommentModal.js'
 import { CommentsPopover } from './CommentsPopover.js'
 import { DecisionBar } from './DecisionBar.js'
-import { isReviewDemo, isReviewMode, openKeepalive, postDraft, postFeedback } from './feedback.js'
+import {
+  isQueueMode,
+  isReviewDemo,
+  isReviewMode,
+  openKeepalive,
+  postDraft,
+  postFeedback,
+} from './feedback.js'
 import { useQuestionAnswers } from './ReviewAnswers.js'
 import {
   type Section,
@@ -83,9 +90,11 @@ function ReviewSession() {
 
   // Hold a connection open so the server resolves Deny if the tab closes; the server, not an
   // unreliable unload beacon, detects the drop. Aborted on unmount (e.g. after a submitted decision).
-  // A demo has no server behind it, so there is nothing to keep alive.
+  // A demo has no server behind it, so there is nothing to keep alive. In queue mode the SHELL owns
+  // the daemon's lifecycle (its `/__vp_events` stream is the liveness signal), so a plan iframe must
+  // NOT open a keepalive: swapping the iframe to the next plan would otherwise deny this one.
   useEffect(() => {
-    if (isReviewDemo()) return
+    if (isReviewDemo() || isQueueMode()) return
     const connection = openKeepalive()
     return () => connection.abort()
   }, [])
@@ -110,8 +119,10 @@ function ReviewSession() {
   const submittedRef = useRef(submitted)
   submittedRef.current = submitted
   useEffect(() => {
-    // A demo is meant to be navigated away from and reset freely, so it never arms the prompt.
-    if (isReviewDemo()) return
+    // A demo is meant to be navigated away from and reset freely, so it never arms the prompt. In
+    // queue mode the plan iframe is swapped by the shell on every advance, so an unload prompt would
+    // fire on each swap; the shell, not the plan, owns the prompt-on-real-close.
+    if (isReviewDemo() || isQueueMode()) return
     const onBeforeUnload = (event: BeforeUnloadEvent) => {
       if (!submittedRef.current) {
         event.preventDefault()
@@ -179,9 +190,11 @@ function ReviewSession() {
       // programmatic close (it still prompts on a manual browser close while undecided).
       submittedRef.current = decision
       setSubmitted(decision)
-      // Best-effort: close the tab now the review is done. Browsers block this for a user-opened
-      // tab, in which case the SubmittedNotice fallback tells them they can close it.
-      window.close()
+      // In queue mode the shell owns the tab and advances to the next plan once the daemon marks this
+      // one done; the plan iframe must not close the tab (that would tear the whole queue down). The
+      // submitted notice is shown instead. In standalone mode, best-effort close the now-done tab
+      // (browsers block this for a user-opened tab, where the notice tells them they can close it).
+      if (!isQueueMode()) window.close()
     } else {
       setBusy(false)
       window.alert('Could not reach the review server. Is the CLI still running?')

--- a/packages/runtime/components/review/feedback.ts
+++ b/packages/runtime/components/review/feedback.ts
@@ -1,4 +1,4 @@
-import type { Feedback } from '@visualplan/core'
+import type { Feedback, ReviewDecision } from '@visualplan/core'
 
 /** The review server (`compile.ts` `reviewPlugin`) endpoints. */
 const FEEDBACK_ENDPOINT = '/__vp_feedback'
@@ -24,6 +24,16 @@ export function isReviewDemo(): boolean {
 export function reviewIteration(): number | null {
   const value = (globalThis as { __VP_REVIEW_ITERATION__?: number }).__VP_REVIEW_ITERATION__
   return typeof value === 'number' ? value : null
+}
+
+/**
+ * The verdict this plan was already decided with, or null if it is still open. The Review Queue
+ * daemon injects `__VP_REVIEW_DECIDED__` when it re-serves a plan the reviewer already decided, so
+ * re-opening it shows the locked-in decision instead of live controls.
+ */
+export function reviewDecided(): ReviewDecision | null {
+  const value = (globalThis as { __VP_REVIEW_DECIDED__?: ReviewDecision }).__VP_REVIEW_DECIDED__
+  return value === 'approve' || value === 'deny' || value === 'iterate' ? value : null
 }
 
 /**

--- a/packages/runtime/components/review/feedback.ts
+++ b/packages/runtime/components/review/feedback.ts
@@ -1,4 +1,4 @@
-import type { Feedback, ReviewDecision } from '@visualplan/core'
+import type { Feedback, ReviewAnswer, ReviewDecision } from '@visualplan/core'
 
 /** The review server (`compile.ts` `reviewPlugin`) endpoints. */
 const FEEDBACK_ENDPOINT = '/__vp_feedback'
@@ -34,6 +34,15 @@ export function reviewIteration(): number | null {
 export function reviewDecided(): ReviewDecision | null {
   const value = (globalThis as { __VP_REVIEW_DECIDED__?: ReviewDecision }).__VP_REVIEW_DECIDED__
   return value === 'approve' || value === 'deny' || value === 'iterate' ? value : null
+}
+
+/**
+ * The answers the reviewer gave to the plan's `Questions`, injected alongside the verdict when the
+ * daemon re-serves a decided plan, so the locked page can still show them. Empty when not decided.
+ */
+export function reviewAnswers(): ReviewAnswer[] {
+  const value = (globalThis as { __VP_REVIEW_ANSWERS__?: ReviewAnswer[] }).__VP_REVIEW_ANSWERS__
+  return Array.isArray(value) ? value : []
 }
 
 /**

--- a/packages/runtime/components/review/feedback.ts
+++ b/packages/runtime/components/review/feedback.ts
@@ -26,13 +26,41 @@ export function reviewIteration(): number | null {
   return typeof value === 'number' ? value : null
 }
 
+/**
+ * The id of this plan within the Review Queue, or null in standalone single-review mode. Injected as
+ * `__VP_REVIEW_PLAN_ID__` by the daemon (its PRESENCE is what marks queue mode). An empty id cannot
+ * route a verdict, so it is treated as absent (and matches `feedbackSchema`'s `planId.min(1)`).
+ */
+export function reviewPlanId(): string | null {
+  const value = (globalThis as { __VP_REVIEW_PLAN_ID__?: string }).__VP_REVIEW_PLAN_ID__
+  return typeof value === 'string' && value.length > 0 ? value : null
+}
+
+/**
+ * True when this plan iframe is one of several in the daemon's Review Queue. In queue mode the
+ * feedback/draft POSTs carry the plan id so the daemon routes them, and the SHELL (not the plan)
+ * owns daemon lifecycle, so the plan must not open the keepalive or arm the unload prompt.
+ */
+export function isQueueMode(): boolean {
+  return reviewPlanId() !== null
+}
+
+/**
+ * Tag the feedback with the queue plan id when in queue mode, so the daemon routes the verdict to the
+ * right caller. In standalone single-review mode the id is absent and the payload is unchanged.
+ */
+function withPlanId(feedback: Feedback): Feedback {
+  const planId = reviewPlanId()
+  return planId ? { ...feedback, planId } : feedback
+}
+
 /** POST the explicit decision to the CLI, which resolves the blocking session. Returns whether it was accepted. */
 export async function postFeedback(feedback: Feedback): Promise<boolean> {
   try {
     const res = await fetch(FEEDBACK_ENDPOINT, {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
-      body: JSON.stringify(feedback),
+      body: JSON.stringify(withPlanId(feedback)),
     })
     return res.ok
   } catch {
@@ -48,7 +76,7 @@ export function postDraft(feedback: Feedback): void {
   void fetch(DRAFT_ENDPOINT, {
     method: 'POST',
     headers: { 'content-type': 'application/json' },
-    body: JSON.stringify(feedback),
+    body: JSON.stringify(withPlanId(feedback)),
   }).catch(() => {})
 }
 

--- a/packages/runtime/queue-main.tsx
+++ b/packages/runtime/queue-main.tsx
@@ -1,0 +1,12 @@
+import { createRoot } from 'react-dom/client'
+import { QueueShell } from './components/queue/QueueShell.js'
+import { applyThemePreference, getThemePreference } from './theme.js'
+import './theme.css'
+
+/** Mount the Review Queue shell into the page. Unlike the plan entry (`main.tsx`) there is no plan to
+ * import: the shell renders chrome plus the per-plan iframes the daemon serves at `/plan/<id>`. */
+const container = document.getElementById('root')
+if (!container) throw new Error('Visual Plan: #root element not found')
+// Resolve the color scheme for parity with the plan page (the shell shares the same tokens).
+applyThemePreference(getThemePreference())
+createRoot(container).render(<QueueShell />)

--- a/packages/runtime/queue.html
+++ b/packages/runtime/queue.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Review Queue</title>
+    <link rel="icon" href="data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20viewBox%3D%220%200%2024%2024%22%20fill%3D%22none%22%20stroke-width%3D%222%22%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%3E%3Cstyle%3Epath%7Bstroke%3A%231a1a1c%7D%40media(prefers-color-scheme%3Adark)%7Bpath%7Bstroke%3A%23e9e9e6%7D%7D%3C%2Fstyle%3E%3Cpath%20d%3D%22M15%2021h-9a3%203%200%200%201%20-3%20-3v-1h10v2a2%202%200%200%200%204%200v-14a2%202%200%201%201%202%202h-2m2%20-4h-11a3%203%200%200%200%20-3%203v11%22%2F%3E%3Cpath%20d%3D%22M9%207l4%200%22%2F%3E%3Cpath%20d%3D%22M9%2011l4%200%22%2F%3E%3C%2Fsvg%3E" />
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="./queue-main.tsx"></script>
+  </body>
+</html>

--- a/packages/runtime/queue.html
+++ b/packages/runtime/queue.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Plans to Review</title>
+    <title>Visual Plan Review Queue</title>
     <link rel="icon" href="data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20viewBox%3D%220%200%2024%2024%22%20fill%3D%22none%22%20stroke-width%3D%222%22%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%3E%3Cstyle%3Epath%7Bstroke%3A%231a1a1c%7D%40media(prefers-color-scheme%3Adark)%7Bpath%7Bstroke%3A%23e9e9e6%7D%7D%3C%2Fstyle%3E%3Cpath%20d%3D%22M15%2021h-9a3%203%200%200%201%20-3%20-3v-1h10v2a2%202%200%200%200%204%200v-14a2%202%200%201%201%202%202h-2m2%20-4h-11a3%203%200%200%200%20-3%203v11%22%2F%3E%3Cpath%20d%3D%22M9%207l4%200%22%2F%3E%3Cpath%20d%3D%22M9%2011l4%200%22%2F%3E%3C%2Fsvg%3E" />
   </head>
   <body>

--- a/packages/runtime/queue.html
+++ b/packages/runtime/queue.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Review Queue</title>
+    <title>Plans to Review</title>
     <link rel="icon" href="data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20viewBox%3D%220%200%2024%2024%22%20fill%3D%22none%22%20stroke-width%3D%222%22%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%3E%3Cstyle%3Epath%7Bstroke%3A%231a1a1c%7D%40media(prefers-color-scheme%3Adark)%7Bpath%7Bstroke%3A%23e9e9e6%7D%7D%3C%2Fstyle%3E%3Cpath%20d%3D%22M15%2021h-9a3%203%200%200%201%20-3%20-3v-1h10v2a2%202%200%200%200%204%200v-14a2%202%200%201%201%202%202h-2m2%20-4h-11a3%203%200%200%200%20-3%203v11%22%2F%3E%3Cpath%20d%3D%22M9%207l4%200%22%2F%3E%3Cpath%20d%3D%22M9%2011l4%200%22%2F%3E%3C%2Fsvg%3E" />
   </head>
   <body>

--- a/packages/runtime/tests/components.test.tsx
+++ b/packages/runtime/tests/components.test.tsx
@@ -278,6 +278,50 @@ describe('Questions in review mode', () => {
   })
 })
 
+describe('Questions locked after a decision', () => {
+  type G = {
+    __VP_REVIEW__?: boolean
+    __VP_REVIEW_DECIDED__?: string
+    __VP_REVIEW_ANSWERS__?: unknown
+  }
+  afterEach(() => {
+    ;(globalThis as G).__VP_REVIEW__ = undefined
+    ;(globalThis as G).__VP_REVIEW_DECIDED__ = undefined
+    ;(globalThis as G).__VP_REVIEW_ANSWERS__ = undefined
+  })
+
+  it('keeps an answered question as a read-only field and drops an unanswered input once locked (golden)', () => {
+    ;(globalThis as G).__VP_REVIEW__ = true
+    ;(globalThis as G).__VP_REVIEW_DECIDED__ = 'approve'
+    ;(globalThis as G).__VP_REVIEW_ANSWERS__ = [
+      { question: 'Fail open or closed?', answer: 'Closed' },
+    ]
+    const html = renderToStaticMarkup(
+      <ReviewAnswersProvider>
+        <Questions items={['Fail open or closed?', 'TTL ok?']} />
+      </ReviewAnswersProvider>,
+    )
+    // Only the answered question keeps a field; it is read-only and shows its answer.
+    expect((html.match(/vp-questions__answer/g) || []).length).toBe(1)
+    expect(html).toMatch(/readonly/i)
+    expect(html).toContain('Closed')
+    // Both questions still appear as text.
+    expect(html).toContain('Fail open or closed?')
+    expect(html).toContain('TTL ok?')
+  })
+
+  it('keeps every answer field editable while the plan is undecided (edge)', () => {
+    ;(globalThis as G).__VP_REVIEW__ = true
+    const html = renderToStaticMarkup(
+      <ReviewAnswersProvider>
+        <Questions items={['A?', 'B?']} />
+      </ReviewAnswersProvider>,
+    )
+    expect((html.match(/vp-questions__answer/g) || []).length).toBe(2)
+    expect(html).not.toMatch(/readonly/i)
+  })
+})
+
 describe('JSON-string data prop (the remark-plan-blocks decode path)', () => {
   // At render the list components receive their data as a JSON string (the markdown
   // children, parsed by the CLI's remark plugin), not an array. Each must decode it.

--- a/packages/runtime/tests/queue-favicon.test.ts
+++ b/packages/runtime/tests/queue-favicon.test.ts
@@ -1,0 +1,45 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { faviconHref, setActivityDot } from '../components/queue/favicon.js'
+
+describe('faviconHref', () => {
+  it('encodes the base glyph with no dot by default (golden)', () => {
+    const href = faviconHref(false)
+    expect(href.startsWith('data:image/svg+xml,')).toBe(true)
+    expect(decodeURIComponent(href)).toContain('<svg')
+    expect(decodeURIComponent(href)).not.toContain('<circle')
+  })
+
+  it('adds the yellow activity dot when asked (golden)', () => {
+    const decoded = decodeURIComponent(faviconHref(true))
+    expect(decoded).toContain('<circle')
+    expect(decoded).toContain('#eab308')
+  })
+})
+
+describe('setActivityDot', () => {
+  beforeEach(() => {
+    document.head.innerHTML = ''
+  })
+
+  afterEach(() => {
+    document.head.innerHTML = ''
+  })
+
+  it('creates the favicon link and points it at the dotted glyph (golden)', () => {
+    setActivityDot(true)
+    const link = document.querySelector<HTMLLinkElement>('link[rel="icon"]')
+    expect(link).not.toBeNull()
+    expect(decodeURIComponent(link?.href ?? '')).toContain('<circle')
+  })
+
+  it('reuses the existing link and clears the dot (edge)', () => {
+    const existing = document.createElement('link')
+    existing.rel = 'icon'
+    document.head.appendChild(existing)
+    setActivityDot(true)
+    setActivityDot(false)
+    const links = document.querySelectorAll('link[rel="icon"]')
+    expect(links.length).toBe(1)
+    expect(decodeURIComponent((links[0] as HTMLLinkElement).href)).not.toContain('<circle')
+  })
+})

--- a/packages/runtime/tests/queue-favicon.test.ts
+++ b/packages/runtime/tests/queue-favicon.test.ts
@@ -9,10 +9,12 @@ describe('faviconHref', () => {
     expect(decodeURIComponent(href)).not.toContain('<circle')
   })
 
-  it('adds the yellow activity dot when asked (golden)', () => {
+  it('adds the blue activity dot in the bottom-right corner when asked (golden)', () => {
     const decoded = decodeURIComponent(faviconHref(true))
     expect(decoded).toContain('<circle')
-    expect(decoded).toContain('#eab308')
+    expect(decoded).toContain('#2f6fed')
+    // Bottom-right of the 24x24 viewBox.
+    expect(decoded).toContain('cx="17" cy="17"')
   })
 })
 

--- a/packages/runtime/tests/queue-feedback.test.ts
+++ b/packages/runtime/tests/queue-feedback.test.ts
@@ -3,11 +3,16 @@ import {
   isQueueMode,
   postDraft,
   postFeedback,
+  reviewAnswers,
   reviewDecided,
   reviewPlanId,
 } from '../components/review/feedback.js'
 
-type QueueGlobal = { __VP_REVIEW_PLAN_ID__?: string; __VP_REVIEW_DECIDED__?: string }
+type QueueGlobal = {
+  __VP_REVIEW_PLAN_ID__?: string
+  __VP_REVIEW_DECIDED__?: string
+  __VP_REVIEW_ANSWERS__?: unknown
+}
 
 function setPlanId(id: string | undefined): void {
   ;(globalThis as QueueGlobal).__VP_REVIEW_PLAN_ID__ = id
@@ -16,7 +21,20 @@ function setPlanId(id: string | undefined): void {
 afterEach(() => {
   setPlanId(undefined)
   ;(globalThis as QueueGlobal).__VP_REVIEW_DECIDED__ = undefined
+  ;(globalThis as QueueGlobal).__VP_REVIEW_ANSWERS__ = undefined
   vi.restoreAllMocks()
+})
+
+describe('reviewAnswers', () => {
+  it('returns the injected answers of a decided plan (golden)', () => {
+    ;(globalThis as QueueGlobal).__VP_REVIEW_ANSWERS__ = [{ question: 'TTL ok?', answer: 'Yes' }]
+    expect(reviewAnswers()).toEqual([{ question: 'TTL ok?', answer: 'Yes' }])
+  })
+
+  it('returns an empty array when none were injected (edge)', () => {
+    ;(globalThis as QueueGlobal).__VP_REVIEW_ANSWERS__ = undefined
+    expect(reviewAnswers()).toEqual([])
+  })
 })
 
 describe('reviewDecided', () => {

--- a/packages/runtime/tests/queue-feedback.test.ts
+++ b/packages/runtime/tests/queue-feedback.test.ts
@@ -1,0 +1,111 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  isQueueMode,
+  postDraft,
+  postFeedback,
+  reviewPlanId,
+} from '../components/review/feedback.js'
+
+type QueueGlobal = { __VP_REVIEW_PLAN_ID__?: string }
+
+function setPlanId(id: string | undefined): void {
+  ;(globalThis as QueueGlobal).__VP_REVIEW_PLAN_ID__ = id
+}
+
+afterEach(() => {
+  setPlanId(undefined)
+  vi.restoreAllMocks()
+})
+
+describe('reviewPlanId', () => {
+  it('returns the injected plan id in queue mode (golden)', () => {
+    setPlanId('plan-7')
+    expect(reviewPlanId()).toBe('plan-7')
+  })
+
+  it('returns null when the global is absent (edge)', () => {
+    setPlanId(undefined)
+    expect(reviewPlanId()).toBeNull()
+  })
+
+  it('returns null for an empty id, which cannot route (error)', () => {
+    setPlanId('')
+    expect(reviewPlanId()).toBeNull()
+  })
+})
+
+describe('isQueueMode', () => {
+  it('is true when a non-empty plan id is present (golden)', () => {
+    setPlanId('plan-7')
+    expect(isQueueMode()).toBe(true)
+  })
+
+  it('is false when the global is absent (edge)', () => {
+    setPlanId(undefined)
+    expect(isQueueMode()).toBe(false)
+  })
+
+  it('is false for an empty id (error)', () => {
+    setPlanId('')
+    expect(isQueueMode()).toBe(false)
+  })
+})
+
+/** Parse the JSON body the most recent fetch mock call was given. */
+function lastFetchBody(fetchMock: ReturnType<typeof vi.fn>): Record<string, unknown> {
+  const call = fetchMock.mock.calls.at(-1)
+  if (!call) throw new Error('fetch was not called')
+  return JSON.parse((call[1] as RequestInit).body as string)
+}
+
+describe('postFeedback queue-mode tagging', () => {
+  it('includes planId in the body in queue mode (golden)', async () => {
+    setPlanId('plan-7')
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true })
+    vi.stubGlobal('fetch', fetchMock)
+    await postFeedback({ decision: 'approve', comments: [], answers: [] })
+    expect(lastFetchBody(fetchMock).planId).toBe('plan-7')
+  })
+
+  it('omits planId in standalone mode (edge)', async () => {
+    setPlanId(undefined)
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true })
+    vi.stubGlobal('fetch', fetchMock)
+    await postFeedback({ decision: 'approve', comments: [], answers: [] })
+    expect('planId' in lastFetchBody(fetchMock)).toBe(false)
+  })
+
+  it('omits planId for an empty injected id (error)', async () => {
+    setPlanId('')
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true })
+    vi.stubGlobal('fetch', fetchMock)
+    await postFeedback({ decision: 'approve', comments: [], answers: [] })
+    expect('planId' in lastFetchBody(fetchMock)).toBe(false)
+  })
+})
+
+describe('postDraft queue-mode tagging', () => {
+  it('includes planId in the body in queue mode (golden)', () => {
+    setPlanId('plan-7')
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true })
+    vi.stubGlobal('fetch', fetchMock)
+    postDraft({ decision: 'deny', comments: [], answers: [] })
+    expect(lastFetchBody(fetchMock).planId).toBe('plan-7')
+  })
+
+  it('omits planId in standalone mode (edge)', () => {
+    setPlanId(undefined)
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true })
+    vi.stubGlobal('fetch', fetchMock)
+    postDraft({ decision: 'deny', comments: [], answers: [] })
+    expect('planId' in lastFetchBody(fetchMock)).toBe(false)
+  })
+
+  it('omits planId for an empty injected id (error)', () => {
+    setPlanId('')
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true })
+    vi.stubGlobal('fetch', fetchMock)
+    postDraft({ decision: 'deny', comments: [], answers: [] })
+    expect('planId' in lastFetchBody(fetchMock)).toBe(false)
+  })
+})

--- a/packages/runtime/tests/queue-feedback.test.ts
+++ b/packages/runtime/tests/queue-feedback.test.ts
@@ -3,10 +3,11 @@ import {
   isQueueMode,
   postDraft,
   postFeedback,
+  reviewDecided,
   reviewPlanId,
 } from '../components/review/feedback.js'
 
-type QueueGlobal = { __VP_REVIEW_PLAN_ID__?: string }
+type QueueGlobal = { __VP_REVIEW_PLAN_ID__?: string; __VP_REVIEW_DECIDED__?: string }
 
 function setPlanId(id: string | undefined): void {
   ;(globalThis as QueueGlobal).__VP_REVIEW_PLAN_ID__ = id
@@ -14,7 +15,25 @@ function setPlanId(id: string | undefined): void {
 
 afterEach(() => {
   setPlanId(undefined)
+  ;(globalThis as QueueGlobal).__VP_REVIEW_DECIDED__ = undefined
   vi.restoreAllMocks()
+})
+
+describe('reviewDecided', () => {
+  it('returns the injected verdict of an already-decided plan (golden)', () => {
+    ;(globalThis as QueueGlobal).__VP_REVIEW_DECIDED__ = 'iterate'
+    expect(reviewDecided()).toBe('iterate')
+  })
+
+  it('returns null when absent (edge)', () => {
+    ;(globalThis as QueueGlobal).__VP_REVIEW_DECIDED__ = undefined
+    expect(reviewDecided()).toBeNull()
+  })
+
+  it('returns null for an unrecognized value (error)', () => {
+    ;(globalThis as QueueGlobal).__VP_REVIEW_DECIDED__ = 'maybe'
+    expect(reviewDecided()).toBeNull()
+  })
 })
 
 describe('reviewPlanId', () => {

--- a/packages/runtime/tests/queue-review-layer.test.tsx
+++ b/packages/runtime/tests/queue-review-layer.test.tsx
@@ -1,0 +1,87 @@
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { ReviewLayer } from '../components/review/ReviewLayer.js'
+
+type ReviewGlobal = { __VP_REVIEW__?: boolean; __VP_REVIEW_PLAN_ID__?: string }
+
+function setReview(plan: string | undefined): void {
+  ;(globalThis as ReviewGlobal).__VP_REVIEW__ = true
+  ;(globalThis as ReviewGlobal).__VP_REVIEW_PLAN_ID__ = plan
+}
+
+let container: HTMLDivElement
+let root: Root
+let fetchMock: ReturnType<typeof vi.fn>
+let closeSpy: ReturnType<typeof vi.fn>
+
+beforeEach(() => {
+  container = document.createElement('div')
+  container.className = 'vp-main'
+  document.body.appendChild(container)
+  fetchMock = vi.fn().mockResolvedValue({ ok: true })
+  vi.stubGlobal('fetch', fetchMock)
+  closeSpy = vi.fn()
+  vi.stubGlobal('close', closeSpy)
+})
+
+afterEach(() => {
+  act(() => root?.unmount())
+  container.remove()
+  ;(globalThis as ReviewGlobal).__VP_REVIEW__ = undefined
+  ;(globalThis as ReviewGlobal).__VP_REVIEW_PLAN_ID__ = undefined
+  vi.restoreAllMocks()
+})
+
+/** URLs of every fetch call made so far. */
+function fetchedUrls(): string[] {
+  return fetchMock.mock.calls.map(call => String(call[0]))
+}
+
+/** Drive an Approve click through the rendered decision bar. */
+async function clickApprove(): Promise<void> {
+  const approve = Array.from(container.querySelectorAll('button')).find(
+    b => b.textContent?.trim() === 'Approve',
+  )
+  if (!approve) throw new Error('Approve button not found')
+  await act(async () => {
+    approve.click()
+  })
+}
+
+describe('ReviewLayer queue mode', () => {
+  it('does not open the daemon keepalive in queue mode (golden)', () => {
+    setReview('plan-7')
+    root = createRoot(container)
+    act(() => root.render(<ReviewLayer />))
+    expect(fetchedUrls()).not.toContain('/__vp_alive')
+  })
+
+  it('opens the keepalive in standalone mode (edge)', () => {
+    setReview(undefined)
+    root = createRoot(container)
+    act(() => root.render(<ReviewLayer />))
+    expect(fetchedUrls()).toContain('/__vp_alive')
+  })
+
+  it('submits feedback without closing the tab in queue mode (golden)', async () => {
+    setReview('plan-7')
+    root = createRoot(container)
+    act(() => root.render(<ReviewLayer />))
+    await clickApprove()
+    const feedbackCall = fetchMock.mock.calls.find(c => String(c[0]) === '/__vp_feedback')
+    expect(feedbackCall).toBeDefined()
+    const body = JSON.parse((feedbackCall?.[1] as RequestInit).body as string)
+    expect(body.planId).toBe('plan-7')
+    expect(closeSpy).not.toHaveBeenCalled()
+    expect(container.textContent).toContain('submitted')
+  })
+
+  it('closes the tab after submit in standalone mode (error)', async () => {
+    setReview(undefined)
+    root = createRoot(container)
+    act(() => root.render(<ReviewLayer />))
+    await clickApprove()
+    expect(closeSpy).toHaveBeenCalled()
+  })
+})

--- a/packages/runtime/tests/queue-review-layer.test.tsx
+++ b/packages/runtime/tests/queue-review-layer.test.tsx
@@ -3,7 +3,11 @@ import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { ReviewLayer } from '../components/review/ReviewLayer.js'
 
-type ReviewGlobal = { __VP_REVIEW__?: boolean; __VP_REVIEW_PLAN_ID__?: string }
+type ReviewGlobal = {
+  __VP_REVIEW__?: boolean
+  __VP_REVIEW_PLAN_ID__?: string
+  __VP_REVIEW_DECIDED__?: string
+}
 
 function setReview(plan: string | undefined): void {
   ;(globalThis as ReviewGlobal).__VP_REVIEW__ = true
@@ -30,6 +34,7 @@ afterEach(() => {
   container.remove()
   ;(globalThis as ReviewGlobal).__VP_REVIEW__ = undefined
   ;(globalThis as ReviewGlobal).__VP_REVIEW_PLAN_ID__ = undefined
+  ;(globalThis as ReviewGlobal).__VP_REVIEW_DECIDED__ = undefined
   vi.restoreAllMocks()
 })
 
@@ -74,14 +79,30 @@ describe('ReviewLayer queue mode', () => {
     const body = JSON.parse((feedbackCall?.[1] as RequestInit).body as string)
     expect(body.planId).toBe('plan-7')
     expect(closeSpy).not.toHaveBeenCalled()
-    expect(container.textContent).toContain('submitted')
+    // Locks the verdict on the bar, and does not tell the user to close the (still-needed) tab.
+    expect(container.textContent).toContain('Approved')
+    expect(container.textContent).not.toContain('close this tab')
   })
 
-  it('closes the tab after submit in standalone mode (error)', async () => {
+  it('opens an already-decided plan locked into its verdict, no controls or close-tab (golden)', () => {
+    setReview('plan-7')
+    ;(globalThis as ReviewGlobal).__VP_REVIEW_DECIDED__ = 'deny'
+    root = createRoot(container)
+    act(() => root.render(<ReviewLayer />))
+    const buttonLabels = Array.from(container.querySelectorAll('button')).map(b =>
+      b.textContent?.trim(),
+    )
+    expect(buttonLabels).not.toContain('Approve')
+    expect(container.textContent).toContain('Denied')
+    expect(container.textContent).not.toContain('close this tab')
+  })
+
+  it('still says to close the tab after submit in standalone mode (error)', async () => {
     setReview(undefined)
     root = createRoot(container)
     act(() => root.render(<ReviewLayer />))
     await clickApprove()
     expect(closeSpy).toHaveBeenCalled()
+    expect(container.textContent).toContain('close this tab')
   })
 })

--- a/packages/runtime/tests/queue-shell-logic.test.ts
+++ b/packages/runtime/tests/queue-shell-logic.test.ts
@@ -1,0 +1,90 @@
+import type { QueueEntry } from '@visualplan/core'
+import { describe, expect, it } from 'vitest'
+import {
+  firstPendingId,
+  moveSelection,
+  nextActiveId,
+  reviewedCount,
+} from '../components/queue/logic.js'
+
+function entry(id: string, status: QueueEntry['status'] = 'pending'): QueueEntry {
+  return { id, title: `Plan ${id}`, dir: 'proj', status }
+}
+
+describe('firstPendingId', () => {
+  it('returns the first not-yet-done entry (golden)', () => {
+    expect(firstPendingId([entry('a', 'done'), entry('b'), entry('c')])).toBe('b')
+  })
+
+  it('returns null when every entry is done (edge)', () => {
+    expect(firstPendingId([entry('a', 'done'), entry('b', 'done')])).toBeNull()
+  })
+
+  it('returns null for an empty queue (error)', () => {
+    expect(firstPendingId([])).toBeNull()
+  })
+})
+
+describe('nextActiveId: auto-advance when the active plan finishes', () => {
+  it('keeps the active id while it is still pending (golden)', () => {
+    const entries = [entry('a'), entry('b')]
+    expect(nextActiveId(entries, 'a')).toBe('a')
+  })
+
+  it('advances to the next pending plan once the active one is done (golden)', () => {
+    const entries = [entry('a', 'done'), entry('b'), entry('c')]
+    expect(nextActiveId(entries, 'a')).toBe('b')
+  })
+
+  it('returns null when the active plan was the last pending one (edge)', () => {
+    const entries = [entry('a', 'done'), entry('b', 'done')]
+    expect(nextActiveId(entries, 'b')).toBeNull()
+  })
+
+  it('falls back to the first pending when the active id is unknown (error)', () => {
+    const entries = [entry('a', 'done'), entry('b')]
+    expect(nextActiveId(entries, 'gone')).toBe('b')
+  })
+})
+
+describe('moveSelection: keyboard navigation', () => {
+  const entries = [entry('a'), entry('b'), entry('c')]
+
+  it('moves down to the next entry (golden)', () => {
+    expect(moveSelection(entries, 'a', 1)).toBe('b')
+  })
+
+  it('moves up to the previous entry (golden)', () => {
+    expect(moveSelection(entries, 'b', -1)).toBe('a')
+  })
+
+  it('clamps at the last entry moving down (edge)', () => {
+    expect(moveSelection(entries, 'c', 1)).toBe('c')
+  })
+
+  it('clamps at the first entry moving up (edge)', () => {
+    expect(moveSelection(entries, 'a', -1)).toBe('a')
+  })
+
+  it('selects the first entry when nothing is active (error)', () => {
+    expect(moveSelection(entries, null, 1)).toBe('a')
+  })
+
+  it('returns null for an empty queue (error)', () => {
+    expect(moveSelection([], 'a', 1)).toBeNull()
+  })
+})
+
+describe('reviewedCount', () => {
+  it('counts done entries (golden)', () => {
+    expect(reviewedCount([entry('a', 'done'), entry('b'), entry('c', 'done')])).toBe(2)
+  })
+
+  it('is zero when none are done (edge)', () => {
+    expect(reviewedCount([entry('a'), entry('b')])).toBe(0)
+  })
+
+  it('is zero for an empty queue (error)', () => {
+    expect(reviewedCount([])).toBe(0)
+  })
+})

--- a/packages/runtime/tests/queue-shell-logic.test.ts
+++ b/packages/runtime/tests/queue-shell-logic.test.ts
@@ -2,6 +2,7 @@ import type { QueueEntry } from '@visualplan/core'
 import { describe, expect, it } from 'vitest'
 import {
   firstPendingId,
+  hasNewActivity,
   moveSelection,
   nextActiveId,
   reviewedCount,
@@ -86,5 +87,39 @@ describe('reviewedCount', () => {
 
   it('is zero for an empty queue (error)', () => {
     expect(reviewedCount([])).toBe(0)
+  })
+})
+
+describe('hasNewActivity', () => {
+  const at = (
+    id: string,
+    status: QueueEntry['status'] = 'pending',
+    iteration?: number,
+  ): QueueEntry => ({
+    id,
+    title: `Plan ${id}`,
+    dir: 'proj',
+    status,
+    iteration,
+  })
+
+  it('flags an added plan (golden)', () => {
+    expect(hasNewActivity([at('a')], [at('a'), at('b')])).toBe(true)
+  })
+
+  it('flags a status change on an existing plan (golden)', () => {
+    expect(hasNewActivity([at('a', 'pending')], [at('a', 'done')])).toBe(true)
+  })
+
+  it('flags a version bump on a requeued plan (golden)', () => {
+    expect(hasNewActivity([at('a', 'pending', 2)], [at('a', 'pending', 3)])).toBe(true)
+  })
+
+  it('does not flag an unchanged queue (edge)', () => {
+    expect(hasNewActivity([at('a'), at('b')], [at('a'), at('b')])).toBe(false)
+  })
+
+  it('does not flag a plan only being removed (edge)', () => {
+    expect(hasNewActivity([at('a'), at('b')], [at('a')])).toBe(false)
   })
 })

--- a/packages/runtime/tests/queue-shell.test.tsx
+++ b/packages/runtime/tests/queue-shell.test.tsx
@@ -167,3 +167,39 @@ describe('QueueShell single-plan vs queue', () => {
     expect(sidebar()).toBeNull()
   })
 })
+
+describe('QueueShell accessibility', () => {
+  function rows(): HTMLButtonElement[] {
+    return Array.from(container.querySelectorAll('.vp-queue__row'))
+  }
+
+  it('announces review progress and the active plan in a polite live region (golden)', () => {
+    render()
+    act(() => source().emitQueue([entry('a', 'done'), entry('b'), entry('c')]))
+    const live = container.querySelector('[aria-live="polite"]')
+    expect(live?.textContent).toContain('1 of 3 plans reviewed')
+    expect(live?.textContent).toContain('Now reviewing Plan b')
+  })
+
+  it('names each row with its origin dir and review status, not by color alone (golden)', () => {
+    render()
+    act(() => source().emitQueue([entry('a', 'done'), entry('b')]))
+    expect(rows()[0].getAttribute('aria-label')).toBe('Plan a, dir-a, reviewed')
+    expect(rows()[1].getAttribute('aria-label')).toBe('Plan b, dir-b, to review')
+  })
+
+  it('keeps only the active row in the tab order (roving tabindex) (golden)', () => {
+    render()
+    act(() => source().emitQueue([entry('a', 'done'), entry('b'), entry('c')]))
+    // The active plan defaults to the first pending one (b); only it is tabbable.
+    const tabindices = rows().map(r => r.getAttribute('tabindex'))
+    expect(tabindices).toEqual(['-1', '0', '-1'])
+  })
+
+  it('makes the first row tabbable when no plan is active yet (edge)', () => {
+    render()
+    // All done means nothing is active; the list must still be reachable by keyboard.
+    act(() => source().emitQueue([entry('a', 'done'), entry('b', 'done')]))
+    expect(rows().map(r => r.getAttribute('tabindex'))).toEqual(['0', '-1'])
+  })
+})

--- a/packages/runtime/tests/queue-shell.test.tsx
+++ b/packages/runtime/tests/queue-shell.test.tsx
@@ -208,6 +208,29 @@ describe('QueueShell accessibility', () => {
   })
 })
 
+describe('QueueShell titles', () => {
+  it('labels the sidebar "Plans to Review" (golden)', () => {
+    render()
+    act(() => source().emitQueue([entry('a'), entry('b')]))
+    expect(container.querySelector('.vp-queue__title')?.textContent ?? '').toBe('Plans to Review')
+  })
+
+  it('sets the tab title to the active plan being reviewed (golden)', () => {
+    render()
+    act(() =>
+      source().emitQueue([entry('a', 'done', { decision: 'approve' }), entry('b'), entry('c')]),
+    )
+    // The active plan defaults to the first pending one (b).
+    expect(document.title).toBe('Plan b')
+  })
+
+  it('falls back to the queue name when no plan is active (edge)', () => {
+    render()
+    act(() => source().emitQueue([entry('a', 'done', { decision: 'approve' })]))
+    expect(document.title).toBe('Plans to Review')
+  })
+})
+
 describe('QueueShell decision icons and version chips', () => {
   function rows(): HTMLButtonElement[] {
     return Array.from(container.querySelectorAll('.vp-queue__row'))

--- a/packages/runtime/tests/queue-shell.test.tsx
+++ b/packages/runtime/tests/queue-shell.test.tsx
@@ -40,8 +40,12 @@ class FakeEventSource {
   }
 }
 
-function entry(id: string, status: QueueEntry['status'] = 'pending'): QueueEntry {
-  return { id, title: `Plan ${id}`, dir: `dir-${id}`, status }
+function entry(
+  id: string,
+  status: QueueEntry['status'] = 'pending',
+  extra: Partial<QueueEntry> = {},
+): QueueEntry {
+  return { id, title: `Plan ${id}`, dir: `dir-${id}`, status, ...extra }
 }
 
 let container: HTMLDivElement
@@ -183,8 +187,8 @@ describe('QueueShell accessibility', () => {
 
   it('names each row with its origin dir and review status, not by color alone (golden)', () => {
     render()
-    act(() => source().emitQueue([entry('a', 'done'), entry('b')]))
-    expect(rows()[0].getAttribute('aria-label')).toBe('Plan a, dir-a, reviewed')
+    act(() => source().emitQueue([entry('a', 'done', { decision: 'approve' }), entry('b')]))
+    expect(rows()[0].getAttribute('aria-label')).toBe('Plan a, dir-a, approved')
     expect(rows()[1].getAttribute('aria-label')).toBe('Plan b, dir-b, to review')
   })
 
@@ -201,5 +205,44 @@ describe('QueueShell accessibility', () => {
     // All done means nothing is active; the list must still be reachable by keyboard.
     act(() => source().emitQueue([entry('a', 'done'), entry('b', 'done')]))
     expect(rows().map(r => r.getAttribute('tabindex'))).toEqual(['0', '-1'])
+  })
+})
+
+describe('QueueShell decision icons and version chips', () => {
+  function rows(): HTMLButtonElement[] {
+    return Array.from(container.querySelectorAll('.vp-queue__row'))
+  }
+
+  it('marks each decided row with its locked-in verdict, not a generic done (golden)', () => {
+    render()
+    act(() =>
+      source().emitQueue([
+        entry('a', 'done', { decision: 'approve' }),
+        entry('b', 'done', { decision: 'deny' }),
+        entry('c', 'done', { decision: 'iterate' }),
+      ]),
+    )
+    expect(rows().map(r => r.getAttribute('data-decision'))).toEqual(['approve', 'deny', 'iterate'])
+  })
+
+  it('carries no decision attribute while a plan is pending (edge)', () => {
+    render()
+    act(() => source().emitQueue([entry('a'), entry('b')]))
+    expect(rows()[0].getAttribute('data-decision')).toBeNull()
+  })
+
+  it('shows a version chip for an iteration but not for a first review (golden)', () => {
+    render()
+    act(() => source().emitQueue([entry('a', 'pending', { iteration: 3 }), entry('b')]))
+    const chips = Array.from(container.querySelectorAll('.vp-queue__chip')).map(c => c.textContent)
+    expect(chips).toEqual(['v3'])
+  })
+
+  it('names a row with its version and locked-in verdict (golden)', () => {
+    render()
+    act(() =>
+      source().emitQueue([entry('a', 'done', { decision: 'approve', iteration: 2 }), entry('b')]),
+    )
+    expect(rows()[0].getAttribute('aria-label')).toBe('Plan a, dir-a, v2, approved')
   })
 })

--- a/packages/runtime/tests/queue-shell.test.tsx
+++ b/packages/runtime/tests/queue-shell.test.tsx
@@ -224,10 +224,53 @@ describe('QueueShell titles', () => {
     expect(document.title).toBe('Plan b')
   })
 
-  it('falls back to the queue name when no plan is active (edge)', () => {
+  it('falls back to the default queue title when no plan is active (edge)', () => {
     render()
     act(() => source().emitQueue([entry('a', 'done', { decision: 'approve' })]))
-    expect(document.title).toBe('Plans to Review')
+    expect(document.title).toBe('Visual Plan Review Queue')
+  })
+})
+
+describe('QueueShell background activity dot', () => {
+  function setHidden(hidden: boolean): void {
+    Object.defineProperty(document, 'hidden', { value: hidden, configurable: true })
+    Object.defineProperty(document, 'visibilityState', {
+      value: hidden ? 'hidden' : 'visible',
+      configurable: true,
+    })
+  }
+
+  function faviconHasDot(): boolean {
+    const link = document.querySelector<HTMLLinkElement>('link[rel="icon"]')
+    return decodeURIComponent(link?.href ?? '').includes('<circle')
+  }
+
+  afterEach(() => setHidden(false))
+
+  it('raises the favicon dot when a plan arrives while the tab is hidden (golden)', () => {
+    setHidden(true)
+    render()
+    act(() => source().emitQueue([entry('a'), entry('b')]))
+    expect(faviconHasDot()).toBe(true)
+  })
+
+  it('leaves the favicon plain when the tab is in the foreground (edge)', () => {
+    setHidden(false)
+    render()
+    act(() => source().emitQueue([entry('a'), entry('b')]))
+    expect(faviconHasDot()).toBe(false)
+  })
+
+  it('clears the dot when the tab returns to the foreground (golden)', () => {
+    setHidden(true)
+    render()
+    act(() => source().emitQueue([entry('a'), entry('b')]))
+    expect(faviconHasDot()).toBe(true)
+    act(() => {
+      setHidden(false)
+      document.dispatchEvent(new Event('visibilitychange'))
+    })
+    expect(faviconHasDot()).toBe(false)
   })
 })
 

--- a/packages/runtime/tests/queue-shell.test.tsx
+++ b/packages/runtime/tests/queue-shell.test.tsx
@@ -119,6 +119,21 @@ describe('QueueShell', () => {
     expect((container.textContent ?? '').toLowerCase()).toContain('reviewed')
   })
 
+  it('reloads a decided plan in the iframe when its row is reselected (golden)', () => {
+    render()
+    act(() =>
+      source().emitQueue([
+        entry('a', 'done', { decision: 'approve' }),
+        entry('b', 'done', { decision: 'deny' }),
+      ]),
+    )
+    // All done: nothing is auto-selected, so the empty state shows.
+    expect(container.querySelector('iframe')).toBeNull()
+    // Clicking a decided row loads it (the daemon serves it locked into its verdict).
+    act(() => container.querySelector<HTMLButtonElement>('.vp-queue__row')?.click())
+    expect(iframeSrc()).toBe('/plan/a')
+  })
+
   it('shows a progress count of reviewed plans (edge)', () => {
     render()
     act(() => source().emitQueue([entry('a', 'done'), entry('b'), entry('c')]))

--- a/packages/runtime/tests/queue-shell.test.tsx
+++ b/packages/runtime/tests/queue-shell.test.tsx
@@ -1,0 +1,136 @@
+import type { QueueEntry } from '@visualplan/core'
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { QueueShell } from '../components/queue/QueueShell.js'
+
+/** A minimal EventSource stand-in the test drives directly, mirroring the daemon's `queue` event. */
+class FakeEventSource {
+  static last: FakeEventSource | null = null
+  url: string
+  closed = false
+  private listeners = new Map<string, ((event: MessageEvent) => void)[]>()
+
+  constructor(url: string) {
+    this.url = url
+    FakeEventSource.last = this
+  }
+
+  addEventListener(type: string, fn: (event: MessageEvent) => void): void {
+    const list = this.listeners.get(type) ?? []
+    list.push(fn)
+    this.listeners.set(type, list)
+  }
+
+  removeEventListener(type: string, fn: (event: MessageEvent) => void): void {
+    this.listeners.set(
+      type,
+      (this.listeners.get(type) ?? []).filter(f => f !== fn),
+    )
+  }
+
+  close(): void {
+    this.closed = true
+  }
+
+  /** Push a `queue` payload to the shell as the daemon would. */
+  emitQueue(entries: QueueEntry[]): void {
+    const event = new MessageEvent('queue', { data: JSON.stringify(entries) })
+    for (const fn of this.listeners.get('queue') ?? []) fn(event)
+  }
+}
+
+function entry(id: string, status: QueueEntry['status'] = 'pending'): QueueEntry {
+  return { id, title: `Plan ${id}`, dir: `dir-${id}`, status }
+}
+
+let container: HTMLDivElement
+let root: Root
+
+beforeEach(() => {
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  FakeEventSource.last = null
+  vi.stubGlobal('EventSource', FakeEventSource)
+})
+
+afterEach(() => {
+  act(() => root?.unmount())
+  container.remove()
+  vi.restoreAllMocks()
+})
+
+function render(): void {
+  root = createRoot(container)
+  act(() => root.render(<QueueShell />))
+}
+
+function source(): FakeEventSource {
+  if (!FakeEventSource.last) throw new Error('EventSource was not opened')
+  return FakeEventSource.last
+}
+
+function iframeSrc(): string | null {
+  return container.querySelector('iframe')?.getAttribute('src') ?? null
+}
+
+describe('QueueShell', () => {
+  it('opens the events stream for liveness on mount (golden)', () => {
+    render()
+    expect(source().url).toBe('/__vp_events')
+  })
+
+  it('renders a sidebar row per entry with title and originating dir (golden)', () => {
+    render()
+    act(() => source().emitQueue([entry('a'), entry('b')]))
+    const text = container.textContent ?? ''
+    expect(text).toContain('Plan a')
+    expect(text).toContain('dir-a')
+    expect(text).toContain('Plan b')
+    expect(text).toContain('dir-b')
+  })
+
+  it('defaults the active iframe to the first pending plan (golden)', () => {
+    render()
+    act(() => source().emitQueue([entry('a', 'done'), entry('b'), entry('c')]))
+    expect(iframeSrc()).toBe('/plan/b')
+  })
+
+  it('auto-advances the iframe when the active plan is marked done (golden)', () => {
+    render()
+    act(() => source().emitQueue([entry('a'), entry('b')]))
+    expect(iframeSrc()).toBe('/plan/a')
+    act(() => source().emitQueue([entry('a', 'done'), entry('b')]))
+    expect(iframeSrc()).toBe('/plan/b')
+  })
+
+  it('shows an all-reviewed empty state when every plan is done (edge)', () => {
+    render()
+    act(() => source().emitQueue([entry('a', 'done'), entry('b', 'done')]))
+    expect(container.querySelector('iframe')).toBeNull()
+    expect((container.textContent ?? '').toLowerCase()).toContain('reviewed')
+  })
+
+  it('shows a progress count of reviewed plans (edge)', () => {
+    render()
+    act(() => source().emitQueue([entry('a', 'done'), entry('b'), entry('c')]))
+    expect(container.textContent ?? '').toContain('1 of 3')
+  })
+
+  it('moves the active plan with the j key (golden)', () => {
+    render()
+    act(() => source().emitQueue([entry('a'), entry('b'), entry('c')]))
+    expect(iframeSrc()).toBe('/plan/a')
+    act(() => {
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'j' }))
+    })
+    expect(iframeSrc()).toBe('/plan/b')
+  })
+
+  it('closes the events stream on unmount (error)', () => {
+    render()
+    const es = source()
+    act(() => root.unmount())
+    expect(es.closed).toBe(true)
+  })
+})

--- a/packages/runtime/tests/queue-shell.test.tsx
+++ b/packages/runtime/tests/queue-shell.test.tsx
@@ -74,6 +74,10 @@ function iframeSrc(): string | null {
   return container.querySelector('iframe')?.getAttribute('src') ?? null
 }
 
+function sidebar(): Element | null {
+  return container.querySelector('.vp-queue__sidebar')
+}
+
 describe('QueueShell', () => {
   it('opens the events stream for liveness on mount (golden)', () => {
     render()
@@ -132,5 +136,34 @@ describe('QueueShell', () => {
     const es = source()
     act(() => root.unmount())
     expect(es.closed).toBe(true)
+  })
+})
+
+// The queue chrome is for navigating BETWEEN plans, so a lone plan should look like an ordinary
+// single review (no sidebar); the sidebar appears only once a second plan is in the queue.
+describe('QueueShell single-plan vs queue', () => {
+  it('hides the sidebar and shows the plan full-width when only one plan is queued (golden)', () => {
+    render()
+    act(() => source().emitQueue([entry('a')]))
+    expect(sidebar()).toBeNull()
+    // The single plan still renders; it just has no queue rail beside it.
+    expect(iframeSrc()).toBe('/plan/a')
+  })
+
+  it('reveals the sidebar when a second plan joins the queue mid-review (golden)', () => {
+    render()
+    act(() => source().emitQueue([entry('a')]))
+    expect(sidebar()).toBeNull()
+    act(() => source().emitQueue([entry('a'), entry('b')]))
+    expect(sidebar()).not.toBeNull()
+  })
+
+  it('hides the sidebar again if the queue drops back to a single plan (edge)', () => {
+    render()
+    act(() => source().emitQueue([entry('a'), entry('b')]))
+    expect(sidebar()).not.toBeNull()
+    // A caller abandoning its plan removes it; back to one plan means back to no chrome.
+    act(() => source().emitQueue([entry('a')]))
+    expect(sidebar()).toBeNull()
   })
 })

--- a/packages/runtime/theme.css
+++ b/packages/runtime/theme.css
@@ -705,6 +705,13 @@ body {
   color: var(--vp-faint);
 }
 
+/* A decided plan locks the answer fields: the answer stays readable but reads as settled, not editable. */
+.vp-questions__answer[readonly] {
+  cursor: default;
+  background: var(--vp-surface);
+  color: var(--vp-muted);
+}
+
 .vp-questions__answer:focus-visible {
   outline: none;
   border-color: var(--vp-question);

--- a/skills/visual-plan/SKILL.md
+++ b/skills/visual-plan/SKILL.md
@@ -28,11 +28,6 @@ and tables, with prose only connecting the visuals, not carrying the plan itself
 
 ## Workflow
 
-- [ ] 1. Write the plan to a `.mdx` file (`# Title` first; components are always in scope).
-- [ ] 2. `vplan check <file>.mdx` and fix every reported issue, quality-lint warnings included.
-- [ ] 3. Present with `vplan <file>.mdx` (an interactive review is the default), then act on the feedback.
-- [ ] 4. For a static page, a live preview, or a PDF/JPG instead, load `references/static-exports.md`.
-
 1. Write the plan to a `.mdx` file, starting with a single `# Title` heading (it becomes the plan
    title; no frontmatter). Then use the components below; you never write `import` statements, they
    are always in scope.

--- a/skills/visual-plan/SKILL.md
+++ b/skills/visual-plan/SKILL.md
@@ -8,8 +8,8 @@ description: >-
   page (diagrams, phases, file-change maps, comparisons) via the `vplan` CLI. It applies when the
   user says "plan this", "what's the approach", "how should we approach X", "show me the plan",
   "make a visual plan", "render this plan", or asks for a plan with diagrams/charts, and when they
-  want to review, approve, sign off on, or give feedback on a plan via `vplan render --review`. Skip
-  only for a trivial one-step change or when the user explicitly asks for plain prose.
+  want to review, approve, sign off on, or give feedback on a plan. Skip only for a trivial 
+  one-step change or when the user explicitly asks for plain prose.
 ---
 
 ## Purpose
@@ -31,7 +31,7 @@ and tables, with prose only connecting the visuals, not carrying the plan itself
 - [ ] 1. Write the plan to a `.mdx` file (`# Title` first; components are always in scope).
 - [ ] 2. `vplan check <file>.mdx` and fix every reported issue, quality-lint warnings included.
 - [ ] 3. Present with `vplan <file>.mdx` (an interactive review is the default), then act on the feedback.
-- [ ] 4. For a static page, a live preview, or a PDF/JPG instead, see `references/static-exports.md`.
+- [ ] 4. For a static page, a live preview, or a PDF/JPG instead, load `references/static-exports.md`.
 
 1. Write the plan to a `.mdx` file, starting with a single `# Title` heading (it becomes the plan
    title; no frontmatter). Then use the components below; you never write `import` statements, they
@@ -48,7 +48,7 @@ and tables, with prose only connecting the visuals, not carrying the plan itself
    answers to stdout, and exits: approve 0, deny 1, iterate 2, timeout 3 (`--timeout`, default 15m;
    closing the tab counts as deny). It is a long-running foreground server, so run it in the
    background. (The explicit `--review` flag still works but is redundant now that review is the
-   default; `--static` opts out into a one-shot page, see step 4.) Then act on the printed feedback:
+   default.) Then act on the printed feedback:
    - **Approve** -> proceed with the plan as written.
    - **Iterate** -> revise the plan addressing each comment, then review again with `-i N`
      (`--iteration N`) incremented so the bar shows the round; repeat until Approve or Deny. **Edit
@@ -64,9 +64,10 @@ and tables, with prose only connecting the visuals, not carrying the plan itself
    explicit Approve so you know it is settled. Reach for a static render (step 4) only when the user
    just wants to look, not shape or decide.
 4. **A static page, a live-reloading preview, or a PDF/JPG export** are the non-review outputs, for
-   when the user only wants to look or wants a shareable file. They opt out of the review default via
-   `--static`, `--watch`, `--stdout`, or `vplan export`. See **`references/static-exports.md`** for
-   all of them; authoring the plan (everything below) is identical whichever output you choose.
+   when the user only wants to look or wants a shareable file rather than review one. When you need
+   one, **load `references/static-exports.md`**; it holds the commands and flags for these (kept out
+   of here so review stays the default path). Authoring the plan (everything below) is identical
+   whichever output you choose.
 
 Run `vplan components` anytime for the exact prop signatures.
 
@@ -236,8 +237,7 @@ it in paragraphs. Prose is the connective tissue between visuals, never the subs
 ## Rules
 
 - **Never pass `--no-open` for a user-facing plan.** The point is that the user sees it; the review
-  session and a static render both open automatically. Reserve `--no-open` for an explicit
-  headless/CI request.
+  session opens automatically. Reserve `--no-open` for an explicit headless/CI request.
 - **No images or external assets.** The page is a single self-contained file, so a markdown image
   (`![](url)`) or any external asset cannot be embedded, and `check` rejects markdown images. Use a
   ` ```mermaid ` diagram for anything visual, or describe it in text.

--- a/skills/visual-plan/SKILL.md
+++ b/skills/visual-plan/SKILL.md
@@ -30,9 +30,8 @@ and tables, with prose only connecting the visuals, not carrying the plan itself
 
 - [ ] 1. Write the plan to a `.mdx` file (`# Title` first; components are always in scope).
 - [ ] 2. `vplan check <file>.mdx` and fix every reported issue, quality-lint warnings included.
-- [ ] 3. Present with `vplan render --review <file>.mdx` (the default), then act on the feedback.
-- [ ] 4. Or a plain `vplan <file>.mdx` when the user only wants to look, not shape or decide.
-- [ ] 5. `vplan export <pdf|jpg> <file>.mdx` when the user wants a shareable static file.
+- [ ] 3. Present with `vplan <file>.mdx` (an interactive review is the default), then act on the feedback.
+- [ ] 4. For a static page, a live preview, or a PDF/JPG instead, see `references/static-exports.md`.
 
 1. Write the plan to a `.mdx` file, starting with a single `# Title` heading (it becomes the plan
    title; no frontmatter). Then use the components below; you never write `import` statements, they
@@ -41,14 +40,15 @@ and tables, with prose only connecting the visuals, not carrying the plan itself
    issue (it names valid enum values and flags unknown components). `check` also runs a **quality
    lint** that flags weak renders (the enforced Gotchas below); its warnings fail `check`, so fix
    them too.
-3. **Present the plan with `vplan render --review <file>.mdx`. This is the default way to deliver a
+3. **Present the plan with `vplan <file>.mdx`. An interactive review is the default way to deliver a
    plan, not a special mode reserved for sign-off.** It opens the plan with a feedback layer where the
    user comments on whole sections or on selected text, **answers any `<Questions>` directly** (each
    question becomes an inline answer field, printed back as `Answer to "<question>":`), then clicks
    Approve / Deny / Iterate. It **blocks** until they submit, prints the decision, comments, and
    answers to stdout, and exits: approve 0, deny 1, iterate 2, timeout 3 (`--timeout`, default 15m;
    closing the tab counts as deny). It is a long-running foreground server, so run it in the
-   background. Then act on the printed feedback:
+   background. (The explicit `--review` flag still works but is redundant now that review is the
+   default; `--static` opts out into a one-shot page, see step 4.) Then act on the printed feedback:
    - **Approve** -> proceed with the plan as written.
    - **Iterate** -> revise the plan addressing each comment, then review again with `-i N`
      (`--iteration N`) incremented so the bar shows the round; repeat until Approve or Deny. **Edit
@@ -59,21 +59,14 @@ and tables, with prose only connecting the visuals, not carrying the plan itself
      `--no-diff` to suppress diffing (e.g. a clean first look).
    - **Deny** -> stop and reconsider; do not proceed.
 
-   **Default to `--review` for every non-trivial plan.** Targeted comments and in-place `<Questions>`
-   answers drive sharper revisions than back-and-forth chat, and the loop ends in an explicit Approve
-   so you know it is settled. Use the plain render (step 4) only when the user just wants to look.
-4. **Plain render is the fallback, for when the user only wants to look, not shape or decide.**
-   `vplan <file>.mdx` writes `<file>.plan.html` next to the source and opens it (`--out <path>` sets
-   the location). While iterating visually, `vplan --watch <file>.mdx` starts a live-reloading dev
-   server (a long-running foreground server: run it in the background; it writes no file and stops on
-   Ctrl+C). The iteration diff shows on a plain render too, not just `--review`.
-5. **To export a plan as a static file**, run `vplan export <pdf|jpg> <file>.mdx`. It builds the
-   same self-contained page and captures it headless: `pdf` prints a paginated A4 document, `jpg` a
-   full-page hi-dpi screenshot. Output defaults to `<file>.pdf` / `<file>.jpg` (override with
-   `--out`); `--theme` overrides the baked color scheme, `--no-open` suppresses opening the result.
-   This needs a Chromium: it uses a system Chrome/Edge or a `playwright`-installed one, and otherwise
-   prints `npx playwright install chromium`. Use this when the user wants a shareable file rather than
-   the interactive HTML page.
+   **Review is the right default for every non-trivial plan.** Targeted comments and in-place
+   `<Questions>` answers drive sharper revisions than back-and-forth chat, and the loop ends in an
+   explicit Approve so you know it is settled. Reach for a static render (step 4) only when the user
+   just wants to look, not shape or decide.
+4. **A static page, a live-reloading preview, or a PDF/JPG export** are the non-review outputs, for
+   when the user only wants to look or wants a shareable file. They opt out of the review default via
+   `--static`, `--watch`, `--stdout`, or `vplan export`. See **`references/static-exports.md`** for
+   all of them; authoring the plan (everything below) is identical whichever output you choose.
 
 Run `vplan components` anytime for the exact prop signatures.
 
@@ -242,8 +235,9 @@ it in paragraphs. Prose is the connective tissue between visuals, never the subs
 
 ## Rules
 
-- **Never pass `--no-open` for a user-facing plan.** The point is that the user sees it; the plain
-  render and `--watch` open automatically. Reserve `--no-open` for an explicit headless/CI request.
+- **Never pass `--no-open` for a user-facing plan.** The point is that the user sees it; the review
+  session and a static render both open automatically. Reserve `--no-open` for an explicit
+  headless/CI request.
 - **No images or external assets.** The page is a single self-contained file, so a markdown image
   (`![](url)`) or any external asset cannot be embedded, and `check` rejects markdown images. Use a
   ` ```mermaid ` diagram for anything visual, or describe it in text.

--- a/skills/visual-plan/references/static-exports.md
+++ b/skills/visual-plan/references/static-exports.md
@@ -1,0 +1,42 @@
+# Static renders and exports
+
+The non-review outputs of `vplan`, for when the user only wants to **look** at a plan (not shape or
+decide on it) or wants a **shareable file**. Each opts out of the default interactive review.
+
+Authoring a plan (the components, the show-don't-tell rules, the gotchas) is identical whichever
+output you pick; it all lives in the main `SKILL.md`. Always `vplan check <file>.mdx` first.
+
+## Static HTML page (`--static`)
+
+`vplan --static <file>.mdx` writes `<file>.plan.html` next to the source and opens it: a one-shot,
+self-contained page with no feedback layer. This is the pre-review default, for when the user just
+wants to see the plan.
+
+- `--out <path>` sets the output location (and implies a static render).
+- `--stdout` writes the HTML to stdout instead of a file (implies a static render), so it composes in
+  a pipeline; a `--stdout` render is deterministic and never auto-diffs.
+- `--no-open` suppresses opening the result (reserve for an explicit headless/CI request).
+
+The iteration diff (git-gutter accents marking what changed since the last view) shows on a static
+render too, not just in review: `vplan` snapshots each plan it presents, keyed by the file path.
+`--diff <baseline.mdx>` diffs against an explicit file; `--no-diff` suppresses it.
+
+## Live-reloading preview (`--watch`)
+
+`vplan --watch <file>.mdx` starts a hot-reloading dev server (default `--port 9140`, auto-incrementing
+if taken) and opens it; editing the file live-reloads the page. It needs a real file (not stdin),
+writes no file, and runs until Ctrl+C. It is a long-running foreground server, so run it in the
+background. Use it while iterating on a plan's visuals before a review.
+
+## PDF / JPG export (`vplan export`)
+
+`vplan export <pdf|jpg> <file>.mdx` builds the same self-contained page, then captures it headless:
+`pdf` prints a paginated A4 document, `jpg` a full-page hi-dpi screenshot. Use this when the user
+wants a shareable static file rather than the interactive HTML page.
+
+- Output defaults to `<file>.pdf` / `<file>.jpg`; `--out <path>` overrides (and is required for stdin
+  input).
+- `--theme light|dark|system` overrides the baked color scheme; `--no-open` suppresses opening.
+- It needs a Chromium: it uses a system Chrome/Edge or a `playwright`-installed one, with
+  `--browser <path>` / `VPLAN_CHROMIUM` overrides, otherwise it prints `npx playwright install
+  chromium`.


### PR DESCRIPTION
## What

A **Review Queue**: a per-user daemon that `vplan render --review` auto-starts so plans from many sessions land in one browser tab with a left sidebar, reviewed one after another, each verdict routed back to the session that queued it. Review is now the **default** render mode.

## Why

Reviewing plans one tab at a time does not scale when several plans are in flight (parallel agents, iterating phases). One shared, warm tab you clear like an inbox is the goal.

## Highlights

**CLI**
- `vplan <file>` now opens an **interactive review by default**. `--static` captures the old behavior (write `<file>.plan.html` and open); `--watch`/`--stdout`/`--out` also opt out into a static artifact. `--review` is kept for compatibility. `--no-daemon` keeps a one-shot in-process server.
- `vplan review <files...>` queues several plans at once and streams each verdict.
- `vplan open` opens (or pre-warms) the queue tab on its own, starting the daemon if needed.

**Daemon** (`packages/cli/src/review/`)
- A detached, per-user background process (so a caller returns its own verdict promptly while the queue keeps serving). An atomic `~/.vplan/review-daemon.json` lockfile mutex collapses simultaneous launches to one.
- Owns one tab, serves each plan as a same-origin review-mode iframe at `/plan/<id>`, routes verdicts to the waiting caller, denies all and exits on tab close, lingers `daemonTimeout` (config, default 15m) after the queue empties. Requeuing a plan (keyed by file path) replaces its prior version in place.

**Shell** (`packages/runtime/components/queue/`)
- Sidebar of queued plans (title + origin-dir basename), hidden until a second plan joins so a lone plan reads as an ordinary review. Per-decision status icons (green check / red cross / gold spinning iterate), `vN` version chips, roving-tabindex keyboard nav, an `aria-live` progress announcer.
- Tab title tracks the active plan (default "Visual Plan Review Queue"); a blue bottom-right favicon dot signals queue activity while the tab is backgrounded.
- A decided plan re-opens **locked** into its verdict on the bottom bar (no live controls, no "close this tab" in queue mode), and its `Questions` answers stay visible read-only.

**Docs**: root + package `AGENTS.md`, README, and the `visual-plan` skill updated; static/export CLI details moved into a `references/static-exports.md` so the skill centers on create-and-review.

## Verification

- Unit + integration tests across core/cli/runtime (schema, config, daemon endpoints and lifecycle, lockfile mutex, routing, batch, sidebar/decision/version logic, favicon, locked-state, Questions lock). New a11y tests (contrast, roving tabindex, live region, accessible names).
- A gated real-spawn e2e (`VP_DAEMON_E2E=1`) confirms two simultaneous launches collapse to one surviving daemon.
- Real headless-browser checks at each step (sidebar render, single-plan no-sidebar, decision icons/colors, version chips, requeue-replaces, tab title, favicon dot, locked verdict bar, read-only answers).
- `pnpm typecheck` and `pnpm check` (biome) clean.

Note: a few CLI tests that spin up real Vite builds can flake (`fetch failed`) under full-suite memory pressure on a loaded machine; they pass deterministically in isolation. This is a pre-existing environment limitation, not from this change.