### PR TITLE
docs(site): review-as-default and a Review queue section

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,23 +36,6 @@ npm i -g vplan
 npx vplan plan.mdx
 ```
 
-## Usage
-
-```bash
-vplan plan.mdx              # open an interactive review session (the default), blocks for sign-off
-vplan plan.mdx --static     # render to plan.plan.html and open it, no review
-vplan plan.mdx --watch      # live-reloading dev server while you edit
-vplan review a.mdx b.mdx    # queue several plans, review them in one tab, stream verdicts
-vplan check plan.mdx        # validate a plan (syntax + quality lint) without rendering
-vplan export pdf plan.mdx   # render to a static PDF or JPG via headless Chromium
-vplan share plan.mdx        # print a shareable visualplan.dev link
-vplan components            # print the component vocabulary
-vplan config                # view or change persistent settings (default theme)
-```
-
-A plan is an MDX file that starts with a `# Title` (no frontmatter) and uses a fixed set of
-components, always in scope (no imports):
-
 ### Example Plan
 
 ````mdx

--- a/packages/app/src/pages/docs/cli.md
+++ b/packages/app/src/pages/docs/cli.md
@@ -15,34 +15,40 @@ description: Every vplan command and flag.
 vplan <file.mdx>
 ```
 
-Compiles a plan to a single self-contained `<file>.plan.html` next to the source and opens it.
-`render` is the default command, so `vplan plan.mdx` and `vplan render plan.mdx` are the same. The
-file argument may be `-` (or omitted) to read the plan from stdin.
+Opens the plan in an interactive review session by default (see [Review mode](#review-mode)). Pass
+`--static` to instead compile a single self-contained `<file>.plan.html` next to the source and open
+it. `render` is the default command, so `vplan plan.mdx` and `vplan render plan.mdx` are the same.
+The file argument may be `-` (or omitted) to read the plan from stdin.
 
 | Flag | Effect |
 |------|--------|
+| `--static` | Render a static HTML page and open it instead of the review session (the pre-review default). |
 | `--watch` | Start a hot-reloading dev server instead of writing a file. Long-running; stops on Ctrl+C. |
 | `--port <number>` | Port for the `--watch` dev server (default `9140`, auto-incrementing if taken). |
-| `--out <path>` | Write the HTML to `<path>` instead of `<file>.plan.html`. |
-| `--stdout` | Write the rendered HTML to stdout instead of a file (composes in a pipeline; never auto-diffs). |
-| `--review` | Open an interactive review session and block until the reviewer decides (see below). |
+| `--out <path>` | Write the HTML to `<path>` instead of `<file>.plan.html` (implies `--static`). |
+| `--stdout` | Write the rendered HTML to stdout instead of a file (implies `--static`; composes in a pipeline; never auto-diffs). |
+| `--review` | Open the interactive review session (now the default; kept for compatibility). |
+| `--no-daemon` | Review without the shared queue daemon, using a one-shot in-process server. |
 | `-i, --iteration <n>` | Plan revision number shown in the review bar; increment it each re-review. |
 | `--timeout <duration>` | Max wait for review feedback, e.g. `15m`, `30s`, `1h` (default `15m`). |
 | `--diff <path>` | Diff this render against an explicit baseline plan, overriding the snapshot cache. |
 | `--no-diff` | Skip iteration diffing (do not read or write the snapshot cache). |
 | `--no-open` | Do not open the result in the browser. |
 
-`--watch` serves a local URL and writes no file, so for a one-shot HTML output use the plain
-render, not `--watch`.
+For a one-shot HTML file use `--static` (or `--stdout` for a pipeline), not `--watch` (which serves a
+local URL and writes no file).
 
 ### Review mode
 
-`vplan render --review <file.mdx>` opens the plan as an interactive review session: the reviewer
-comments on sections or selected text, answers any `<Questions>` inline, then clicks Approve, Deny,
-or Iterate. The command **blocks** until they submit, prints the decision, comments, and answers to
-stdout, then exits with a decision-specific code (see [Exit codes](#exit-codes)). It is a
-long-running foreground server; a closed tab counts as Deny, and `--timeout` bounds the wait. See
-[Review mode](/docs/review/) for an interactive demo and the full session walkthrough.
+`vplan <file.mdx>` opens the plan as an interactive review session: the reviewer comments on sections
+or selected text, answers any `<Questions>` inline, then clicks Approve, Deny, or Iterate. The
+command **blocks** until they submit, prints the decision, comments, and answers to stdout, then
+exits with a decision-specific code (see [Exit codes](#exit-codes)). It is a long-running foreground
+server; a closed tab counts as Deny, and `--timeout` bounds the wait.
+
+Reviews join a shared **queue** so several plans share one tab: `vplan review <files...>` enqueues
+several at once, and `vplan open` opens (or pre-warms) the queue tab on its own. See
+[Review mode](/docs/review/) for the demo, the queue, and the full session walkthrough.
 
 ### Iteration diffing
 
@@ -124,10 +130,13 @@ vplan config set <key> <value>
 vplan config path       # print the config file path
 ```
 
-Views and edits persistent settings stored in `~/.vplan/config.json`. The only setting is `theme`
-(`light`, `dark`, or `system`), the default color scheme baked into every rendered plan. The in-page
-settings cog overrides this per view in the browser (via `localStorage`) and never writes the file,
-so the on-disk default and the in-page override are separate layers.
+Views and edits persistent settings stored in `~/.vplan/config.json`:
+
+- `theme` (`light`, `dark`, or `system`): the default color scheme baked into every rendered plan.
+  The in-page settings cog overrides this per view in the browser (via `localStorage`) and never
+  writes the file, so the on-disk default and the in-page override are separate layers.
+- `daemonTimeout` (a duration like `15m`, default `15m`): how long the review queue daemon lingers
+  after its queue empties before exiting, so a quick re-plan reuses the warm tab.
 
 ## Exit codes
 

--- a/packages/app/src/pages/docs/review.mdx
+++ b/packages/app/src/pages/docs/review.mdx
@@ -8,13 +8,14 @@ import ReviewDemoEmbed from '../../components/ReviewDemoEmbed.astro'
 
 # Review mode
 
-Most of the time you render a plan just to read it. **Review mode** is for when you want a decision:
-it opens the plan as an interactive session where you comment on the plan, answer its open questions,
-and end with an explicit Approve, Deny, or Iterate. The CLI blocks on that verdict and hands it back
-to the agent, so the agent knows exactly when the plan is settled and what to change if it is not.
+Rendering a plan opens an interactive **review** by default: a session where you comment on the
+plan, answer its open questions, and end with an explicit Approve, Deny, or Iterate. The CLI blocks
+on that verdict and hands it back to the agent, so the agent knows exactly when the plan is settled
+and what to change if it is not. (Reach for `--static` when you only want to read a plan, not decide
+on it.)
 
 ```bash
-vplan render --review plan.mdx
+vplan plan.mdx          # opens a review session (the default)
 ```
 
 The demo below is the real review layer running over a dummy plan, in a self-contained mode with no
@@ -59,8 +60,37 @@ git-gutter accent and an "N changed" summary, so you re-review only the delta. T
 Deny.
 
 ```bash
-vplan render --review plan.mdx -i 2   # second review round, shows the diff since round 1
+vplan plan.mdx -i 2   # second review round, shows the diff since round 1
 ```
+
+## Review queue
+
+When several plans are in flight at once, they share one tab instead of opening one each. The first
+review starts a small background daemon that owns a single browser tab with a left sidebar of every
+queued plan; reviews launched from any other session join the same tab. You clear them like an
+inbox: decide a plan and it is checked off and the next one opens, and each plan's verdict returns to
+the session that queued it.
+
+Queue several plans at once:
+
+```bash
+vplan review plan-a.mdx plan-b.mdx plan-c.mdx
+```
+
+Or open the queue tab on its own, so later reviews have somewhere to land (it starts the daemon if
+one is not already running):
+
+```bash
+vplan open
+```
+
+In the sidebar each plan shows its title, its origin directory, and a status icon for the verdict it
+locked in (a green check for Approve, a red cross for Deny, a spinning mark for Iterate); a
+re-reviewed plan carries a `vN` version chip, and requeuing a plan replaces its prior version in
+place. Reselect a decided plan to revisit its locked-in verdict with your answers preserved. The
+daemon lingers for a configurable idle window after the queue empties so a quick re-plan reuses the
+warm tab, and closing the tab denies anything still pending. Pass `--no-daemon` for a one-shot tab
+per review instead.
 
 See the [CLI reference](/docs/cli/#review-mode) for the full flag list, including `--timeout`,
 `--diff`, and `--no-diff`.


### PR DESCRIPTION
Follow-up to #19 (Review Queue), updating the docs site now that `--review` is the default render mode.

- **Review mode page**: rendering a plan opens a review by default (`--static` for a read-only page); refreshed the intro and the iterate example, and added a **Review queue** section covering the shared tab, `vplan review <files...>`, `vplan open`, the sidebar verdict icons / version chips, and the locked-on-reselect behavior.
- **CLI reference**: `render` now reviews by default; added `--static` and `--no-daemon`, reworded `--review` as the compatibility flag, updated the Review mode subsection, and documented the new `daemonTimeout` config setting.

Verified: `astro check` clean (0 errors).