### PR TITLE
feat: iterate plans in place, harden the review daemon lifecycle, richer review feedback

### DIFF
--- a/packages/cli/AGENTS.md
+++ b/packages/cli/AGENTS.md
@@ -53,20 +53,40 @@ programmatic Node API at `dist/api.js` (the package's `import` entry, `exports["
   (NOT Vite) holding an in-memory queue: each enqueued plan is built once via `compile.ts buildHtml`
   with `review: { planId, iteration }` and served from `/plan/<id>`; a browser "shell" lists the queue.
   The HTTP/SSE contract is FROZEN (the runtime shell depends on exact endpoint/field/frame shapes):
-  `GET /__vp_ping` (liveness), `GET /` (shell, cached), `GET /plan/<id>`, `POST /__vp_enqueue`
-  (-> `{ id, shellConnected }`; cancel idle timer BEFORE the slow build or a short idleMs shuts the
-  daemon mid-enqueue), `GET /__vp_verdict?id` (long-held; caller disconnect drops the plan),
-  `POST /__vp_feedback` + `POST /__vp_draft` (both validated by `feedbackSchema`, routed by `planId`;
-  feedback is idempotent once settled), `GET /__vp_events` (SSE `event: queue` = `QueueEntry[]`; the
-  shell's liveness signal). Lifecycle: idle TTL fires when no `pending` plans remain (a new enqueue
-  cancels it); the LAST events client closing starts a 1500ms grace (survives a reload), after which
-  all still-pending plans are denied (with their draft) and the daemon shuts down. One idempotent
-  `shutdown()` ends every held connection so `close()` cannot hang on an SSE (the same regression the
-  one-shot server guards). `lockfile.ts` is discovery + the mutex: `~/.vplan/review-daemon.json`
+  `GET /__vp_ping` (liveness), `GET /` (shell, cached), `GET /plan/<id>` (served `no-store`: ids are
+  reused across revisions), `POST /__vp_enqueue` (-> `{ id, shellConnected }`; cancel idle timer
+  BEFORE the slow build or a short idleMs shuts the daemon mid-enqueue), `GET /__vp_verdict?id`
+  (long-held; caller disconnect drops the plan), `POST /__vp_feedback` + `POST /__vp_draft` (both
+  validated by `feedbackSchema`, routed by `planId`; feedback is idempotent once settled),
+  `GET /__vp_events` (SSE `event: queue` = `QueueEntry[]`; the shell's liveness signal, kept warm by
+  `: hb` comment frames every `HEARTBEAT_MS` so a half-dead socket surfaces its close), and
+  `POST /__vp_shell_closed` (204; the shell's pagehide beacon, evidence-only, see grace below).
+  **Same-key enqueue is an update-in-place**: the entry keeps its id, `rev` increments, status resets
+  to `pending`, decision clears, settle state and draft reset (so a new caller's `/__vp_verdict`
+  rebinds instead of replaying the stale verdict), and `iteration` auto-increments when the caller
+  passed none (explicit `-i` wins). The new HTML is built BEFORE any state mutation (with the stable
+  id as the injected planId, or feedback routing breaks) so a failed build leaves the old revision
+  servable. An iterate decision settles the entry to `status: 'iterating'` (not `done`), which counts
+  as pending for the idle TTL: the daemon must hold between the iterate verdict and the re-enqueue.
+  Lifecycle: idle TTL fires when no `pending`/`iterating` plans remain (a new enqueue cancels it).
+  Tab-close detection is two-tier: the LAST events client closing arms `RELOAD_GRACE_MS` (5s) when a
+  close beacon arrived within `BEACON_ASSOC_MS` (unload evidence: reload, navigation, or real close),
+  else the silent tier (`idleMs`, default 15m) because a beaconless drop is likely tab suspension or
+  laptop sleep, and EventSource auto-reconnects on resume; a late beacon reschedules silent -> reload.
+  Grace expiry denies all still-pending plans (with their drafts) and shuts down. The beacon is
+  EVIDENCE for tier selection only, never the close signal itself (a beacon is dropped on some real
+  closes, per the one-shot server's finding above); the socket close remains the detector. One
+  idempotent `shutdown()` ends every held connection so `close()` cannot hang on an SSE (the same
+  regression the one-shot server guards) and awaits `onIdle` so the lock is removed before exit.
+  `lockfile.ts` is discovery + the mutex: `~/.vplan/review-daemon.json`
   (`{ port, pid }`), claimed via `writeFile`'s `wx` flag (atomic create-or-fail collapses racing
-  daemons), `isDaemonAlive` pings. `ensure-daemon.ts` reuses a live daemon or spawns the detached
+  daemons), `isDaemonAlive` pings (and requires the body `ok`, so an unrelated server squatting a
+  recycled port is not mistaken for the daemon). `removeLockIfOwned` guards shutdown cleanup: only
+  the owning pid's lock is deleted, so a signalled old daemon cannot remove a successor's lock.
+  `ensure-daemon.ts` reuses a live daemon or spawns the detached
   `__review-daemon` process (`cli-entry.ts` derives the entry from `process.argv[1]`) and polls.
-  `commands/review-daemon.ts` owns the mutex (start -> `wx` claim; lost race or stale lock handled);
+  `commands/review-daemon.ts` owns the mutex (start -> `wx` claim; lost race or stale lock handled)
+  and registers SIGTERM/SIGINT handlers after the lock is won (close -> lock removal -> exit 0);
   `commands/review.ts` is the `review <files...>` orchestration (stream each verdict as it resolves,
   exit 0 iff all approved, `--json` for one keyed object). `client.ts` is `enqueuePlan`/`awaitVerdict`.
   All of these take injectable seams so the routing/lifecycle is unit-tested in-process with a fake

--- a/packages/cli/src/commands/review-daemon.ts
+++ b/packages/cli/src/commands/review-daemon.ts
@@ -3,11 +3,19 @@
  * spawns. It owns the lock mutex. It starts the HTTP daemon, then atomically claims the lock; if
  * another daemon won the race it closes and exits, and if it finds only a stale lock (present but
  * pointing at a dead daemon) it clears it and retries once. While the daemon runs, its HTTP server
- * keeps the event loop alive; on idle/shell-close shutdown it removes the lock and exits.
+ * keeps the event loop alive; on idle/shell-close shutdown or a SIGTERM/SIGINT it removes its own
+ * lock and exits. Binding necessarily precedes the lock claim (the port is unknowable pre-bind);
+ * the lock's `wx` mutex is what collapses two daemons racing through that window down to one.
  */
 import { mkdir } from 'node:fs/promises'
 import { type DaemonInstance, startDaemon } from '../review/daemon.js'
-import { isDaemonAlive, readLock, removeLock, writeLockExclusive } from '../review/lockfile.js'
+import {
+  isDaemonAlive,
+  readLock,
+  removeLock,
+  removeLockIfOwned,
+  writeLockExclusive,
+} from '../review/lockfile.js'
 import { buildQueueShell } from '../build/queue-shell.js'
 import { configDir as defaultConfigDir } from '../config.js'
 
@@ -16,12 +24,19 @@ export interface RunReviewDaemonOptions {
   idleMs: number
 }
 
-/** Injectable seams so the mutex/stale-lock logic is unit-testable without a real Vite build, a real
- * port bind, or `process.exit`. Production uses the real implementations. */
+/** Injectable seams so the mutex/stale-lock/signal logic is unit-testable without a real Vite
+ * build, a real port bind, real signal delivery, or `process.exit`. Production uses the real
+ * implementations. */
 export interface ReviewDaemonDeps {
   configDir?: string
-  startDaemon?: (port: number, idleMs: number, onIdle: () => void) => Promise<DaemonInstance>
+  startDaemon?: (
+    port: number,
+    idleMs: number,
+    onIdle: () => void | Promise<void>,
+  ) => Promise<DaemonInstance>
   isAlive?: (port: number) => Promise<boolean>
+  onSignal?: (signal: 'SIGTERM' | 'SIGINT', handler: () => void) => void
+  exit?: (code: number) => void
 }
 
 /** Start the real HTTP daemon on `port`, incrementing past a port taken by a non-daemon (EADDRINUSE)
@@ -29,7 +44,7 @@ export interface ReviewDaemonDeps {
 async function startRealDaemon(
   port: number,
   idleMs: number,
-  onIdle: () => void,
+  onIdle: () => void | Promise<void>,
 ): Promise<DaemonInstance> {
   let lastError: unknown
   for (let attempt = 0; attempt < 5; attempt++) {
@@ -61,18 +76,29 @@ export async function runReviewDaemon(
   const dir = deps.configDir ?? process.env.VPLAN_REVIEW_DIR ?? defaultConfigDir
   const start = deps.startDaemon ?? startRealDaemon
   const isAlive = deps.isAlive ?? isDaemonAlive
+  const onSignal = deps.onSignal ?? ((signal, handler) => process.on(signal, handler))
+  const exit = deps.exit ?? ((code: number) => process.exit(code))
   // The lock dir must exist before the `wx` write; the daemon owns creating `~/.vplan`.
   await mkdir(dir, { recursive: true })
 
-  // The daemon removes its lock on shutdown so the next invocation starts fresh.
-  const onIdle = () => {
-    void removeLock(dir)
-  }
+  // The daemon removes its lock on shutdown so the next invocation starts fresh. Owned-only: a
+  // SIGTERM'd old daemon must not delete a lock a successor already claimed. `shutdown()` awaits
+  // this, so the lock is provably gone before close() resolves.
+  const onIdle = () => removeLockIfOwned(dir, process.pid)
 
   const instance = await start(opts.port, opts.idleMs, onIdle)
 
   // Claim the lock. If a live daemon already owns it, this process lost the race: close and bow out.
-  if (await acquireLock(dir, instance.port, isAlive)) return
+  if (await acquireLock(dir, instance.port, isAlive)) {
+    // Only the lock owner listens for signals: a graceful stop closes the instance (which removes
+    // the lock via the awaited onIdle) and then exits cleanly.
+    const handler = (): void => {
+      void instance.close().then(() => exit(0))
+    }
+    onSignal('SIGTERM', handler)
+    onSignal('SIGINT', handler)
+    return
+  }
   await instance.close()
 }
 

--- a/packages/cli/src/review/daemon.ts
+++ b/packages/cli/src/review/daemon.ts
@@ -9,6 +9,15 @@
  *
  * The HTTP/SSE contract here is FROZEN: the runtime shell page depends on the exact endpoints,
  * field names, and SSE frame shape. See the task's contract section before changing anything.
+ * Additive extensions to that contract (all backward compatible):
+ * - Queue entries carry `status: 'iterating'` (reviewer asked for iteration; the daemon holds the
+ *   row awaiting the revision), `rev` (serving-generation counter), and `createdAt`/`updatedAt`.
+ * - An enqueue whose `key` matches an existing plan UPDATES that entry in place and returns the
+ *   SAME id (`rev` bumps, status resets to pending); ids are stable across revisions.
+ * - `/plan/<id>` responses carry `cache-control: no-store` (ids are reused across revisions).
+ * - `POST /__vp_shell_closed` (204): the shell's pagehide beacon, evidence of a real unload that
+ *   selects the short close-grace tier; a silent socket drop gets the long (idleMs) tier instead.
+ * - `/__vp_events` writes `: hb` SSE comment frames (invisible to EventSource) as a heartbeat.
  *
  * `startDaemon` is deliberately a plain `http.createServer` (not Vite) and is directly testable
  * in-process, like `startReviewServer`: no child process is required to exercise the routing.
@@ -32,17 +41,35 @@ export interface StartDaemonOptions {
   /** Builds the shell page served at `/`; defaults to the real `buildQueueShell`. Injectable so
    * tests avoid the slow Vite build. The result is cached after the first call. */
   getShellHtml?: () => Promise<string>
+  /** SSE heartbeat interval; defaults to `HEARTBEAT_MS`. Injectable for tests, like `idleMs`. */
+  heartbeatMs?: number
+  /** Grace after the last shell closes WITH unload evidence (a close beacon); defaults to
+   * `RELOAD_GRACE_MS`. Injectable for tests, like `idleMs`. */
+  reloadGraceMs?: number
   /** Called once when the daemon shuts down (idle TTL or shell close), so the owner can clean up
-   * its lock and exit the process. */
-  onIdle?: () => void
+   * its lock and exit the process. `shutdown()` awaits it, so lock removal completes before the
+   * daemon reports closed. */
+  onIdle?: () => void | Promise<void>
 }
 
 /** The default Deny resolved for a pending plan that is abandoned (tab/shell closed) with no draft. */
 const DEFAULT_DENY: Feedback = { decision: 'deny', comments: [], answers: [] }
 
-/** Grace window after the last events (shell) connection closes before denying pending plans, so a
- * page reload that briefly drops then reconnects survives. */
-const SHELL_GRACE_MS = 1500
+/** SSE heartbeat interval: comment frames (`: hb`, invisible to EventSource) written to every held
+ * events client so a half-dead socket (suspended tab, laptop sleep) surfaces its `close` within
+ * about one interval instead of lingering as a zombie, and so intermediaries do not idle-close the
+ * stream. 25s stays comfortably under common 30-60s proxy idle timeouts. */
+const HEARTBEAT_MS = 25_000
+
+/** Grace after the last shell closes WITH unload evidence (a close beacon): a real reload has to
+ * re-boot the whole shell JS, and 1.5s proved too tight for a heavy page; 5s still tears down
+ * promptly on a genuine close. */
+const RELOAD_GRACE_MS = 5_000
+
+/** How close (ms) a close beacon must precede the socket drop to count as evidence of a real
+ * unload. Beacons fire at `pagehide`, essentially simultaneous with the drop; 2s absorbs delivery
+ * jitter without letting a stale beacon tag an unrelated later drop. */
+const BEACON_ASSOC_MS = 2_000
 
 /** Max request body size, mirroring compile.ts's cap so a malformed client cannot stream unbounded. */
 const MAX_BODY_BYTES = 1_000_000
@@ -108,6 +135,8 @@ interface EnqueueBody {
 
 export async function startDaemon(opts: StartDaemonOptions): Promise<DaemonInstance> {
   const getShellHtml = opts.getShellHtml ?? buildQueueShell
+  const heartbeatMs = opts.heartbeatMs ?? HEARTBEAT_MS
+  const reloadGraceMs = opts.reloadGraceMs ?? RELOAD_GRACE_MS
   const plans = new Map<string, QueuedPlan>()
   /** Held SSE responses for the shell(s); each gets every queue change. */
   const eventClients = new Set<ServerResponse>()
@@ -115,7 +144,30 @@ export async function startDaemon(opts: StartDaemonOptions): Promise<DaemonInsta
   let shellHtml: string | null = null
   let idleTimer: ReturnType<typeof setTimeout> | undefined
   let graceTimer: ReturnType<typeof setTimeout> | undefined
+  /** Which grace tier is currently armed, so a late beacon can tell a long (silent) timer apart
+   * from one already running at the short (reload) tier. */
+  let graceTier: 'reload' | 'silent' | undefined
+  let heartbeatTimer: ReturnType<typeof setInterval> | undefined
+  /** When the last `POST /__vp_shell_closed` beacon landed; 0 when none is outstanding. */
+  let lastCloseBeaconAt = 0
   let shuttingDown = false
+
+  /** Runs while any events client is held: comment frames keep half-dead sockets surfacing their
+   * close promptly and keep intermediaries from idle-closing. Comment frames are invisible to
+   * EventSource, so this is contract-additive. */
+  const startHeartbeat = (): void => {
+    if (heartbeatTimer) return
+    heartbeatTimer = setInterval(() => {
+      for (const res of eventClients) res.write(': hb\n\n')
+    }, heartbeatMs)
+  }
+
+  const stopHeartbeat = (): void => {
+    if (heartbeatTimer) {
+      clearInterval(heartbeatTimer)
+      heartbeatTimer = undefined
+    }
+  }
 
   const queueSnapshot = (): QueueEntry[] => [...plans.values()].map(p => p.entry)
 
@@ -124,7 +176,10 @@ export async function startDaemon(opts: StartDaemonOptions): Promise<DaemonInsta
     for (const res of eventClients) res.write(frame)
   }
 
-  const hasPending = (): boolean => [...plans.values()].some(p => p.entry.status === 'pending')
+  // `iterating` counts as pending: it is an explicit promise of an imminent re-enqueue, so the
+  // idle TTL must not fire between the iterate verdict and the revision's arrival.
+  const hasPending = (): boolean =>
+    [...plans.values()].some(p => p.entry.status === 'pending' || p.entry.status === 'iterating')
 
   const cancelIdle = (): void => {
     if (idleTimer) {
@@ -141,13 +196,26 @@ export async function startDaemon(opts: StartDaemonOptions): Promise<DaemonInsta
     idleTimer = setTimeout(() => void shutdown(), opts.idleMs)
   }
 
+  /** (Re)arm the shell-gone grace timer at the given tier; expiry denies everything pending and
+   * shuts down. Shared by the SSE close handler and the close-beacon route. */
+  const armGrace = (ms: number, tier: 'reload' | 'silent'): void => {
+    if (graceTimer) clearTimeout(graceTimer)
+    graceTier = tier
+    graceTimer = setTimeout(() => {
+      if (eventClients.size === 0) void denyAllAndShutdown()
+    }, ms)
+  }
+
   /** Settle a plan exactly once: resolve its waiters, mark it done, broadcast, and arm the idle TTL
    * if nothing is pending. */
   const settle = (plan: QueuedPlan, feedback: Feedback): void => {
     if (plan.settled) return
     plan.settled = true
     plan.settledFeedback = feedback
-    plan.entry.status = 'done'
+    // An iterate verdict is not terminal: the entry stays listed as `iterating`, an explicit
+    // promise that the agent will re-enqueue a revision under the same key.
+    plan.entry.status = feedback.decision === 'iterate' ? 'iterating' : 'done'
+    plan.entry.updatedAt = Date.now()
     // Record the verdict so the sidebar shows the matching icon (approve/deny/iterate), not a
     // generic "done" mark.
     plan.entry.decision = feedback.decision
@@ -163,12 +231,15 @@ export async function startDaemon(opts: StartDaemonOptions): Promise<DaemonInsta
     if (shuttingDown) return
     shuttingDown = true
     cancelIdle()
+    stopHeartbeat()
     if (graceTimer) clearTimeout(graceTimer)
     // End every held connection (SSE shells, long-held verdicts) or close() hangs on them.
     for (const res of eventClients) res.end()
     eventClients.clear()
     await new Promise<void>(resolve => server.close(() => resolve()))
-    opts.onIdle?.()
+    // Awaited so owner cleanup (lock removal) provably completes before close() resolves; a
+    // signal handler can then exit the process without racing the cleanup.
+    await opts.onIdle?.()
   }
 
   /** Deny all still-pending plans (used when the shell goes away past the grace), then shut down. */
@@ -206,7 +277,12 @@ export async function startDaemon(opts: StartDaemonOptions): Promise<DaemonInsta
         res.end('unknown plan')
         return
       }
-      res.writeHead(200, { 'content-type': 'text/html; charset=utf-8' })
+      // `no-store`: the id is reused across revisions (iterate-in-place), so the browser must
+      // re-fetch every load instead of serving a cached prior revision.
+      res.writeHead(200, {
+        'content-type': 'text/html; charset=utf-8',
+        'cache-control': 'no-store',
+      })
       // A decided plan re-served carries its verdict so the page opens locked into the submitted bar.
       res.end(
         plan.settled && plan.settledFeedback
@@ -236,6 +312,19 @@ export async function startDaemon(opts: StartDaemonOptions): Promise<DaemonInsta
       return
     }
 
+    if (pathname === '/__vp_shell_closed') {
+      // The shell's `pagehide` beacon: positive evidence of a real unload (reload, navigation, or
+      // close), as opposed to a silent socket drop (suspension/sleep/crash). A no-op while
+      // connected; its timestamp picks the grace tier when the socket drop follows.
+      lastCloseBeaconAt = Date.now()
+      // A late beacon after a silent drop means the drop WAS a real unload: tighten the long
+      // grace to the reload tier.
+      if (graceTimer && graceTier === 'silent') armGrace(reloadGraceMs, 'reload')
+      res.writeHead(204)
+      res.end()
+      return
+    }
+
     if (pathname === '/__vp_events') {
       handleEvents(res)
       return
@@ -260,38 +349,76 @@ export async function startDaemon(opts: StartDaemonOptions): Promise<DaemonInsta
     // Cancel the idle timer up front: the build below can take longer than a short idleMs, and the
     // daemon must not shut down mid-enqueue. The enqueue itself proves the daemon is wanted.
     cancelIdle()
-    // A requeue (same key) replaces its predecessor, so a plan and its iterations appear once. Drop
-    // the prior version, unblocking any caller still waiting on it (deny) so it cannot hang.
+    // A requeue (same key) UPDATES its predecessor in place, so a plan and its iterations keep one
+    // stable row (and id) across revisions. The first match is the update target; any extra
+    // same-key matches (defensive: should not happen) are dropped as before, unblocking their
+    // waiters with their drafts so no caller can hang.
+    let existing: QueuedPlan | undefined
     if (body.key !== undefined) {
       for (const [oldId, oldPlan] of plans) {
         if (oldPlan.key !== body.key) continue
+        if (!existing) {
+          existing = oldPlan
+          continue
+        }
         for (const resolve of oldPlan.waiters) resolve(oldPlan.draft)
         oldPlan.waiters = []
         plans.delete(oldId)
       }
     }
-    counter += 1
-    const id = `p${counter}`
+    // The id must be decided before the build: the injected plan id has to be the stable existing
+    // id or feedback from the revised page would not route back to this entry.
+    const id = existing ? existing.entry.id : `p${++counter}`
+    // Auto-increment the review round on a same-key update so the agent needs no `-i` bookkeeping;
+    // an explicit iteration still wins, and a fresh enqueue keeps whatever it sent (or nothing).
+    // Computed before the build so the injected `__VP_REVIEW_ITERATION__` matches the entry.
+    const iteration = existing
+      ? (body.iteration ?? (existing.entry.iteration ?? 1) + 1)
+      : body.iteration
+    // Build BEFORE mutating any state, so a throwing build leaves the old revision servable.
     const html = await buildHtml(body.source, {
       theme: body.theme,
       baseline: body.baseline,
-      review: { planId: id, iteration: body.iteration },
+      review: { planId: id, iteration },
     })
-    const entry: QueueEntry = {
-      id,
-      title: titleFromSource(body.source),
-      dir: body.dir,
-      status: 'pending',
-      iteration: body.iteration,
+    const now = Date.now()
+    if (existing) {
+      // Supersede: a caller still waiting on the old revision gets its draft, as before.
+      for (const resolve of existing.waiters) resolve(existing.draft)
+      existing.waiters = []
+      existing.entry.title = titleFromSource(body.source)
+      existing.entry.dir = body.dir
+      existing.entry.iteration = iteration
+      existing.entry.status = 'pending'
+      delete existing.entry.decision
+      existing.entry.rev += 1
+      existing.entry.updatedAt = now
+      existing.html = html
+      // Un-settle: the revision awaits a fresh verdict; a new `/__vp_verdict` must long-poll, not
+      // replay the stale iterate feedback, and the deny-on-close draft starts clean.
+      existing.settled = false
+      existing.settledFeedback = undefined
+      existing.draft = { ...DEFAULT_DENY }
+    } else {
+      const entry: QueueEntry = {
+        id,
+        title: titleFromSource(body.source),
+        dir: body.dir,
+        status: 'pending',
+        iteration,
+        rev: 1,
+        createdAt: now,
+        updatedAt: now,
+      }
+      plans.set(id, {
+        entry,
+        key: body.key,
+        html,
+        waiters: [],
+        draft: { ...DEFAULT_DENY },
+        settled: false,
+      })
     }
-    plans.set(id, {
-      entry,
-      key: body.key,
-      html,
-      waiters: [],
-      draft: { ...DEFAULT_DENY },
-      settled: false,
-    })
     broadcast()
     res.writeHead(200, { 'content-type': 'application/json; charset=utf-8' })
     res.end(JSON.stringify({ id, shellConnected: eventClients.size > 0 }))
@@ -363,22 +490,28 @@ export async function startDaemon(opts: StartDaemonOptions): Promise<DaemonInsta
       'cache-control': 'no-cache',
       connection: 'keep-alive',
     })
-    // A new shell cancels any in-flight grace shutdown: the shell is back.
+    // A new shell cancels any in-flight grace shutdown: the shell is back. Any outstanding close
+    // beacon belonged to the connection that just ended; it must not tag a future drop.
     if (graceTimer) {
       clearTimeout(graceTimer)
       graceTimer = undefined
+      graceTier = undefined
     }
+    lastCloseBeaconAt = 0
     eventClients.add(res)
+    startHeartbeat()
     res.write(`event: queue\ndata: ${JSON.stringify(queueSnapshot())}\n\n`)
     res.on('close', () => {
       eventClients.delete(res)
       // When the LAST shell closes, wait a grace window; if still none reconnect, deny all pending
-      // plans and shut down. The events stream is the shell's liveness signal.
+      // plans and shut down. The events stream is the shell's liveness signal. The tier depends on
+      // the evidence: a close beacon just before the drop means a real unload (short grace); a
+      // silent drop is suspension/sleep/crash or a lost beacon, so hold for the idle horizon
+      // (EventSource auto-reconnects on resume, which cancels the grace).
       if (eventClients.size === 0 && !shuttingDown) {
-        if (graceTimer) clearTimeout(graceTimer)
-        graceTimer = setTimeout(() => {
-          if (eventClients.size === 0) void denyAllAndShutdown()
-        }, SHELL_GRACE_MS)
+        stopHeartbeat()
+        if (Date.now() - lastCloseBeaconAt <= BEACON_ASSOC_MS) armGrace(reloadGraceMs, 'reload')
+        else armGrace(opts.idleMs, 'silent')
       }
     })
   }

--- a/packages/cli/src/review/format.ts
+++ b/packages/cli/src/review/format.ts
@@ -25,7 +25,10 @@ export function formatFeedback(feedback: Feedback): string {
   const lines: string[] = [`DECISION: ${feedback.decision}`]
 
   for (const comment of feedback.comments) {
-    lines.push('', `Comment on "${comment.section}":`, indent(comment.body))
+    // The severity tag rides in the header so the agent can tell blocking must-fixes from
+    // take-or-leave suggestions; an untagged comment prints exactly as before (old clients).
+    const tag = comment.severity ? ` [${comment.severity}]` : ''
+    lines.push('', `Comment on "${comment.section}"${tag}:`, indent(comment.body))
   }
 
   for (const answer of feedback.answers) {

--- a/packages/cli/src/review/lockfile.ts
+++ b/packages/cli/src/review/lockfile.ts
@@ -62,16 +62,29 @@ export async function removeLock(dir: string = configDir): Promise<void> {
 }
 
 /**
+ * Remove the lock only when it is missing or owned by `pid`. A shutting-down daemon uses this
+ * instead of plain `removeLock` so a SIGTERM'd old daemon cannot delete the lock a successor
+ * daemon has already claimed (which would orphan the successor from discovery).
+ */
+export async function removeLockIfOwned(dir: string, pid: number): Promise<void> {
+  const existing = await readLock(dir)
+  if (existing && existing.pid !== pid) return
+  await removeLock(dir)
+}
+
+/**
  * Probe whether a daemon is actually listening on `port` by hitting its liveness endpoint, true iff
- * it answers 200. A short timeout via AbortController keeps discovery snappy and treats a dead or
- * stale port (connection refused, no response) as not-alive rather than hanging.
+ * it answers 200 with the exact body 'ok' (an unrelated server squatting the port may 200 anything;
+ * only the daemon speaks the ping contract). A short timeout via AbortController keeps discovery
+ * snappy and treats a dead or stale port (connection refused, no response) as not-alive rather than
+ * hanging.
  */
 export async function isDaemonAlive(port: number, timeoutMs = 500): Promise<boolean> {
   const controller = new AbortController()
   const timer = setTimeout(() => controller.abort(), timeoutMs)
   try {
     const res = await fetch(`http://localhost:${port}/__vp_ping`, { signal: controller.signal })
-    return res.status === 200
+    return res.status === 200 && (await res.text()) === 'ok'
   } catch {
     return false
   } finally {

--- a/packages/cli/templates/example.mdx
+++ b/packages/cli/templates/example.mdx
@@ -52,6 +52,8 @@ flowchart LR
 <Questions>
 - What is the limit per token: a fixed number, or per-plan tier?
 - Should the limiter fail open or fail closed if Redis is unreachable?
+  - Fail open, availability first
+  - Fail closed, safety first
 - Do internal service-to-service calls get exempted from limiting?
 </Questions>
 

--- a/packages/cli/tests/check.test.ts
+++ b/packages/cli/tests/check.test.ts
@@ -72,6 +72,36 @@ describe('checkPlan', () => {
     expect(issues[0]?.message).toMatch(/is not a number/)
   })
 
+  it('accepts a Questions block with nested multiple-choice options (golden)', async () => {
+    const path = await writePlan(
+      'option-questions.mdx',
+      '# T\n\n<Questions>\n- Rotate refresh tokens?\n  - Yes, every use\n  - Only after 24h\n- Is a 15-minute TTL acceptable?\n</Questions>\n',
+    )
+    expect(await checkPlan(path)).toEqual([])
+  })
+
+  it('flags an empty Questions option with its line (error)', async () => {
+    const path = await writePlan(
+      'empty-option.mdx',
+      '# T\n\n<Questions>\n- Rotate refresh tokens?\n  - Yes\n  -\n</Questions>\n',
+    )
+    const issues = await checkPlan(path)
+    expect(issues).toHaveLength(1)
+    expect(issues[0]?.message).toMatch(/option .* must not be empty/)
+    expect(issues[0]?.line).toBe(6)
+  })
+
+  it('flags a Questions option nesting a deeper list (error)', async () => {
+    const path = await writePlan(
+      'deep-option.mdx',
+      '# T\n\n<Questions>\n- Rotate refresh tokens?\n  - Yes\n    - too deep\n</Questions>\n',
+    )
+    const issues = await checkPlan(path)
+    expect(issues).toHaveLength(1)
+    expect(issues[0]?.message).toMatch(/one level deep/)
+    expect(issues[0]?.line).toBe(5)
+  })
+
   it('accepts valid markdown-children blocks (golden)', async () => {
     const path = await writePlan(
       'good-blocks.mdx',

--- a/packages/cli/tests/review-daemon-command.test.ts
+++ b/packages/cli/tests/review-daemon-command.test.ts
@@ -17,13 +17,18 @@ afterEach(async () => {
   await rm(dir, { recursive: true, force: true })
 })
 
-/** A fake daemon that records close() and lets the test control its bound port. */
-function fakeInstance(port: number): DaemonInstance & { closed: boolean } {
+/** A fake daemon that records close() and lets the test control its bound port. Like the real
+ * daemon, close() runs the onIdle cleanup the command wired in (awaited before resolving). */
+function fakeInstance(
+  port: number,
+  onIdle?: () => void | Promise<void>,
+): DaemonInstance & { closed: boolean } {
   const inst = {
     port,
     closed: false,
     close: async () => {
       inst.closed = true
+      await onIdle?.()
     },
   }
   return inst
@@ -49,6 +54,57 @@ describe('runReviewDaemon', () => {
       { configDir: dir, startDaemon: async () => inst, isAlive: async () => true },
     )
     expect(inst.closed).toBe(true)
+    expect(await readLock(dir)).toEqual({ port: 8000, pid: 111 })
+  })
+
+  it('closes the daemon, removes the lock, and exits 0 on SIGTERM (golden)', async () => {
+    const signals = new Map<string, () => void>()
+    let exitCode: number | undefined
+    let inst: (DaemonInstance & { closed: boolean }) | undefined
+    await runReviewDaemon(
+      { port: 9151, idleMs: 1000 },
+      {
+        configDir: dir,
+        startDaemon: async (port, _idleMs, onIdle) => {
+          inst = fakeInstance(port, onIdle)
+          return inst
+        },
+        isAlive: async () => false,
+        onSignal: (signal, handler) => signals.set(signal, handler),
+        exit: code => {
+          exitCode = code
+        },
+      },
+    )
+    // The lock is claimed and handlers are registered only after the mutex is won.
+    expect(await readLock(dir)).toEqual({ port: 9151, pid: process.pid })
+    expect([...signals.keys()].sort()).toEqual(['SIGINT', 'SIGTERM'])
+    signals.get('SIGTERM')!()
+    // The handler closes asynchronously; wait for the exit to land.
+    for (let i = 0; i < 50 && exitCode === undefined; i++) {
+      await new Promise(r => setTimeout(r, 10))
+    }
+    expect(inst!.closed).toBe(true)
+    expect(await readLock(dir)).toBeNull()
+    expect(exitCode).toBe(0)
+  })
+
+  it('registers no signal handlers when it loses the mutex race (edge)', async () => {
+    await writeLockExclusive({ port: 8000, pid: 111 }, dir)
+    const signals = new Map<string, () => void>()
+    await runReviewDaemon(
+      { port: 9151, idleMs: 1000 },
+      {
+        configDir: dir,
+        startDaemon: async (port, _idleMs, onIdle) => fakeInstance(port, onIdle),
+        isAlive: async () => true,
+        onSignal: (signal, handler) => signals.set(signal, handler),
+        exit: () => {},
+      },
+    )
+    // The losing daemon exits on its own; a signal handler would keep dead wiring around.
+    expect(signals.size).toBe(0)
+    // And its close must NOT have removed the winner's lock.
     expect(await readLock(dir)).toEqual({ port: 8000, pid: 111 })
   })
 

--- a/packages/cli/tests/review-daemon.test.ts
+++ b/packages/cli/tests/review-daemon.test.ts
@@ -52,6 +52,48 @@ async function firstQueueEvent(d: DaemonInstance, signal: AbortSignal): Promise<
   }
 }
 
+/** Read the raw /__vp_events stream until `predicate` matches the buffer or `timeoutMs` elapses;
+ * returns the buffered text either way. */
+async function readEventsUntil(
+  d: DaemonInstance,
+  signal: AbortSignal,
+  predicate: (buffer: string) => boolean,
+  timeoutMs: number,
+): Promise<string> {
+  const res = await fetch(url(d, '/__vp_events'), {
+    signal,
+    headers: { accept: 'text/event-stream' },
+  })
+  const reader = res.body!.getReader()
+  const decoder = new TextDecoder()
+  let buffer = ''
+  const deadline = Date.now() + timeoutMs
+  while (Date.now() < deadline && !predicate(buffer)) {
+    const next = await Promise.race([
+      reader.read(),
+      new Promise<'timeout'>(r => setTimeout(() => r('timeout'), deadline - Date.now())),
+    ])
+    if (next === 'timeout' || next.done) break
+    buffer += decoder.decode(next.value, { stream: true })
+  }
+  return buffer
+}
+
+describe('daemon SSE heartbeat', () => {
+  let d: DaemonInstance
+  afterEach(async () => {
+    await d?.close()
+  })
+
+  it('writes ": hb" comment frames to held events clients between queue frames (golden)', async () => {
+    d = await fakeDaemon({ idleMs: 60_000, heartbeatMs: 50 })
+    const ctrl = new AbortController()
+    const buffer = await readEventsUntil(d, ctrl.signal, b => b.includes(': hb\n\n'), 2_000)
+    ctrl.abort()
+    expect(buffer).toContain(': hb\n\n')
+  }, 60_000)
+})
+
 describe('daemon liveness and shell', () => {
   let d: DaemonInstance
   afterEach(async () => {
@@ -315,34 +357,179 @@ describe('daemon idle TTL', () => {
   }, 60_000)
 })
 
-describe('daemon shell-close deny-all', () => {
-  it('denies still-pending plans when the last events client closes past the grace (golden)', async () => {
-    const d = await fakeDaemon({ idleMs: 60_000 })
+describe('daemon two-tier close grace', () => {
+  it('denies pending plans about reloadGraceMs after a close beacon plus last-close (golden)', async () => {
+    const d = await fakeDaemon({ idleMs: 60_000, reloadGraceMs: 200 })
     const { id } = await enqueue(d)
-    // A caller awaits the verdict; it should resolve to the deny when the shell closes.
-    const verdictP = fetch(url(d, `/__vp_verdict?id=${id}`)).then(r => r.json())
-    // Open and then close the events (shell) connection.
-    const controller = new AbortController()
-    void fetch(url(d, '/__vp_events'), { signal: controller.signal }).catch(() => {})
+    // The reviewer left a partial draft; the beacon-evidenced close must deliver it.
+    await fetch(url(d, '/__vp_draft'), {
+      method: 'POST',
+      body: JSON.stringify({
+        decision: 'deny',
+        planId: id,
+        comments: [{ section: 'X', body: 'partial' }],
+      }),
+    })
+    const verdictP = fetch(url(d, `/__vp_verdict?id=${id}`)).then(
+      r => r.json() as Promise<{ decision: string; comments: Array<{ body: string }> }>,
+    )
+    const ctrl = new AbortController()
+    void fetch(url(d, '/__vp_events'), { signal: ctrl.signal }).catch(() => {})
     await new Promise(r => setTimeout(r, 100))
-    controller.abort()
-    // Past the 1500ms grace, the pending plan is denied with its default draft.
-    await expect(verdictP).resolves.toMatchObject({ decision: 'deny' })
+    // The page unloads: beacon first, then the socket drops.
+    const beacon = await fetch(url(d, '/__vp_shell_closed'), { method: 'POST' })
+    expect(beacon.status).toBe(204)
+    ctrl.abort()
+    const start = Date.now()
+    const resolved = await verdictP
+    expect(resolved.decision).toBe('deny')
+    expect(resolved.comments).toMatchObject([{ body: 'partial' }])
+    // Fast tier: about reloadGraceMs, nowhere near idleMs.
+    expect(Date.now() - start).toBeLessThan(2_000)
   }, 60_000)
 
-  it('survives a brief events reconnect within the grace without denying (edge)', async () => {
-    const d = await fakeDaemon({ idleMs: 60_000 })
+  it('holds a beaconless (silent) last-close for idleMs, surviving several reload windows (golden)', async () => {
+    let denied = false
+    const d = await fakeDaemon({ idleMs: 400, reloadGraceMs: 100 })
+    const { id } = await enqueue(d)
+    const verdictP = fetch(url(d, `/__vp_verdict?id=${id}`))
+      .then(r => r.json() as Promise<{ decision: string }>)
+      .then(v => {
+        denied = true
+        return v
+      })
+    const ctrl = new AbortController()
+    void fetch(url(d, '/__vp_events'), { signal: ctrl.signal }).catch(() => {})
+    await new Promise(r => setTimeout(r, 100))
+    // Socket drops with no beacon: suspension/sleep/crash. Several reload windows pass undenyed.
+    ctrl.abort()
+    await new Promise(r => setTimeout(r, 300))
+    expect(denied).toBe(false)
+    // The silent tier expires at idleMs and denies.
+    await expect(verdictP).resolves.toMatchObject({ decision: 'deny' })
+  }, 60_000)
+})
+
+describe('daemon grace edge cases', () => {
+  it('reschedules a silent grace to the reload tier when a late beacon arrives (edge)', async () => {
+    const d = await fakeDaemon({ idleMs: 60_000, reloadGraceMs: 200 })
+    const { id } = await enqueue(d)
+    const verdictP = fetch(url(d, `/__vp_verdict?id=${id}`)).then(
+      r => r.json() as Promise<{ decision: string }>,
+    )
+    const ctrl = new AbortController()
+    void fetch(url(d, '/__vp_events'), { signal: ctrl.signal }).catch(() => {})
+    await new Promise(r => setTimeout(r, 100))
+    // Silent drop first (no beacon): the long grace arms.
+    ctrl.abort()
+    await new Promise(r => setTimeout(r, 300))
+    // The delayed unload beacon finally lands: the drop WAS a real unload; tighten to reload grace.
+    await fetch(url(d, '/__vp_shell_closed'), { method: 'POST' })
+    const start = Date.now()
+    await expect(verdictP).resolves.toMatchObject({ decision: 'deny' })
+    expect(Date.now() - start).toBeLessThan(2_000)
+  }, 60_000)
+
+  it('cancels a silent grace when a client reconnects; the plan survives (edge)', async () => {
+    const d = await fakeDaemon({ idleMs: 500, reloadGraceMs: 100 })
     const { id } = await enqueue(d)
     const c1 = new AbortController()
     void fetch(url(d, '/__vp_events'), { signal: c1.signal }).catch(() => {})
     await new Promise(r => setTimeout(r, 100))
+    // Silent drop (suspension), then the tab resumes and EventSource reconnects mid-grace.
     c1.abort()
-    // Reconnect well within the 1500ms grace window.
     await new Promise(r => setTimeout(r, 200))
     const c2 = new AbortController()
     void fetch(url(d, '/__vp_events'), { signal: c2.signal }).catch(() => {})
+    // Wait past when the silent grace would have fired had it not been cancelled.
+    await new Promise(r => setTimeout(r, 600))
+    const res = await fetch(url(d, `/plan/${id}`))
+    expect(res.status).toBe(200)
+    c2.abort()
+    await d.close()
+  }, 60_000)
+
+  it('denies nothing when one of two shells closes, beacon or not (edge)', async () => {
+    const d = await fakeDaemon({ idleMs: 60_000, reloadGraceMs: 100 })
+    const { id } = await enqueue(d)
+    const c1 = new AbortController()
+    const c2 = new AbortController()
+    void fetch(url(d, '/__vp_events'), { signal: c1.signal }).catch(() => {})
+    void fetch(url(d, '/__vp_events'), { signal: c2.signal }).catch(() => {})
+    await new Promise(r => setTimeout(r, 100))
+    // One duplicate tab closes (with its unload beacon); a shell remains, so no grace arms.
+    await fetch(url(d, '/__vp_shell_closed'), { method: 'POST' })
+    c1.abort()
+    await new Promise(r => setTimeout(r, 400))
+    const res = await fetch(url(d, `/plan/${id}`))
+    expect(res.status).toBe(200)
+    c2.abort()
+    await d.close()
+  }, 60_000)
+
+  it('answers the close beacon 204 and stays fully up while a shell is connected (edge)', async () => {
+    const d = await fakeDaemon({ idleMs: 60_000, reloadGraceMs: 100 })
+    const { id } = await enqueue(d)
+    const ctrl = new AbortController()
+    void fetch(url(d, '/__vp_events'), { signal: ctrl.signal }).catch(() => {})
+    await new Promise(r => setTimeout(r, 100))
+    // A beacon with no socket drop (e.g. a cancelled navigation) must be a harmless no-op.
+    const res = await fetch(url(d, '/__vp_shell_closed'), { method: 'POST' })
+    expect(res.status).toBe(204)
+    await new Promise(r => setTimeout(r, 400))
+    expect((await fetch(url(d, `/plan/${id}`))).status).toBe(200)
+    expect((await fetch(url(d, '/__vp_ping'))).status).toBe(200)
+    ctrl.abort()
+    await d.close()
+  }, 60_000)
+})
+
+describe('daemon shutdown onIdle ordering', () => {
+  it('awaits an async onIdle before close() resolves (golden)', async () => {
+    let cleaned = false
+    const d = await fakeDaemon({
+      idleMs: 60_000,
+      onIdle: async () => {
+        await new Promise(r => setTimeout(r, 100))
+        cleaned = true
+      },
+    })
+    await d.close()
+    // Lock removal and other cleanup must have completed by the time close() resolves.
+    expect(cleaned).toBe(true)
+  }, 60_000)
+})
+
+describe('daemon shell-close deny-all', () => {
+  it('denies still-pending plans when the last events client closes past the grace (golden)', async () => {
+    const d = await fakeDaemon({ idleMs: 60_000, reloadGraceMs: 200 })
+    const { id } = await enqueue(d)
+    // A caller awaits the verdict; it should resolve to the deny when the shell closes.
+    const verdictP = fetch(url(d, `/__vp_verdict?id=${id}`)).then(r => r.json())
+    // Open and then close the events (shell) connection, with the unload beacon a real close sends.
+    const controller = new AbortController()
+    void fetch(url(d, '/__vp_events'), { signal: controller.signal }).catch(() => {})
+    await new Promise(r => setTimeout(r, 100))
+    await fetch(url(d, '/__vp_shell_closed'), { method: 'POST' })
+    controller.abort()
+    // Past the reload grace, the pending plan is denied with its default draft.
+    await expect(verdictP).resolves.toMatchObject({ decision: 'deny' })
+  }, 60_000)
+
+  it('survives a brief events reconnect within the grace without denying (edge)', async () => {
+    const d = await fakeDaemon({ idleMs: 60_000, reloadGraceMs: 300 })
+    const { id } = await enqueue(d)
+    const c1 = new AbortController()
+    void fetch(url(d, '/__vp_events'), { signal: c1.signal }).catch(() => {})
+    await new Promise(r => setTimeout(r, 100))
+    // A reload: unload beacon, socket drop, then the fresh page reconnects within the grace.
+    await fetch(url(d, '/__vp_shell_closed'), { method: 'POST' })
+    c1.abort()
+    await new Promise(r => setTimeout(r, 100))
+    const c2 = new AbortController()
+    void fetch(url(d, '/__vp_events'), { signal: c2.signal }).catch(() => {})
     // Wait past when the grace would have fired had it not been cancelled.
-    await new Promise(r => setTimeout(r, 1600))
+    await new Promise(r => setTimeout(r, 500))
     // The plan must still be live (not denied): its html still serves.
     const res = await fetch(url(d, `/plan/${id}`))
     expect(res.status).toBe(200)
@@ -384,19 +571,31 @@ describe('daemon queue entries: version, decision, requeue dedupe', () => {
     expect(queue[0].decision).toBe('deny')
   }, 60_000)
 
-  it('replaces the prior version when requeued with the same key (golden)', async () => {
+  it('updates the entry in place when requeued with the same key, keeping the id (golden)', async () => {
     d = await fakeDaemon()
     const first = await enqueue(d, { key: '/p/a.mdx', iteration: 1 })
-    const second = await enqueue(d, { key: '/p/a.mdx', iteration: 2 })
+    const second = await enqueue(d, {
+      key: '/p/a.mdx',
+      iteration: 2,
+      source: '# Revised Plan\n\nbody v2\n',
+    })
+    expect(second.id).toBe(first.id)
     const ctrl = new AbortController()
     const queue = (await firstQueueEvent(d, ctrl.signal)) as Array<{
       id: string
+      title: string
+      status: string
       iteration?: number
+      decision?: string
+      rev: number
     }>
     ctrl.abort()
     expect(queue).toHaveLength(1)
-    expect(queue[0].id).toBe(second.id)
-    expect(queue[0].id).not.toBe(first.id)
+    expect(queue[0].id).toBe(first.id)
+    expect(queue[0].rev).toBe(2)
+    expect(queue[0].status).toBe('pending')
+    expect(queue[0].decision).toBeUndefined()
+    expect(queue[0].title).toBe('Revised Plan')
     expect(queue[0].iteration).toBe(2)
   }, 60_000)
 
@@ -410,15 +609,241 @@ describe('daemon queue entries: version, decision, requeue dedupe', () => {
     expect(queue).toHaveLength(2)
   }, 60_000)
 
-  it('unblocks a caller still waiting on the superseded version with a deny (edge)', async () => {
+  it('unblocks a caller still waiting on the superseded version with its draft (edge)', async () => {
     d = await fakeDaemon()
     const first = await enqueue(d, { key: '/p/a.mdx' })
     const verdict = fetch(url(d, `/__vp_verdict?id=${first.id}`)).then(
-      r => r.json() as Promise<{ decision: string }>,
+      r => r.json() as Promise<{ decision: string; comments: Array<{ body: string }> }>,
     )
     await new Promise(resolve => setTimeout(resolve, 50))
+    // The reviewer left a partial draft on the old revision; superseding must deliver it, not an
+    // empty default deny.
+    await fetch(url(d, '/__vp_draft'), {
+      method: 'POST',
+      body: JSON.stringify({
+        decision: 'deny',
+        planId: first.id,
+        comments: [{ section: 'X', body: 'wip note' }],
+      }),
+    })
     await enqueue(d, { key: '/p/a.mdx' })
-    expect((await verdict).decision).toBe('deny')
+    const resolved = await verdict
+    expect(resolved.decision).toBe('deny')
+    expect(resolved.comments).toMatchObject([{ body: 'wip note' }])
+  }, 60_000)
+
+  it('resets an approved (done) plan in place on a same-key re-enqueue (edge)', async () => {
+    d = await fakeDaemon({ idleMs: 60_000 })
+    const first = await enqueue(d, { key: '/p/a.mdx' })
+    await fetch(url(d, '/__vp_feedback'), {
+      method: 'POST',
+      body: JSON.stringify({ decision: 'approve', planId: first.id }),
+    })
+    const second = await enqueue(d, { key: '/p/a.mdx' })
+    expect(second.id).toBe(first.id)
+    const ctrl = new AbortController()
+    const queue = (await firstQueueEvent(d, ctrl.signal)) as Array<{
+      id: string
+      status: string
+      decision?: string
+      rev: number
+    }>
+    ctrl.abort()
+    expect(queue).toHaveLength(1)
+    expect(queue[0]).toMatchObject({ id: first.id, status: 'pending', rev: 2 })
+    expect(queue[0].decision).toBeUndefined()
+  }, 120_000)
+})
+
+describe('daemon iterate-in-place', () => {
+  let d: DaemonInstance
+  afterEach(async () => {
+    await d?.close()
+  })
+
+  it('marks an iterate verdict as status iterating and resolves the waiter (golden)', async () => {
+    d = await fakeDaemon({ idleMs: 60_000 })
+    const { id } = await enqueue(d, { key: '/p/a.mdx' })
+    const verdictP = fetch(url(d, `/__vp_verdict?id=${id}`)).then(r => r.json())
+    await new Promise(r => setTimeout(r, 50))
+    await fetch(url(d, '/__vp_feedback'), {
+      method: 'POST',
+      body: JSON.stringify({ decision: 'iterate', planId: id }),
+    })
+    await expect(verdictP).resolves.toMatchObject({ decision: 'iterate' })
+    const ctrl = new AbortController()
+    const queue = (await firstQueueEvent(d, ctrl.signal)) as Array<{
+      status: string
+      decision?: string
+    }>
+    ctrl.abort()
+    expect(queue[0].status).toBe('iterating')
+    expect(queue[0].decision).toBe('iterate')
+  }, 60_000)
+})
+
+describe('daemon iterate -> re-enqueue -> verdict rebind', () => {
+  let d: DaemonInstance
+  afterEach(async () => {
+    await d?.close()
+  })
+
+  it('long-polls a new verdict after a same-key re-enqueue instead of replaying the stale iterate (golden)', async () => {
+    d = await fakeDaemon({ idleMs: 60_000 })
+    const { id } = await enqueue(d, { key: '/p/a.mdx' })
+    await fetch(url(d, '/__vp_feedback'), {
+      method: 'POST',
+      body: JSON.stringify({ decision: 'iterate', planId: id }),
+    })
+    const second = await enqueue(d, { key: '/p/a.mdx' })
+    expect(second.id).toBe(id)
+    // The revised plan's caller awaits a fresh verdict on the same id: it must hang (the entry was
+    // reset to pending), not be answered instantly with the settled iterate feedback.
+    let resolvedEarly = false
+    const verdictP = fetch(url(d, `/__vp_verdict?id=${id}`))
+      .then(r => r.json() as Promise<{ decision: string }>)
+      .then(v => {
+        resolvedEarly = true
+        return v
+      })
+    await new Promise(r => setTimeout(r, 300))
+    expect(resolvedEarly).toBe(false)
+    await fetch(url(d, '/__vp_feedback'), {
+      method: 'POST',
+      body: JSON.stringify({ decision: 'approve', planId: id }),
+    })
+    await expect(verdictP).resolves.toMatchObject({ decision: 'approve' })
+  }, 60_000)
+})
+
+describe('daemon auto-increment iteration', () => {
+  let d: DaemonInstance
+  afterEach(async () => {
+    await d?.close()
+  })
+
+  /** Read the single queue entry's iteration from a fresh events connection. */
+  async function queuedIteration(): Promise<number | undefined> {
+    const ctrl = new AbortController()
+    const queue = (await firstQueueEvent(d, ctrl.signal)) as Array<{ iteration?: number }>
+    ctrl.abort()
+    return queue[0]?.iteration
+  }
+
+  it('bumps the iteration to old+1 on a same-key re-enqueue without an explicit one (golden)', async () => {
+    d = await fakeDaemon({ idleMs: 60_000 })
+    await enqueue(d, { key: '/p/a.mdx', iteration: 3 })
+    await enqueue(d, { key: '/p/a.mdx' })
+    expect(await queuedIteration()).toBe(4)
+  }, 60_000)
+
+  it('treats a missing old iteration as 1, bumping to 2 (edge)', async () => {
+    d = await fakeDaemon({ idleMs: 60_000 })
+    await enqueue(d, { key: '/p/a.mdx' })
+    await enqueue(d, { key: '/p/a.mdx' })
+    expect(await queuedIteration()).toBe(2)
+  }, 60_000)
+
+  it('lets an explicit iteration win over the auto-bump (edge)', async () => {
+    d = await fakeDaemon({ idleMs: 60_000 })
+    await enqueue(d, { key: '/p/a.mdx', iteration: 3 })
+    await enqueue(d, { key: '/p/a.mdx', iteration: 7 })
+    expect(await queuedIteration()).toBe(7)
+  }, 60_000)
+
+  it('keeps a fresh (non-update) enqueue iteration as given, possibly undefined (edge)', async () => {
+    d = await fakeDaemon({ idleMs: 60_000 })
+    await enqueue(d, { key: '/p/a.mdx' })
+    expect(await queuedIteration()).toBeUndefined()
+  }, 60_000)
+})
+
+describe('daemon /plan across revisions', () => {
+  let d: DaemonInstance
+  afterEach(async () => {
+    await d?.close()
+  })
+
+  it('serves the swapped html with no-store and no stale decided-injection after a re-enqueue (golden)', async () => {
+    d = await fakeDaemon({ idleMs: 60_000 })
+    const { id } = await enqueue(d, { key: '/p/a.mdx' })
+    await fetch(url(d, '/__vp_feedback'), {
+      method: 'POST',
+      body: JSON.stringify({ decision: 'iterate', planId: id }),
+    })
+    await enqueue(d, { key: '/p/a.mdx', source: '# Revised Plan\n\nbody v2\n' })
+    const res = await fetch(url(d, `/plan/${id}`))
+    expect(res.status).toBe(200)
+    // The id is reused across revisions, so the browser must never serve a cached revision.
+    expect(res.headers.get('cache-control')).toBe('no-store')
+    const html = await res.text()
+    expect(html).toContain('Revised Plan')
+    // The reset entry is pending again: no locked-in verdict may be injected.
+    expect(html).not.toContain('globalThis.__VP_REVIEW_DECIDED__=')
+  }, 120_000)
+})
+
+describe('daemon entry timestamps', () => {
+  let d: DaemonInstance
+  afterEach(async () => {
+    await d?.close()
+  })
+
+  /** Read the single queue entry's timestamps from a fresh events connection. */
+  async function stamps(): Promise<{ createdAt?: number; updatedAt?: number }> {
+    const ctrl = new AbortController()
+    const queue = (await firstQueueEvent(d, ctrl.signal)) as Array<{
+      createdAt?: number
+      updatedAt?: number
+    }>
+    ctrl.abort()
+    return queue[0]
+  }
+
+  it('stamps createdAt and updatedAt on enqueue, moving updatedAt on settle and re-enqueue (golden)', async () => {
+    d = await fakeDaemon({ idleMs: 60_000 })
+    const before = Date.now()
+    const { id } = await enqueue(d, { key: '/p/a.mdx' })
+    const fresh = await stamps()
+    expect(fresh.createdAt).toBeGreaterThanOrEqual(before)
+    expect(fresh.updatedAt).toBeGreaterThanOrEqual(before)
+    await new Promise(r => setTimeout(r, 20))
+    await fetch(url(d, '/__vp_feedback'), {
+      method: 'POST',
+      body: JSON.stringify({ decision: 'iterate', planId: id }),
+    })
+    const settled = await stamps()
+    expect(settled.updatedAt!).toBeGreaterThan(fresh.updatedAt!)
+    expect(settled.createdAt).toBe(fresh.createdAt)
+    await new Promise(r => setTimeout(r, 20))
+    await enqueue(d, { key: '/p/a.mdx' })
+    const revised = await stamps()
+    expect(revised.updatedAt!).toBeGreaterThan(settled.updatedAt!)
+    expect(revised.createdAt).toBe(fresh.createdAt)
+  }, 120_000)
+})
+
+describe('daemon idle TTL with iterating plans', () => {
+  it('keeps the daemon alive past idleMs while a plan is iterating, idles after approve (golden)', async () => {
+    let idled = false
+    const d = await fakeDaemon({ idleMs: 300, onIdle: () => (idled = true) })
+    const { id } = await enqueue(d, { key: '/p/a.mdx' })
+    await fetch(url(d, '/__vp_feedback'), {
+      method: 'POST',
+      body: JSON.stringify({ decision: 'iterate', planId: id }),
+    })
+    // An iterating entry is a promise of an imminent re-enqueue; the idle TTL must not fire.
+    await new Promise(r => setTimeout(r, 500))
+    expect(idled).toBe(false)
+    expect((await fetch(url(d, '/__vp_ping'))).status).toBe(200)
+    // The revised plan arrives and is approved: nothing pending remains, idle fires.
+    const second = await enqueue(d, { key: '/p/a.mdx' })
+    await fetch(url(d, '/__vp_feedback'), {
+      method: 'POST',
+      body: JSON.stringify({ decision: 'approve', planId: second.id }),
+    })
+    await new Promise(r => setTimeout(r, 500))
+    expect(idled).toBe(true)
   }, 60_000)
 })
 

--- a/packages/cli/tests/review-lockfile.test.ts
+++ b/packages/cli/tests/review-lockfile.test.ts
@@ -4,7 +4,13 @@ import { mkdtemp, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
-import { isDaemonAlive, readLock, removeLock, writeLockExclusive } from '../src/review/lockfile.js'
+import {
+  isDaemonAlive,
+  readLock,
+  removeLock,
+  removeLockIfOwned,
+  writeLockExclusive,
+} from '../src/review/lockfile.js'
 
 let dir: string
 
@@ -66,6 +72,26 @@ describe('removeLock', () => {
   })
 })
 
+describe('removeLockIfOwned', () => {
+  it('removes the lock when it belongs to the given pid (golden)', async () => {
+    await writeLockExclusive({ port: 9151, pid: 42 }, dir)
+    await removeLockIfOwned(dir, 42)
+    expect(await readLock(dir)).toBeNull()
+  })
+
+  it('leaves a lock owned by a different pid untouched (error: successor guard)', async () => {
+    // A SIGTERM'd old daemon must not delete the lock a successor daemon already claimed.
+    await writeLockExclusive({ port: 9152, pid: 99 }, dir)
+    await removeLockIfOwned(dir, 42)
+    expect(await readLock(dir)).toEqual({ port: 9152, pid: 99 })
+  })
+
+  it('is a no-op when there is no lock (edge)', async () => {
+    await expect(removeLockIfOwned(dir, 42)).resolves.toBeUndefined()
+    expect(await readLock(dir)).toBeNull()
+  })
+})
+
 describe('isDaemonAlive', () => {
   it('returns true when /__vp_ping answers 200 (golden)', async () => {
     const server = createServer((req, res) => {
@@ -93,6 +119,21 @@ describe('isDaemonAlive', () => {
     const port = (probe.address() as { port: number }).port
     await new Promise<void>(resolve => probe.close(() => resolve()))
     expect(await isDaemonAlive(port)).toBe(false)
+  })
+
+  it('returns false when a 200 response body is not exactly "ok" (error: port squatter)', async () => {
+    // An unrelated server squatting the port may answer 200 to anything; only the daemon says 'ok'.
+    const server = createServer((_req, res) => {
+      res.writeHead(200)
+      res.end('<html>welcome</html>')
+    })
+    await new Promise<void>(resolve => server.listen(0, resolve))
+    const port = (server.address() as { port: number }).port
+    try {
+      expect(await isDaemonAlive(port)).toBe(false)
+    } finally {
+      await new Promise<void>(resolve => server.close(() => resolve()))
+    }
   })
 
   it('returns false when the endpoint answers non-200 (edge)', async () => {

--- a/packages/cli/tests/review.test.ts
+++ b/packages/cli/tests/review.test.ts
@@ -43,6 +43,30 @@ describe('formatFeedback', () => {
       'DECISION: approve',
     )
   })
+
+  it('tags a comment with its severity after the section name (golden)', () => {
+    const text = formatFeedback({
+      decision: 'iterate',
+      comments: [
+        { section: 'Phase 2', body: 'fix this', severity: 'must-fix' },
+        { section: 'Phase 3', body: 'nicer name', severity: 'suggestion' },
+      ],
+      answers: [],
+    })
+    expect(text).toContain('Comment on "Phase 2" [must-fix]:')
+    expect(text).toContain('Comment on "Phase 3" [suggestion]:')
+  })
+
+  it('prints an untagged comment exactly as before (edge: back-compat)', () => {
+    const text = formatFeedback({
+      decision: 'deny',
+      comments: [{ section: 'Phase 2', body: 'fix this' }],
+      answers: [],
+    })
+    expect(text).toContain('Comment on "Phase 2":')
+    expect(text).not.toContain('[must-fix]')
+    expect(text).not.toContain('[suggestion]')
+  })
 })
 
 describe('exitCodeFor', () => {

--- a/packages/compile/src/plan-blocks.ts
+++ b/packages/compile/src/plan-blocks.ts
@@ -280,13 +280,53 @@ function parseChecklist(node: MdNode): BlockResult {
 
 function parseQuestions(node: MdNode): BlockResult {
   const issues: BlockIssue[] = []
-  const items: string[] = []
+  const items: Array<string | { text: string; options: string[] }> = []
   const list = firstList(node)
   if (!list) {
     issues.push({ ...pos(node), message: '<Questions> needs a markdown list of questions.' })
     return { value: items, issues }
   }
-  for (const item of list.children ?? []) items.push(toText(item).trim())
+  for (const item of list.children ?? []) {
+    const children = item.children ?? []
+    // Nested bullets under a question are its multiple-choice options, so the question's own text
+    // is only the non-list children. A question with no nested list stays a plain string (the
+    // pre-options shape, keeping flat plans byte-stable; the schema normalizes both forms).
+    const text = children
+      .filter(child => child.type !== 'list')
+      .map(toText)
+      .join('')
+      .trim()
+    const nested = children.filter(child => child.type === 'list')
+    if (nested.length === 0) {
+      items.push(text)
+      continue
+    }
+    const options: string[] = []
+    for (const option of nested.flatMap(sub => sub.children ?? [])) {
+      const optionChildren = option.children ?? []
+      // Options are one level deep by design: a list nested inside an option has no meaning
+      // (options are flat choices), so flag it instead of silently folding its text in.
+      if (optionChildren.some(child => child.type === 'list')) {
+        issues.push({
+          ...pos(option),
+          message: `<Questions> options under "${text}" must stay one level deep (no nested lists).`,
+        })
+      }
+      const optionText = optionChildren
+        .filter(child => child.type !== 'list')
+        .map(toText)
+        .join('')
+        .trim()
+      if (!optionText) {
+        issues.push({
+          ...pos(option),
+          message: `<Questions> option under "${text}" must not be empty.`,
+        })
+      }
+      options.push(optionText)
+    }
+    items.push({ text, options })
+  }
   return { value: items, issues }
 }
 

--- a/packages/compile/tests/plan-blocks.test.ts
+++ b/packages/compile/tests/plan-blocks.test.ts
@@ -239,6 +239,57 @@ describe('Questions block', () => {
     expect(issues).toEqual([])
     expect(value).toEqual(['First?', 'Second?'])
   })
+
+  it('parses nested bullets under a question into its options (golden)', () => {
+    const { value, issues } = parseBlock(
+      'Questions',
+      '<Questions>\n- Rotate refresh tokens?\n  - Yes, every use\n  - Only after 24h\n</Questions>\n',
+    )
+    expect(issues).toEqual([])
+    expect(value).toEqual([
+      { text: 'Rotate refresh tokens?', options: ['Yes, every use', 'Only after 24h'] },
+    ])
+  })
+
+  it('mixes option questions with plain free-text questions (golden)', () => {
+    const { value, issues } = parseBlock(
+      'Questions',
+      '<Questions>\n- Rotate refresh tokens?\n  - Yes\n  - No\n- Is a 15-minute TTL acceptable?\n</Questions>\n',
+    )
+    expect(issues).toEqual([])
+    expect(value).toEqual([
+      { text: 'Rotate refresh tokens?', options: ['Yes', 'No'] },
+      'Is a 15-minute TTL acceptable?',
+    ])
+  })
+
+  it('flags an empty option with its line (error)', () => {
+    const { issues } = parseBlock(
+      'Questions',
+      '<Questions>\n- Rotate refresh tokens?\n  - Yes\n  -\n</Questions>\n',
+    )
+    expect(issues).toHaveLength(1)
+    expect(issues[0]?.message).toMatch(/option .* must not be empty/)
+    expect(issues[0]?.line).toBe(4)
+  })
+
+  it('flags a list nested inside an option with its line (error)', () => {
+    const { value, issues } = parseBlock(
+      'Questions',
+      '<Questions>\n- Rotate refresh tokens?\n  - Yes\n    - way too deep\n</Questions>\n',
+    )
+    expect(issues).toHaveLength(1)
+    expect(issues[0]?.message).toMatch(/one level deep/)
+    expect(issues[0]?.line).toBe(3)
+    // The option keeps its own text; the too-deep list is not folded into it.
+    expect(value).toEqual([{ text: 'Rotate refresh tokens?', options: ['Yes'] }])
+  })
+
+  it('flags a block with no list (edge)', () => {
+    const { issues } = parseBlock('Questions', '<Questions>\nno list here\n</Questions>\n')
+    expect(issues).toHaveLength(1)
+    expect(issues[0]?.message).toMatch(/needs a markdown list/)
+  })
 })
 
 describe('Stat block', () => {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -17,10 +17,16 @@ export const SHARE_VIEW_URL = 'https://visualplan.dev/view'
 /** The reviewer's verdict in interactive review mode (`vplan render --review`). */
 export const REVIEW_DECISION_VALUES = ['approve', 'deny', 'iterate'] as const
 
+/** How strongly a review comment binds: a `must-fix` blocks approval, a `suggestion` does not. */
+export const REVIEW_SEVERITY_VALUES = ['must-fix', 'suggestion'] as const
+
 /** A single targeted comment from a review session: which section it is about, and the note. */
 export const reviewCommentSchema = z.object({
   section: z.string().min(1),
   body: z.string().min(1),
+  // Optional weight the reviewer assigns; absent means untagged (an old client or an unweighted
+  // note), which readers should treat like a suggestion.
+  severity: z.enum(REVIEW_SEVERITY_VALUES).optional(),
 })
 
 /** A direct answer to one of a plan's `Questions`, keyed by the question text the reviewer answered. */
@@ -47,12 +53,15 @@ export const feedbackSchema = z.object({
 })
 
 export type ReviewDecision = (typeof REVIEW_DECISION_VALUES)[number]
+export type ReviewSeverity = (typeof REVIEW_SEVERITY_VALUES)[number]
 export type ReviewComment = z.infer<typeof reviewCommentSchema>
 export type ReviewAnswer = z.infer<typeof reviewAnswerSchema>
 export type Feedback = z.infer<typeof feedbackSchema>
 
-/** The sidebar status of a queued plan in Review Queue mode: waiting, currently shown, or decided. */
-export const QUEUE_STATUS_VALUES = ['pending', 'active', 'done'] as const
+/** The sidebar status of a queued plan in Review Queue mode: waiting, currently shown, decided, or
+ * `iterating` (the reviewer requested iteration and the daemon holds the entry awaiting the revised
+ * plan re-enqueued under the same key). */
+export const QUEUE_STATUS_VALUES = ['pending', 'active', 'done', 'iterating'] as const
 
 /**
  * One plan in the Review Queue, as the daemon streams it to the sidebar shell. `dir` is the
@@ -71,6 +80,14 @@ export const queueEntrySchema = z.object({
   // The locked-in verdict once the plan is `done`, so the sidebar shows the matching icon (check /
   // cross / iterate) rather than a generic one. Absent while pending.
   decision: z.enum(REVIEW_DECISION_VALUES).optional(),
+  // The daemon's serving-generation counter, bumped on every in-place same-key re-enqueue. Distinct
+  // from `iteration` (the author-facing round): `rev` drives the shell's iframe re-keying and
+  // unseen-update dots, and moves even when the author does not bump the iteration.
+  rev: z.number().int().positive().default(1),
+  // Epoch-ms stamps set by the daemon (enqueue / last status or revision change), shown as relative
+  // times in the sidebar. Optional so frames from an older daemon still parse.
+  createdAt: z.number().optional(),
+  updatedAt: z.number().optional(),
 })
 
 export type QueueStatus = (typeof QUEUE_STATUS_VALUES)[number]
@@ -164,9 +181,27 @@ export const calloutSchema = z.object({
   type: z.enum(CALLOUT_TYPE_VALUES).default('note'),
 })
 
+/** One open question, optionally offering multiple-choice options the reviewer can pick from
+ * (authored as nested bullets under the question). No options means free-text-only. */
+export const questionItemSchema = z.object({
+  text: z.string().min(1, 'each question needs text'),
+  options: z.array(z.string().min(1, 'each option needs text')).default([]),
+})
+
+export type QuestionItem = z.infer<typeof questionItemSchema>
+
 export const questionsSchema = z.object({
   title: z.string().default('Open questions'),
-  items: z.array(z.string().min(1)).min(1, 'questions needs at least one item'),
+  items: z
+    .array(
+      // A plain string is normalized to a free-text question, so consumers always see one shape.
+      // The string form stays accepted because option-less questions parse to plain strings (the
+      // pre-options wire shape, keeping flat plans byte-stable) and direct-JSX callers pass them.
+      z
+        .union([z.string().min(1), questionItemSchema])
+        .transform(item => (typeof item === 'string' ? { text: item, options: [] } : item)),
+    )
+    .min(1, 'questions needs at least one item'),
 })
 
 export const checklistSchema = z.object({
@@ -261,10 +296,10 @@ export const callout: CatalogEntry = {
 export const questions: CatalogEntry = {
   name: 'Questions',
   summary:
-    'Open questions you want the reader to weigh in on before building, as a highlighted panel. Write a markdown list. Title defaults to "Open questions"; override with title.',
+    'Open questions you want the reader to weigh in on before building, as a highlighted panel. Write a markdown list, one question per bullet. Nested bullets under a question become clickable multiple-choice options in a review (the reviewer picks one or types an "Other" answer); a question with no nested bullets takes a free-text answer. Title defaults to "Open questions"; override with title.',
   staticEnums: {},
   example:
-    '<Questions>\n- Should refresh tokens rotate on every use?\n- Is a 15-minute access-token TTL acceptable?\n</Questions>',
+    '<Questions>\n- Should refresh tokens rotate on every use?\n  - Yes, rotate every use\n  - Only on refresh after 24h\n- Is a 15-minute access-token TTL acceptable?\n</Questions>',
 }
 
 export const checklist: CatalogEntry = {

--- a/packages/core/tests/catalog.test.ts
+++ b/packages/core/tests/catalog.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, it } from 'vitest'
-import { CATALOG, chartSchema, matrixSchema, statSchema } from '../src/index.js'
+import {
+  CATALOG,
+  chartSchema,
+  matrixSchema,
+  questionItemSchema,
+  questionsSchema,
+  statSchema,
+} from '../src/index.js'
 
 describe('chartSchema', () => {
   it('accepts a valid bar spec (golden)', () => {
@@ -78,6 +85,56 @@ describe('matrixSchema', () => {
   it('rejects a grid with no rows (edge)', () => {
     const result = matrixSchema.safeParse({ columns: [{ name: 'A' }, { name: 'B' }], rows: [] })
     expect(result.success).toBe(false)
+  })
+})
+
+describe('questionItemSchema', () => {
+  it('accepts a question with multiple-choice options (golden)', () => {
+    const result = questionItemSchema.safeParse({
+      text: 'Rotate refresh tokens?',
+      options: ['Yes, every use', 'Only after 24h'],
+    })
+    expect(result.success).toBe(true)
+    if (result.success) expect(result.data.options).toEqual(['Yes, every use', 'Only after 24h'])
+  })
+
+  it('rejects an empty option string (error)', () => {
+    const result = questionItemSchema.safeParse({ text: 'Rotate?', options: [''] })
+    expect(result.success).toBe(false)
+  })
+
+  it('defaults options to an empty array (edge)', () => {
+    const result = questionItemSchema.safeParse({ text: 'Rotate?' })
+    expect(result.success).toBe(true)
+    if (result.success) expect(result.data.options).toEqual([])
+  })
+
+  it('rejects empty question text (error)', () => {
+    const result = questionItemSchema.safeParse({ text: '', options: [] })
+    expect(result.success).toBe(false)
+  })
+})
+
+describe('questionsSchema', () => {
+  it('accepts object items alongside plain strings, normalizing both (golden)', () => {
+    const result = questionsSchema.safeParse({
+      items: ['Free text only?', { text: 'Rotate?', options: ['Yes', 'No'] }],
+    })
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.items).toEqual([
+        { text: 'Free text only?', options: [] },
+        { text: 'Rotate?', options: ['Yes', 'No'] },
+      ])
+    }
+  })
+
+  it('rejects an empty string question (error)', () => {
+    expect(questionsSchema.safeParse({ items: [''] }).success).toBe(false)
+  })
+
+  it('rejects an empty item list (edge)', () => {
+    expect(questionsSchema.safeParse({ items: [] }).success).toBe(false)
   })
 })
 

--- a/packages/core/tests/feedback.test.ts
+++ b/packages/core/tests/feedback.test.ts
@@ -32,6 +32,36 @@ describe('feedbackSchema answers', () => {
   })
 })
 
+describe('reviewCommentSchema severity', () => {
+  it('carries an optional must-fix or suggestion tag (golden)', () => {
+    const parsed = feedbackSchema.parse({
+      decision: 'iterate',
+      comments: [
+        { section: 'Phase 1', body: 'wrong table', severity: 'must-fix' },
+        { section: 'Phase 2', body: 'maybe rename', severity: 'suggestion' },
+      ],
+    })
+    expect(parsed.comments.map(c => c.severity)).toEqual(['must-fix', 'suggestion'])
+  })
+
+  it('leaves severity undefined when untagged (edge)', () => {
+    const parsed = feedbackSchema.parse({
+      decision: 'iterate',
+      comments: [{ section: 'Phase 1', body: 'tweak' }],
+    })
+    expect(parsed.comments[0]?.severity).toBeUndefined()
+  })
+
+  it('rejects an unknown severity (error)', () => {
+    expect(() =>
+      feedbackSchema.parse({
+        decision: 'iterate',
+        comments: [{ section: 'Phase 1', body: 'x', severity: 'blocking' }],
+      }),
+    ).toThrow()
+  })
+})
+
 describe('feedbackSchema planId', () => {
   it('carries a planId when the Review Queue tags the feedback (golden)', () => {
     const parsed = feedbackSchema.parse({ decision: 'approve', planId: 'p-1' })

--- a/packages/core/tests/queue.test.ts
+++ b/packages/core/tests/queue.test.ts
@@ -4,7 +4,7 @@ import { QUEUE_STATUS_VALUES, queueEntrySchema } from '../src/index.js'
 describe('queueEntrySchema', () => {
   it('parses a full entry and keeps its fields (golden)', () => {
     const entry = { id: 'p-1', title: 'Review Queue', dir: 'visualplan', status: 'active' }
-    expect(queueEntrySchema.parse(entry)).toEqual(entry)
+    expect(queueEntrySchema.parse(entry)).toEqual({ ...entry, rev: 1 })
   })
 
   it('defaults status to pending when omitted (edge)', () => {
@@ -23,11 +23,35 @@ describe('queueEntrySchema', () => {
     // A plan need not start with a heading mid-compose, and the cwd basename can be empty at root;
     // neither should block enqueueing, so only id and status are constrained.
     const parsed = queueEntrySchema.parse({ id: 'p-1', title: '', dir: '' })
-    expect(parsed).toEqual({ id: 'p-1', title: '', dir: '', status: 'pending' })
+    expect(parsed).toEqual({ id: 'p-1', title: '', dir: '', status: 'pending', rev: 1 })
   })
 
-  it('exposes the three sidebar statuses (golden)', () => {
-    expect(QUEUE_STATUS_VALUES).toEqual(['pending', 'active', 'done'])
+  it('exposes the four sidebar statuses (golden)', () => {
+    expect(QUEUE_STATUS_VALUES).toEqual(['pending', 'active', 'done', 'iterating'])
+  })
+
+  it('defaults rev to 1 for frames from an older daemon (edge)', () => {
+    expect(queueEntrySchema.parse({ id: 'p-1', title: 'P', dir: 'd' }).rev).toBe(1)
+  })
+
+  it('carries rev, iterating status, and timestamps for an in-place re-review (golden)', () => {
+    const parsed = queueEntrySchema.parse({
+      id: 'p-1',
+      title: 'Plan',
+      dir: 'proj',
+      status: 'iterating',
+      rev: 3,
+      createdAt: 1_700_000_000_000,
+      updatedAt: 1_700_000_060_000,
+    })
+    expect(parsed.status).toBe('iterating')
+    expect(parsed.rev).toBe(3)
+    expect(parsed.createdAt).toBe(1_700_000_000_000)
+    expect(parsed.updatedAt).toBe(1_700_000_060_000)
+  })
+
+  it('rejects a zero or negative rev (error)', () => {
+    expect(() => queueEntrySchema.parse({ id: 'p-1', title: 'P', dir: 'd', rev: 0 })).toThrow()
   })
 
   it('carries an optional iteration and decision for re-reviews (golden)', () => {

--- a/packages/runtime/AGENTS.md
+++ b/packages/runtime/AGENTS.md
@@ -27,7 +27,14 @@ the root AGENTS.md for why Vite is configured without `@vitejs/plugin-react`.
   `.vp-chart`, `.vp-filetree`, `.vp-matrix-wrap`, `.vp-compare`, `.vp-checklist`, `.vp-stat`,
   `.vp-questions`) that is a **direct** child of `.vp-main`, so loose top-level intro content does not
   collapse into one oversized section while blocks nested inside a `<Phase>` stay part of it.
-  `CommentModal` is the bottom composer; `DecisionBar` submits Approve/Deny/Iterate. In review mode
+  `CommentModal` is the bottom composer (with an optional must-fix/suggestion severity toggle,
+  default untagged; the tag rides `comments[].severity` and is dropped from JSON when unset, so old
+  daemons never see it); `DecisionBar` submits Approve/Deny/Iterate. After any decision the session
+  goes read-only rather than unmounting: quote marks and section badges stay visible (delete hidden),
+  composer and bar are suppressed, and a queue-mode iterate shows a spinner notice ("Waiting for the
+  revised plan") until the shell swaps in the next revision. Known limit: navigating away and back
+  while iterating remounts the iframe and loses the in-page marks (the daemon reinjects only
+  decision + answers). In review mode
   `Questions` is **directly answerable**: each row renders an answer field whose value flows up via
   the `ReviewAnswers` context (provided in `Layout`, shared by `Questions` and `ReviewSession`) into
   the feedback's distinct `answers` channel. `feedback.ts` POSTs an explicit decision
@@ -47,11 +54,24 @@ the root AGENTS.md for why Vite is configured without `@vitejs/plugin-react`.
   content: just `QueueShell` (chrome) hosting each active plan in a same-origin `<iframe src="/plan/<id>">`.
   `QueueShell` opens `new EventSource('/__vp_events')` and holds it open for the page lifetime (it is
   the daemon's liveness signal: closing the tab tears the daemon down, so the stream is closed only on
-  unmount). The daemon emits `event: queue` with a JSON `QueueEntry[]`; the shell defaults the active
-  iframe to the first pending plan and auto-advances when the active one is marked `done`. j/k or
+  unmount). It also sends a `navigator.sendBeacon('/__vp_shell_closed')` on `pagehide` (evidence that
+  lets the daemon pick the short close grace over the long suspension grace; the socket close remains
+  the actual signal) and arms a `beforeunload` confirm only while a `pending`/`active` entry exists
+  (an `iterating` entry is already resolved to its caller, so closing loses nothing undecided).
+  The daemon emits `event: queue` with a JSON `QueueEntry[]`; the shell defaults the active
+  iframe to the first pending plan. Selection is prev-aware (`nextActiveId(prev, next, activeId)`):
+  the active plan is kept unless it transitioned to `done` THIS frame, so an iterate keeps the plan
+  on screen in its waiting state, the `iterating -> pending` rev bump swaps the revision in place,
+  and a user parked on a decided plan is never yanked away by an unrelated frame. The iframe is keyed
+  `id:rev` with a `?rev=` cache-buster (ids are stable across revisions now; the daemon also serves
+  `/plan/<id>` as `no-store`). The **sidebar always renders**, even for a single plan (deliberate:
+  the queue is the product surface, and history stays visible); rows keep stable insertion order
+  (never reorder under the cursor), show a spinning refresh icon + "awaiting revision" for
+  `iterating`, a relative `updatedAt` timestamp, an unseen-revision dot for background rev bumps
+  (per-plan, distinct from the whole-tab favicon dot), and the `vN` iteration chip. j/k or
   arrow keys navigate. `components/queue/logic.ts` holds the **pure**, unit-tested navigation helpers
-  (`firstPendingId`, `nextActiveId`, `moveSelection`, `reviewedCount`); `QueueSidebar.tsx` is the rail
-  (title + muted originating `dir` + Tabler status icon + "N of M reviewed"); `queue.css` is the
+  (`firstPendingId`, `nextActiveId`, `moveSelection`, `reviewedCount`, `relativeTime`, `unseenRevs`,
+  `revisingCount`); `QueueSidebar.tsx` is the rail; `queue.css` is the
   colocated chrome (the entry imports `theme.css` for the shared `--vp-*` tokens). Built by the CLI's
   `buildQueueShell()` (`packages/cli/src/build/queue-shell.ts`), a Vite single-file build of `queue.html`
   with NO plan plugins (no `virtual:plan`/share/diff/review), so the shell ships self-contained.

--- a/packages/runtime/components/Questions.tsx
+++ b/packages/runtime/components/Questions.tsx
@@ -1,5 +1,5 @@
 import { questionsSchema } from '@visualplan/core'
-import { type ComponentProps, useLayoutEffect, useRef } from 'react'
+import { type ComponentProps, useId, useLayoutEffect, useRef } from 'react'
 import { isReviewMode } from './review/feedback.js'
 import { useQuestionAnswers } from './review/ReviewAnswers.js'
 import { decodeJson, validateProps } from './validate.js'
@@ -27,7 +27,9 @@ interface QuestionsProps {
 }
 
 /** Open questions for the reader to resolve before building, as a highlighted panel. In a review
- * session each question becomes directly answerable; otherwise it is a static numbered list. */
+ * session each question becomes directly answerable; a question authored with multiple-choice
+ * options additionally offers them as a radio group beside an "Other" free-text field. Outside a
+ * review the options render as a plain sub-list. */
 export function Questions(props: QuestionsProps) {
   const { title, items } = validateProps('Questions', questionsSchema, {
     ...props,
@@ -38,29 +40,65 @@ export function Questions(props: QuestionsProps) {
   // Once the plan is decided the answer fields lock: an answered question stays visible (read-only),
   // an unanswered one reverts to a plain question.
   const locked = answers?.locked ?? false
+  // Radio groups need a page-unique name per question so sibling Questions panels never merge.
+  const groupBase = useId()
   return (
     <section className='vp-questions'>
       <div className='vp-questions__title'>{title}</div>
       <ol className='vp-questions__list'>
         {items.map((item, index) => {
-          const answer = answers?.answers.get(item) ?? ''
+          const answer = answers?.answers.get(item.text) ?? ''
+          const selectable = interactive && !locked && item.options.length > 0
           const showInput = interactive && (!locked || answer.trim() !== '')
+          // The single answer string is the source of truth: an answer matching an option reads as
+          // that option selected (Other empty); anything else reads as custom text (no selection).
+          // Picking an option and typing in Other therefore clear each other with no extra state.
+          const selected = selectable && item.options.includes(answer) ? answer : null
           return (
-            <li key={item} className='vp-questions__item'>
+            <li key={item.text} className='vp-questions__item'>
               <span className='vp-questions__num' aria-hidden='true'>
                 {index + 1}
               </span>
               <div className='vp-questions__body'>
-                <span className='vp-questions__text'>{item}</span>
+                <span className='vp-questions__text'>{item.text}</span>
+                {item.options.length > 0 && !selectable && (
+                  <ul className='vp-questions__options'>
+                    {item.options.map(option => (
+                      <li key={option} className='vp-questions__option'>
+                        {option}
+                      </li>
+                    ))}
+                  </ul>
+                )}
+                {selectable && answers && (
+                  <div
+                    className='vp-questions__options'
+                    role='radiogroup'
+                    aria-label={`Options: ${item.text}`}
+                  >
+                    {item.options.map(option => (
+                      <label key={option} className='vp-questions__option'>
+                        <input
+                          type='radio'
+                          name={`${groupBase}-${index}`}
+                          value={option}
+                          checked={selected === option}
+                          onChange={() => answers.setAnswer(item.text, option)}
+                        />
+                        <span>{option}</span>
+                      </label>
+                    ))}
+                  </div>
+                )}
                 {showInput && answers && (
                   <AutoGrowTextarea
                     className='vp-questions__answer'
                     rows={1}
-                    placeholder='Answer this question…'
-                    aria-label={`Answer: ${item}`}
-                    value={answer}
+                    placeholder={selectable ? 'Other…' : 'Answer this question…'}
+                    aria-label={selectable ? `Other answer: ${item.text}` : `Answer: ${item.text}`}
+                    value={selected ? '' : answer}
                     readOnly={locked}
-                    onChange={event => answers.setAnswer(item, event.target.value)}
+                    onChange={event => answers.setAnswer(item.text, event.target.value)}
                   />
                 )}
               </div>

--- a/packages/runtime/components/queue/QueueShell.tsx
+++ b/packages/runtime/components/queue/QueueShell.tsx
@@ -2,12 +2,24 @@ import type { QueueEntry } from '@visualplan/core'
 import { IconChecklist } from '@tabler/icons-react'
 import { useEffect, useRef, useState } from 'react'
 import { setActivityDot } from './favicon.js'
-import { hasNewActivity, moveSelection, nextActiveId, reviewedCount } from './logic.js'
+import {
+  hasNewActivity,
+  moveSelection,
+  nextActiveId,
+  reviewedCount,
+  revisingCount,
+  unseenRevs,
+} from './logic.js'
 import { QueueSidebar } from './QueueSidebar.js'
 import './queue.css'
 
 /** The daemon's SSE endpoint, which doubles as the tab's liveness signal. */
 const EVENTS_ENDPOINT = '/__vp_events'
+
+/** POSTed via sendBeacon on pagehide as positive evidence of a real unload, letting the daemon arm
+ * its short deny grace instead of the long silent one (a suspended tab drops the SSE without this
+ * beacon). Fired on every pagehide: a reload's SSE reconnect cancels the short grace. */
+const SHELL_CLOSED_ENDPOINT = '/__vp_shell_closed'
 
 /**
  * The Review Queue shell the daemon serves at `/`: a left sidebar of queued plans and the active plan
@@ -25,26 +37,35 @@ export function QueueShell() {
   const activeRef = useRef<string | null>(activeId)
   activeRef.current = activeId
 
+  // Whether any plan is still undecided, read by the stable beforeunload handler below (same
+  // pattern as activeRef: the handler must be attached once, not re-bound per frame).
+  const pendingRef = useRef(false)
+  pendingRef.current = entries.some(e => e.status === 'pending' || e.status === 'active')
+
   const containerRef = useRef<HTMLDivElement>(null)
   // Set when an active change came from keyboard nav (not an SSE-driven auto-advance), so focus
   // follows the selection then but never gets yanked out from under the user on a background update.
   const keyboardNavRef = useRef(false)
 
-  // A favicon dot raised when the queue gains activity (a plan added or updated) while the tab is
-  // backgrounded, cleared when the user focuses the tab again; prevEntriesRef diffs against the
-  // last queue to tell new activity from a no-op redraw.
-  const [unseen, setUnseen] = useState(false)
+  // A whole-tab favicon dot raised when the queue gains activity (a plan added or updated) while
+  // the tab is backgrounded, cleared when the user focuses the tab again; prevEntriesRef diffs
+  // against the last queue to tell new activity from a no-op redraw. Distinct from the per-plan
+  // unseen-revision dots derived further down.
+  const [faviconUnseen, setFaviconUnseen] = useState(false)
   const prevEntriesRef = useRef<QueueEntry[]>([])
 
   useEffect(() => {
     const source = new EventSource(EVENTS_ENDPOINT)
     const onQueue = (event: MessageEvent) => {
       const next = JSON.parse(event.data) as QueueEntry[]
-      if (document.hidden && hasNewActivity(prevEntriesRef.current, next)) setUnseen(true)
+      // Read the previous frame BEFORE overwriting the ref: nextActiveId compares the two frames to
+      // advance only when the active plan turned done in this frame.
+      const prev = prevEntriesRef.current
+      if (document.hidden && hasNewActivity(prev, next)) setFaviconUnseen(true)
       prevEntriesRef.current = next
       setEntries(next)
       // Default to the first pending plan, and auto-advance once the active plan is marked done.
-      setActiveId(nextActiveId(next, activeRef.current))
+      setActiveId(nextActiveId(prev, next, activeRef.current))
     }
     source.addEventListener('queue', onQueue)
     return () => {
@@ -56,15 +77,38 @@ export function QueueShell() {
   // Clear the activity dot once the tab is in the foreground again; reflect the flag on the favicon.
   useEffect(() => {
     const onVisible = () => {
-      if (!document.hidden) setUnseen(false)
+      if (!document.hidden) setFaviconUnseen(false)
     }
     document.addEventListener('visibilitychange', onVisible)
     return () => document.removeEventListener('visibilitychange', onVisible)
   }, [])
 
   useEffect(() => {
-    setActivityDot(unseen)
-  }, [unseen])
+    setActivityDot(faviconUnseen)
+  }, [faviconUnseen])
+
+  // Tell the daemon this was a real unload (close/reload/navigation), not a silent socket drop.
+  useEffect(() => {
+    const onPageHide = () => {
+      if (typeof navigator.sendBeacon === 'function') navigator.sendBeacon(SHELL_CLOSED_ENDPOINT)
+    }
+    window.addEventListener('pagehide', onPageHide)
+    return () => window.removeEventListener('pagehide', onPageHide)
+  }, [])
+
+  // Closing the tab with undecided plans denies them (the daemon's deny-on-close), so raise the
+  // native leave-page confirm then. An 'iterating' plan is already resolved to its caller, so it
+  // does not block a close; nor do decided plans or an empty queue.
+  useEffect(() => {
+    const onBeforeUnload = (event: BeforeUnloadEvent) => {
+      if (!pendingRef.current) return
+      event.preventDefault()
+      // Legacy channel some browsers still require to show the confirm.
+      event.returnValue = ''
+    }
+    window.addEventListener('beforeunload', onBeforeUnload)
+    return () => window.removeEventListener('beforeunload', onBeforeUnload)
+  }, [])
 
   // j/k or arrow keys move the active selection; the in-iframe review UI handles every other key.
   useEffect(() => {
@@ -93,13 +137,27 @@ export function QueueShell() {
     containerRef.current?.querySelector<HTMLElement>('.vp-queue__row[tabindex="0"]')?.focus()
   }, [activeId])
 
-  // The sidebar is for navigating BETWEEN plans, so a lone plan shows none: it reads as an ordinary
-  // single review. It appears the moment a second plan joins the queue (the SSE drives this live).
-  const showSidebar = entries.length > 1
-
   // The plan to host in the iframe: whichever row is selected, pending or already decided (a decided
   // plan re-opens locked into its verdict). The empty state shows only when nothing is selected.
   const activeEntry = entries.find(entry => entry.id === activeId) ?? null
+  const activeRev = activeEntry?.rev ?? 1
+
+  // Per-plan unseen-revision dots (distinct from the whole-tab `faviconUnseen` flag above): the
+  // active plan's rev is recorded as seen whenever it is shown, and any OTHER entry whose rev moved
+  // past its seen rev gets an accent dot on its sidebar row instead of stealing focus.
+  const seenRevsRef = useRef(new Map<string, number>())
+  useEffect(() => {
+    if (activeId) seenRevsRef.current.set(activeId, activeRev)
+  }, [activeId, activeRev])
+  const unseenIds = unseenRevs(entries, seenRevsRef.current, activeId)
+
+  // A coarse clock for the sidebar's relative timestamps: a 30s tick keeps "Nm ago" fresh between
+  // queue frames without re-rendering more often than the coarsest bucket needs.
+  const [now, setNow] = useState(() => Date.now())
+  useEffect(() => {
+    const timer = setInterval(() => setNow(Date.now()), 30_000)
+    return () => clearInterval(timer)
+  }, [])
 
   // Announced to assistive tech as the queue changes (a plan reviewed, the active plan advancing, a
   // new plan arriving), which are otherwise silent visual updates.
@@ -110,27 +168,37 @@ export function QueueShell() {
   useEffect(() => {
     document.title = activeTitle || 'Visual Plan Review Queue'
   }, [activeTitle])
+  const revising = revisingCount(entries)
   const announcement =
     entries.length === 0
       ? ''
       : `${reviewedCount(entries)} of ${entries.length} plans reviewed${
-          activeTitle ? `. Now reviewing ${activeTitle}` : '.'
-        }`
+          revising > 0 ? `, ${revising} awaiting revision` : ''
+        }${activeTitle ? `. Now reviewing ${activeTitle}` : '.'}`
 
   return (
-    <div ref={containerRef} className={showSidebar ? 'vp-queue' : 'vp-queue vp-queue--solo'}>
+    <div ref={containerRef} className='vp-queue'>
       <div className='vp-sr-only' role='status' aria-live='polite'>
         {announcement}
       </div>
-      {showSidebar && <QueueSidebar entries={entries} activeId={activeId} onSelect={setActiveId} />}
+      {/* Always rendered, even for a lone plan: the rail carries the session's history and status. */}
+      <QueueSidebar
+        entries={entries}
+        activeId={activeId}
+        unseen={unseenIds}
+        now={now}
+        onSelect={setActiveId}
+      />
       <main className='vp-queue__main'>
         {activeEntry ? (
           <iframe
-            // Re-key on the active id so swapping plans remounts the iframe (a fresh review session,
-            // or a decided plan locked into its verdict) rather than navigating the same frame.
-            key={activeEntry.id}
+            // Re-key on id AND rev: ids are now stable across in-place revisions, so a rev bump must
+            // remount the iframe with the revised plan while swapping rows still gets a fresh frame.
+            // The daemon's router matches the pathname prefix and ignores the query; `?rev=` is a
+            // cache-buster since the same /plan/<id> URL now serves successive revisions.
+            key={`${activeEntry.id}:${activeEntry.rev ?? 1}`}
             className='vp-queue__frame'
-            src={`/plan/${activeEntry.id}`}
+            src={`/plan/${activeEntry.id}?rev=${activeEntry.rev ?? 1}`}
             title='Active plan under review'
           />
         ) : (

--- a/packages/runtime/components/queue/QueueSidebar.tsx
+++ b/packages/runtime/components/queue/QueueSidebar.tsx
@@ -5,11 +5,13 @@ import {
   IconCircleXFilled,
   IconRefresh,
 } from '@tabler/icons-react'
-import { reviewedCount } from './logic.js'
+import { relativeTime, reviewedCount, revisingCount } from './logic.js'
 
-/** The status indicator for a row: an open circle while pending, otherwise the icon for the verdict
- * the reviewer locked in (matching the decision bar: check / cross / iterate). */
+/** The status indicator for a row: an open circle while pending, a spinning refresh while the
+ * daemon awaits the revised plan, otherwise the icon for the verdict the reviewer locked in
+ * (matching the decision bar: check / cross / iterate). */
 function StatusIcon({ entry }: { entry: QueueEntry }) {
+  if (entry.status === 'iterating') return <IconRefresh size={16} />
   if (entry.status !== 'done') return <IconCircle size={16} />
   if (entry.decision === 'deny') return <IconCircleXFilled size={16} />
   if (entry.decision === 'iterate') return <IconRefresh size={16} />
@@ -19,6 +21,7 @@ function StatusIcon({ entry }: { entry: QueueEntry }) {
 /** The reviewer-facing word for a row's state, used in its accessible name (status is otherwise
  * conveyed only by an icon and color). */
 function statusLabel(entry: QueueEntry): string {
+  if (entry.status === 'iterating') return 'awaiting revision'
   if (entry.status !== 'done') return 'to review'
   if (entry.decision === 'deny') return 'denied'
   if (entry.decision === 'iterate') return 'needs iteration'
@@ -28,28 +31,39 @@ function statusLabel(entry: QueueEntry): string {
 /**
  * The left rail of the Review Queue shell: one row per queued plan with its title, the originating
  * directory (muted, so plans from different projects stay distinguishable in the one machine-wide
- * queue), and a status indicator (an open circle while pending, a filled check once reviewed). A
- * progress count summarizes how many of the queue have been decided. Pure presentation: navigation
- * and active state are owned by `QueueShell`.
+ * queue), a status indicator (open circle pending, spinning refresh awaiting revision, the verdict
+ * icon once decided), a relative timestamp, and an unseen-revision dot. The header summarizes how
+ * many plans are decided and how many are out for revision. Pure presentation: navigation and
+ * active state are owned by `QueueShell`.
  */
 export function QueueSidebar({
   entries,
   activeId,
+  unseen,
+  now,
   onSelect,
 }: {
   entries: QueueEntry[]
   activeId: string | null
+  /** Ids with a revision the reviewer has not opened yet; their rows carry an accent dot. */
+  unseen: Set<string>
+  /** The shell's ticking clock (epoch ms) the relative row timestamps are computed against. */
+  now: number
   onSelect: (id: string) => void
 }) {
   const reviewed = reviewedCount(entries)
+  const revising = revisingCount(entries)
   return (
     <aside className='vp-queue__sidebar'>
       <header className='vp-queue__head'>
         <span className='vp-queue__title'>Plans to Review</span>
         <span className='vp-queue__count'>
           {reviewed} of {entries.length} reviewed
+          {revising > 0 ? ` - ${revising} revising` : ''}
         </span>
       </header>
+      {/* Rows keep the daemon's stable insertion order on purpose: no pending-first reordering, so
+          a status change never teleports a row out from under the cursor or j/k muscle memory. */}
       <ul className='vp-queue__list'>
         {entries.map((entry, index) => {
           const done = entry.status === 'done'
@@ -60,7 +74,10 @@ export function QueueSidebar({
           const tabbable = activeId ? isActive : index === 0
           // v1 is the baseline (no chip); a re-review shows its revision so the version is visible.
           const version = entry.iteration && entry.iteration >= 2 ? `v${entry.iteration}` : null
-          const label = `${entry.title}, ${entry.dir}${version ? `, ${version}` : ''}, ${statusLabel(entry)}`
+          const isUnseen = unseen.has(entry.id)
+          // Frames from an older daemon omit updatedAt; the timestamp simply disappears then.
+          const time = entry.updatedAt !== undefined ? relativeTime(now, entry.updatedAt) : null
+          const label = `${entry.title}, ${entry.dir}${version ? `, ${version}` : ''}, ${statusLabel(entry)}${time ? `, ${time}` : ''}${isUnseen ? ', updated' : ''}`
           return (
             <li key={entry.id}>
               <button
@@ -68,6 +85,7 @@ export function QueueSidebar({
                 className='vp-queue__row'
                 data-active={isActive}
                 data-done={done}
+                data-status={entry.status}
                 data-decision={done ? entry.decision : undefined}
                 tabIndex={tabbable ? 0 : -1}
                 aria-current={isActive ? 'true' : undefined}
@@ -83,12 +101,18 @@ export function QueueSidebar({
                 <span className='vp-queue__rowtext'>
                   <span className='vp-queue__rowtitle'>{entry.title}</span>
                   <span className='vp-queue__rowdir'>{entry.dir}</span>
+                  {time && (
+                    <span className='vp-queue__time' aria-hidden='true'>
+                      {time}
+                    </span>
+                  )}
                 </span>
                 {version && (
                   <span className='vp-queue__chip' aria-hidden='true'>
                     {version}
                   </span>
                 )}
+                {isUnseen && <span className='vp-queue__dot' aria-hidden='true' />}
               </button>
             </li>
           )

--- a/packages/runtime/components/queue/logic.ts
+++ b/packages/runtime/components/queue/logic.ts
@@ -2,9 +2,10 @@ import type { QueueEntry } from '@visualplan/core'
 
 /**
  * Pure queue-navigation logic for the Review Queue shell, factored out of `QueueShell` so the
- * active-plan and selection rules are unit-testable without rendering. A plan counts as "still to
- * review" until its status is `done`; the daemon may surface a transient `active` status, which is
- * treated the same as `pending` here (not yet reviewed).
+ * active-plan and selection rules are unit-testable without rendering. A plan is a review target
+ * only while `pending` (or the daemon's transient `active`, treated the same): a `done` plan is
+ * decided, and an `iterating` one is waiting on the agent's revision, so neither is auto-advanced
+ * to. In-place revisions bump `rev`, which drives the unseen-update dots and activity flagging.
  */
 
 /** True once the daemon has resolved this plan; it is no longer a review target. */
@@ -12,20 +13,38 @@ function isDone(entry: QueueEntry): boolean {
   return entry.status === 'done'
 }
 
-/** The id of the first entry still awaiting review, or null when the whole queue is done/empty. */
+/** True while the plan awaits the reviewer: `pending` or the daemon's transient `active`. An
+ * `iterating` entry is excluded — it has nothing new to review until the revision arrives. */
+function isReviewTarget(entry: QueueEntry): boolean {
+  return entry.status === 'pending' || entry.status === 'active'
+}
+
+/** The id of the first entry still awaiting review, or null when nothing is reviewable. */
 export function firstPendingId(entries: QueueEntry[]): string | null {
-  return entries.find(e => !isDone(e))?.id ?? null
+  return entries.find(isReviewTarget)?.id ?? null
 }
 
 /**
- * The id the shell should show given the current `activeId`. The active plan stays put while it is
- * still pending; once the daemon marks it done (observed via the SSE stream) the shell auto-advances
- * to the next pending plan. An unknown active id (or none) falls back to the first pending plan.
+ * The id the shell should show after a queue frame, given the previous frame and the current
+ * `activeId`. The active plan stays put unless it transitioned to `done` in THIS frame (approve or
+ * deny), in which case the shell auto-advances to the first pending plan. Staying put deliberately
+ * covers: still pending; just flipped to `iterating` (show the waiting state); an
+ * `iterating`-to-`pending` rev bump (the iframe swaps content in place); and an entry that is
+ * `done` in both frames (viewing an already-decided plan must not get yanked to the first pending
+ * plan by an unrelated frame). No active id, or one that vanished, falls back to the first pending.
  */
-export function nextActiveId(entries: QueueEntry[], activeId: string | null): string | null {
-  const active = entries.find(e => e.id === activeId)
-  if (active && !isDone(active)) return active.id
-  return firstPendingId(entries)
+export function nextActiveId(
+  prev: QueueEntry[],
+  next: QueueEntry[],
+  activeId: string | null,
+): string | null {
+  const active = next.find(e => e.id === activeId)
+  if (active) {
+    const before = prev.find(p => p.id === activeId)
+    const becameDone = isDone(active) && !(before && isDone(before))
+    if (!becameDone) return active.id
+  }
+  return firstPendingId(next)
 }
 
 /**
@@ -51,13 +70,52 @@ export function reviewedCount(entries: QueueEntry[]): number {
 }
 
 /**
+ * Ids whose serving revision moved past what the reviewer last saw, excluding the active entry
+ * (the user is looking at it). A never-seen id defaults to a last-seen rev of 1, so a brand-new
+ * plan at rev 1 gets no dot (it reads as a normal new row, not an update) while an entry arriving
+ * already revised does.
+ */
+export function unseenRevs(
+  entries: QueueEntry[],
+  seen: ReadonlyMap<string, number>,
+  activeId: string | null,
+): Set<string> {
+  const unseen = new Set<string>()
+  for (const entry of entries) {
+    if (entry.id === activeId) continue
+    if ((entry.rev ?? 1) > (seen.get(entry.id) ?? 1)) unseen.add(entry.id)
+  }
+  return unseen
+}
+
+/** How many plans are `iterating` (verdict delivered, revision not yet re-enqueued). */
+export function revisingCount(entries: QueueEntry[]): number {
+  return entries.filter(e => e.status === 'iterating').length
+}
+
+/** A coarse relative timestamp for a sidebar row: 'just now' under a minute, then whole minutes,
+ * hours, and days. A future `thenMs` (clock skew) clamps to 'just now'. */
+export function relativeTime(nowMs: number, thenMs: number): string {
+  const minutes = Math.floor(Math.max(0, nowMs - thenMs) / 60_000)
+  if (minutes < 1) return 'just now'
+  if (minutes < 60) return `${minutes}m ago`
+  if (minutes < 24 * 60) return `${Math.floor(minutes / 60)}h ago`
+  return `${Math.floor(minutes / (24 * 60))}d ago`
+}
+
+/**
  * Whether `next` represents new queue activity versus `prev`: a plan was added (a new id) or an
- * existing plan changed status or version (a re-review). A plan only being removed is not activity
- * to flag. Used to badge the tab while it is backgrounded.
+ * existing plan changed status, version, or serving revision (an in-place re-review). A plan only
+ * being removed is not activity to flag. Used to badge the tab while it is backgrounded.
  */
 export function hasNewActivity(prev: QueueEntry[], next: QueueEntry[]): boolean {
   return next.some(entry => {
     const before = prev.find(p => p.id === entry.id)
-    return !before || before.status !== entry.status || before.iteration !== entry.iteration
+    return (
+      !before ||
+      before.status !== entry.status ||
+      before.iteration !== entry.iteration ||
+      before.rev !== entry.rev
+    )
   })
 }

--- a/packages/runtime/components/queue/queue.css
+++ b/packages/runtime/components/queue/queue.css
@@ -12,18 +12,13 @@
   font-family: var(--vp-font);
 }
 
-/* A single queued plan drops the sidebar, so the plan fills the tab like an ordinary review. */
-.vp-queue--solo {
-  grid-template-columns: 1fr;
-}
-
 .vp-queue__sidebar {
   display: flex;
   flex-direction: column;
   min-height: 0;
   border-right: 1px solid var(--vp-border);
   background: var(--vp-surface);
-  /* The rail mounts when a second plan joins (solo -> queue); ease it in rather than popping. */
+  /* Ease the rail in on mount rather than popping. */
   animation: vp-queue-sidebar-in 0.18s var(--vp-ease) both;
 }
 
@@ -140,6 +135,17 @@
   animation: vp-queue-spin 1.5s linear infinite;
 }
 
+/* An `iterating` plan is waiting on the agent's revision: same gold spinning refresh as the iterate
+ * verdict. The data-decision selector above is kept for one release as a skew fallback (an older
+ * daemon marks iterate verdicts `done` + decision instead of `iterating`). */
+.vp-queue__row[data-status="iterating"] .vp-queue__status {
+  color: var(--vp-gold);
+}
+
+.vp-queue__row[data-status="iterating"] .vp-queue__status svg {
+  animation: vp-queue-spin 1.5s linear infinite;
+}
+
 @keyframes vp-queue-spin {
   to {
     transform: rotate(360deg);
@@ -173,6 +179,29 @@
   font-family: var(--vp-mono);
   font-size: 0.64rem;
   line-height: 1.4;
+}
+
+/* Relative "Nm ago" stamp under the dir; decorative (the row aria-label carries it in words). */
+.vp-queue__time {
+  font-size: 0.66rem;
+  color: var(--vp-muted);
+}
+
+/* Unseen-revision dot: a revision landed on a row the reviewer is not looking at. Link blue, the
+ * same hue as the favicon activity dot, so "new since you looked" reads as one signal. */
+.vp-queue__dot {
+  flex: none;
+  width: 7px;
+  height: 7px;
+  margin-left: auto;
+  border-radius: 50%;
+  background: var(--vp-link);
+}
+
+/* When a version chip precedes the dot, the chip already claims the trailing edge; the grid gap
+ * spaces the dot beside it. */
+.vp-queue__chip + .vp-queue__dot {
+  margin-left: 0;
 }
 
 .vp-queue__rowdir {
@@ -221,7 +250,8 @@
   .vp-queue__row {
     transition: none;
   }
-  .vp-queue__row[data-decision="iterate"] .vp-queue__status svg {
+  .vp-queue__row[data-decision="iterate"] .vp-queue__status svg,
+  .vp-queue__row[data-status="iterating"] .vp-queue__status svg {
     animation: none;
   }
 }

--- a/packages/runtime/components/review/CommentModal.tsx
+++ b/packages/runtime/components/review/CommentModal.tsx
@@ -1,9 +1,18 @@
+import { REVIEW_SEVERITY_VALUES, type ReviewSeverity } from '@visualplan/core'
 import { IconX } from '@tabler/icons-react'
 import { useState } from 'react'
 
+/** The composer's toggle labels; the payload keeps the schema's enum values. */
+const SEVERITY_OPTION_LABEL: Record<ReviewSeverity, string> = {
+  'must-fix': 'Must fix',
+  suggestion: 'Suggestion',
+}
+
 /**
  * The bottom-of-screen composer for a single section comment. Saves on the button or Cmd/Ctrl+Enter,
- * cancels on Escape. Empty comments are not savable.
+ * cancels on Escape. Empty comments are not savable. The severity toggle defaults to untagged;
+ * clicking the selected option again deselects it (untagged is the resting state, so no third
+ * "none" control is needed).
  */
 export function CommentModal({
   section,
@@ -11,14 +20,15 @@ export function CommentModal({
   onCancel,
 }: {
   section: string
-  onSave: (body: string) => void
+  onSave: (body: string, severity?: ReviewSeverity) => void
   onCancel: () => void
 }) {
   const [body, setBody] = useState('')
+  const [severity, setSeverity] = useState<ReviewSeverity | undefined>(undefined)
   const trimmed = body.trim()
 
   const save = () => {
-    if (trimmed) onSave(trimmed)
+    if (trimmed) onSave(trimmed, severity)
   }
 
   return (
@@ -50,6 +60,19 @@ export function CommentModal({
         }}
       />
       <div className='vp-review-composer__actions'>
+        <fieldset className='vp-review-severity' aria-label='Comment severity'>
+          {REVIEW_SEVERITY_VALUES.map(value => (
+            <button
+              key={value}
+              type='button'
+              className='vp-review-severity__option'
+              aria-pressed={severity === value}
+              onClick={() => setSeverity(prev => (prev === value ? undefined : value))}
+            >
+              {SEVERITY_OPTION_LABEL[value]}
+            </button>
+          ))}
+        </fieldset>
         <button type='button' className='vp-review-btn' onClick={onCancel}>
           Cancel
         </button>

--- a/packages/runtime/components/review/CommentsPopover.tsx
+++ b/packages/runtime/components/review/CommentsPopover.tsx
@@ -1,26 +1,38 @@
+import type { ReviewSeverity } from '@visualplan/core'
 import { IconTrash, IconX } from '@tabler/icons-react'
+
+/** How a severity value reads on the small mark tooltip / popover tags. */
+export const SEVERITY_LABEL: Record<ReviewSeverity, string> = {
+  'must-fix': 'must fix',
+  suggestion: 'suggestion',
+}
 
 /** One comment shown in the popover. `quote` is set when the comment targets selected text. */
 export interface PopoverComment {
   body: string
   /** The quoted text, when this comment was made on a selection rather than the whole section. */
   quote?: string
+  /** The reviewer's severity tag, when one was chosen in the composer. */
+  severity?: ReviewSeverity
 }
 
 /**
  * A small panel listing the comments on one section, so the reviewer can see what they wrote where
- * (and remove a comment). Anchored to the section it belongs to; the caller positions it.
+ * (and remove a comment). Anchored to the section it belongs to; the caller positions it. In
+ * `readOnly` mode (after a decision) the list is view-only: no delete affordance.
  */
 export function CommentsPopover({
   label,
   comments,
   anchor,
+  readOnly,
   onDelete,
   onClose,
 }: {
   label: string
   comments: PopoverComment[]
   anchor: { top: number; left: number }
+  readOnly?: boolean
   onDelete: (index: number) => void
   onClose: () => void
 }) {
@@ -50,17 +62,24 @@ export function CommentsPopover({
           // biome-ignore lint/suspicious/noArrayIndexKey: positional list, no stable id available.
           <li key={index} className='vp-review-popover__item'>
             <div className='vp-review-popover__text'>
+              {comment.severity && (
+                <span className='vp-review-tag' data-severity={comment.severity}>
+                  {SEVERITY_LABEL[comment.severity]}
+                </span>
+              )}
               {comment.quote && <span className='vp-review-popover__quote'>“{comment.quote}”</span>}
               <span>{comment.body}</span>
             </div>
-            <button
-              type='button'
-              className='vp-review-popover__delete'
-              onClick={() => onDelete(index)}
-              aria-label='Delete comment'
-            >
-              <IconTrash size={13} />
-            </button>
+            {!readOnly && (
+              <button
+                type='button'
+                className='vp-review-popover__delete'
+                onClick={() => onDelete(index)}
+                aria-label='Delete comment'
+              >
+                <IconTrash size={13} />
+              </button>
+            )}
           </li>
         ))}
       </ul>

--- a/packages/runtime/components/review/ReviewLayer.tsx
+++ b/packages/runtime/components/review/ReviewLayer.tsx
@@ -1,8 +1,14 @@
-import type { Feedback, ReviewAnswer, ReviewComment, ReviewDecision } from '@visualplan/core'
+import type {
+  Feedback,
+  ReviewAnswer,
+  ReviewComment,
+  ReviewDecision,
+  ReviewSeverity,
+} from '@visualplan/core'
 import { IconCheck, IconMessagePlus, IconRefresh, IconX } from '@tabler/icons-react'
 import { useEffect, useRef, useState } from 'react'
 import { CommentModal } from './CommentModal.js'
-import { CommentsPopover } from './CommentsPopover.js'
+import { CommentsPopover, SEVERITY_LABEL } from './CommentsPopover.js'
 import { DecisionBar } from './DecisionBar.js'
 import {
   isQueueMode,
@@ -29,6 +35,7 @@ interface DraftComment {
   sectionIndex: number
   label: string
   body: string
+  severity?: ReviewSeverity
   quote?: string
   range?: Range
 }
@@ -69,6 +76,7 @@ function ReviewSession() {
   const [busy, setBusy] = useState(false)
   const [hoveredMark, setHoveredMark] = useState<{
     body: string
+    severity?: ReviewSeverity
     top: number
     left: number
   } | null>(null)
@@ -78,10 +86,12 @@ function ReviewSession() {
   const questionAnswers = useQuestionAnswers()
 
   // A selection comment is sent under its quote so the agent can locate the exact text; a section
-  // comment is sent under the section label.
+  // comment is sent under the section label. An untagged severity stays `undefined`, which
+  // JSON.stringify drops, so old daemons never see the key.
   const payloadComments: ReviewComment[] = comments.map(c => ({
     section: c.quote ?? c.label,
     body: c.body,
+    severity: c.severity,
   }))
   // Answered questions (those with non-blank text) ride the distinct `answers` channel, keyed by the
   // question so the agent maps each back to the plan's `Questions`.
@@ -107,7 +117,11 @@ function ReviewSession() {
   const answersMap = questionAnswers?.answers
   useEffect(() => {
     if (!submitted && !isReviewDemo()) {
-      const draft = comments.map(c => ({ section: c.quote ?? c.label, body: c.body }))
+      const draft = comments.map(c => ({
+        section: c.quote ?? c.label,
+        body: c.body,
+        severity: c.severity,
+      }))
       postDraft({
         decision: 'deny',
         comments: draft,
@@ -136,12 +150,19 @@ function ReviewSession() {
     return () => window.removeEventListener('beforeunload', onBeforeUnload)
   }, [])
 
-  const addComment = (body: string) => {
+  const addComment = (body: string, severity?: ReviewSeverity) => {
     if (composing) {
       const t = composing
       setComments(prev => [
         ...prev,
-        { sectionIndex: t.sectionIndex, label: t.label, body, quote: t.quote, range: t.range },
+        {
+          sectionIndex: t.sectionIndex,
+          label: t.label,
+          body,
+          severity,
+          quote: t.quote,
+          range: t.range,
+        },
       ])
     }
     setComposing(null)
@@ -206,13 +227,17 @@ function ReviewSession() {
     }
   }
 
-  if (submitted)
-    return <SubmittedNotice decision={submitted} demo={isReviewDemo()} queue={isQueueMode()} />
+  // After a decision the session turns read-only: the marks and badges stay visible (the reviewer
+  // can still see what they flagged, and in the queue's iterate wait the plan stays on screen), but
+  // the composer, selection button, delete affordances, and DecisionBar are suppressed.
+  // Known limitation (deliberately descoped): navigating away and back while iterating remounts the
+  // iframe and loses these in-page comment marks; the daemon reinjects only the decision + answers.
+  const readOnly = submitted !== null
 
   const viewingComments = viewing
     ? comments
         .filter(comment => comment.sectionIndex === viewing.index)
-        .map(c => ({ body: c.body, quote: c.quote }))
+        .map(c => ({ body: c.body, quote: c.quote, severity: c.severity }))
     : []
   const viewingRect = viewing?.element.getBoundingClientRect()
   const selectionRect = selection?.range.getBoundingClientRect()
@@ -231,10 +256,22 @@ function ReviewSession() {
                 className='vp-review-quote-mark'
                 style={{ top: r.top, left: r.left, width: r.width, height: r.height }}
                 onMouseEnter={() =>
-                  setHoveredMark({ body: comment.body, top: r.top, left: r.left })
+                  setHoveredMark({
+                    body: comment.body,
+                    severity: comment.severity,
+                    top: r.top,
+                    left: r.left,
+                  })
                 }
                 onMouseLeave={() => setHoveredMark(null)}
-                onFocus={() => setHoveredMark({ body: comment.body, top: r.top, left: r.left })}
+                onFocus={() =>
+                  setHoveredMark({
+                    body: comment.body,
+                    severity: comment.severity,
+                    top: r.top,
+                    left: r.left,
+                  })
+                }
                 onBlur={() => setHoveredMark(null)}
                 onClick={() => {
                   const section = sections[comment.sectionIndex]
@@ -256,6 +293,11 @@ function ReviewSession() {
             left: Math.min(hoveredMark.left, window.innerWidth - 360),
           }}
         >
+          {hoveredMark.severity && (
+            <span className='vp-review-tag' data-severity={hoveredMark.severity}>
+              {SEVERITY_LABEL[hoveredMark.severity]}
+            </span>
+          )}
           {hoveredMark.body}
         </div>
       )}
@@ -287,7 +329,7 @@ function ReviewSession() {
           <IconMessagePlus size={14} /> Comment
         </button>
       )}
-      {composing && (
+      {!readOnly && composing && (
         <CommentModal
           section={composing.quote ?? composing.label}
           onSave={addComment}
@@ -299,18 +341,23 @@ function ReviewSession() {
           label={viewing.label}
           comments={viewingComments}
           anchor={{ top: viewingRect.top, left: Math.max(viewingRect.left - 34, 8) }}
+          readOnly={readOnly}
           onDelete={index => deleteComment(viewing.index, index)}
           onClose={() => setViewing(null)}
         />
       )}
-      <DecisionBar
-        commentCount={comments.length}
-        answerCount={payloadAnswers.length}
-        note={note}
-        onNote={setNote}
-        onDecide={decide}
-        busy={busy}
-      />
+      {readOnly && submitted ? (
+        <SubmittedNotice decision={submitted} demo={isReviewDemo()} queue={isQueueMode()} />
+      ) : (
+        <DecisionBar
+          commentCount={comments.length}
+          answerCount={payloadAnswers.length}
+          note={note}
+          onNote={setNote}
+          onDecide={decide}
+          busy={busy}
+        />
+      )}
     </>
   )
 }
@@ -338,14 +385,23 @@ function SubmittedNotice({
   queue?: boolean
 }) {
   const Icon = decision === 'deny' ? IconX : decision === 'iterate' ? IconRefresh : IconCheck
+  // A queue-mode iterate means the daemon holds this slot (status 'iterating') until the agent
+  // re-enqueues the revised plan into the same iframe, so the notice reads as an in-progress wait.
+  // This covers both paths here: a live Iterate click and a re-opened plan whose injected
+  // `__VP_REVIEW_DECIDED__` seeded `submitted`.
+  const waiting = queue === true && decision === 'iterate' && !demo
   return (
     <div className='vp-review-done' data-decision={decision}>
-      <Icon size={18} />
+      <Icon size={18} className={waiting ? 'vp-review-done__spin' : undefined} />
       <span>
         {demo ? (
           <>
             Demo: this would return <strong>{decision}</strong> to your agent. Press Reset to try
             again.
+          </>
+        ) : waiting ? (
+          <>
+            <strong>{DECISION_LABEL[decision]}</strong>. Waiting for the revised plan...
           </>
         ) : queue ? (
           <strong>{DECISION_LABEL[decision]}</strong>

--- a/packages/runtime/components/review/review.css
+++ b/packages/runtime/components/review/review.css
@@ -381,8 +381,62 @@
 .vp-review-composer__actions {
   display: flex;
   gap: 0.5rem;
+  align-items: center;
   justify-content: flex-end;
   margin-top: 0.6rem;
+}
+
+/* The optional severity toggle: two pill options, untagged when neither is pressed. Monochrome
+   like the rest of the chrome; the pressed state reads by fill and border, not hue. A fieldset
+   for the a11y grouping, so its default chrome is reset. */
+.vp-review-severity {
+  display: inline-flex;
+  gap: 0.3rem;
+  margin: 0;
+  margin-right: auto;
+  padding: 0;
+  border: none;
+}
+
+.vp-review-severity__option {
+  padding: 0.25rem 0.6rem;
+  font: inherit;
+  font-size: 0.76rem;
+  font-weight: 550;
+  color: var(--vp-muted);
+  background: var(--vp-bg);
+  border: 1px solid var(--vp-border);
+  border-radius: 999px;
+  cursor: pointer;
+}
+
+.vp-review-severity__option:hover {
+  color: var(--vp-text);
+  border-color: var(--vp-border-strong);
+}
+
+.vp-review-severity__option[aria-pressed="true"] {
+  color: var(--vp-text);
+  background: var(--vp-surface-2);
+  border-color: var(--vp-border-strong);
+}
+
+/* The small severity tag shown beside a tagged comment in the popover listing and mark tooltip. */
+.vp-review-tag {
+  align-self: flex-start;
+  padding: 0.05rem 0.4rem;
+  font-size: 0.64rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--vp-muted);
+  border: 1px solid var(--vp-border);
+  border-radius: 999px;
+}
+
+.vp-review-tip .vp-review-tag {
+  display: inline-block;
+  margin-right: 0.35rem;
 }
 
 .vp-review-btn {
@@ -441,4 +495,23 @@
 
 .vp-review-done strong {
   text-transform: capitalize;
+}
+
+/* The queue-mode iterate notice spins its refresh icon to read as waiting for the revised plan.
+   Same timing as the queue sidebar's vp-queue-spin; duplicated because the plan iframe never loads
+   queue.css. */
+.vp-review-done__spin {
+  animation: vp-review-spin 1.5s linear infinite;
+}
+
+@keyframes vp-review-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .vp-review-done__spin {
+    animation: none;
+  }
 }

--- a/packages/runtime/tests/components.test.tsx
+++ b/packages/runtime/tests/components.test.tsx
@@ -1,5 +1,7 @@
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
 import { renderToStaticMarkup } from 'react-dom/server'
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { Callout } from '../components/Callout.js'
 import { Chart } from '../components/Chart.js'
 import { Checklist } from '../components/Checklist.js'
@@ -10,6 +12,7 @@ import { Matrix } from '../components/Matrix.js'
 import { Phase } from '../components/Phase.js'
 import { Questions } from '../components/Questions.js'
 import { ReviewAnswersProvider } from '../components/review/ReviewAnswers.js'
+import { ReviewLayer } from '../components/review/ReviewLayer.js'
 import { copyText, ShareButton } from '../components/ShareButton.js'
 import { Stat } from '../components/Stat.js'
 import { ThemeToggle } from '../components/ThemeToggle.js'
@@ -275,6 +278,153 @@ describe('Questions in review mode', () => {
       </ReviewAnswersProvider>,
     )
     expect(html).not.toContain('vp-questions__answer')
+  })
+})
+
+describe('Questions with multiple-choice options', () => {
+  function setReviewMode(on: boolean): void {
+    ;(globalThis as { __VP_REVIEW__?: boolean }).__VP_REVIEW__ = on || undefined
+  }
+  afterEach(() => setReviewMode(false))
+
+  const optioned = [
+    { text: 'Rotate refresh tokens?', options: ['Yes, every use', 'Only after 24h'] },
+    { text: 'TTL ok?', options: [] },
+  ]
+
+  it('renders options as a radio group plus an Other field in review mode (golden)', () => {
+    setReviewMode(true)
+    const html = renderToStaticMarkup(
+      <ReviewAnswersProvider>
+        <Questions items={optioned} />
+      </ReviewAnswersProvider>,
+    )
+    expect(html).toContain('role="radiogroup"')
+    expect((html.match(/type="radio"/g) || []).length).toBe(2)
+    expect(html).toContain('Yes, every use')
+    expect(html).toContain('Only after 24h')
+    // Both the option question (its Other field) and the free-text question stay answerable.
+    expect((html.match(/vp-questions__answer/g) || []).length).toBe(2)
+  })
+
+  it('renders options as a plain list, not radios, outside review mode (edge)', () => {
+    setReviewMode(false)
+    const html = renderToStaticMarkup(<Questions items={optioned} />)
+    expect(html).toContain('Yes, every use')
+    expect(html).toContain('Only after 24h')
+    expect(html).not.toContain('type="radio"')
+    expect(html).not.toContain('vp-questions__answer')
+  })
+})
+
+describe('Questions option selection feeding the feedback payload', () => {
+  type G = { __VP_REVIEW__?: boolean; __VP_REVIEW_PLAN_ID__?: string }
+  let container: HTMLDivElement
+  let root: Root
+  let fetchMock: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    ;(globalThis as G).__VP_REVIEW__ = true
+    // Queue mode keeps ReviewLayer off the standalone keepalive/close paths in this jsdom test.
+    ;(globalThis as G).__VP_REVIEW_PLAN_ID__ = 'plan-1'
+    container = document.createElement('div')
+    container.className = 'vp-main'
+    document.body.appendChild(container)
+    fetchMock = vi.fn().mockResolvedValue({ ok: true })
+    vi.stubGlobal('fetch', fetchMock)
+  })
+
+  afterEach(() => {
+    act(() => root?.unmount())
+    container.remove()
+    ;(globalThis as G).__VP_REVIEW__ = undefined
+    ;(globalThis as G).__VP_REVIEW_PLAN_ID__ = undefined
+    vi.restoreAllMocks()
+  })
+
+  function mountPlan(): void {
+    root = createRoot(container)
+    act(() =>
+      root.render(
+        <ReviewAnswersProvider>
+          <Questions
+            items={[
+              { text: 'Rotate refresh tokens?', options: ['Yes, every use', 'Only after 24h'] },
+              'Is a 15-minute TTL acceptable?',
+            ]}
+          />
+          <ReviewLayer />
+        </ReviewAnswersProvider>,
+      ),
+    )
+  }
+
+  function radioFor(option: string): HTMLInputElement {
+    const input = Array.from(
+      container.querySelectorAll<HTMLInputElement>('input[type="radio"]'),
+    ).find(radio => radio.value === option)
+    if (!input) throw new Error(`radio for "${option}" not found`)
+    return input
+  }
+
+  function otherField(): HTMLTextAreaElement {
+    const field = container.querySelector<HTMLTextAreaElement>('.vp-questions__answer')
+    if (!field) throw new Error('Other field not found')
+    return field
+  }
+
+  function typeOther(text: string): void {
+    const field = otherField()
+    const setter = Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype, 'value')?.set
+    act(() => {
+      setter?.call(field, text)
+      field.dispatchEvent(new Event('input', { bubbles: true }))
+    })
+  }
+
+  async function approve(): Promise<unknown> {
+    const button = Array.from(container.querySelectorAll('button')).find(
+      b => b.textContent?.trim() === 'Approve',
+    )
+    if (!button) throw new Error('Approve button not found')
+    await act(async () => {
+      button.click()
+    })
+    const call = fetchMock.mock.calls.find(c => String(c[0]) === '/__vp_feedback')
+    if (!call) throw new Error('no feedback POST')
+    return JSON.parse((call[1] as RequestInit).body as string)
+  }
+
+  it('sends a clicked option as the answer string in the feedback payload (golden)', async () => {
+    mountPlan()
+    act(() => {
+      radioFor('Yes, every use').click()
+    })
+    const body = (await approve()) as { answers: unknown }
+    expect(body.answers).toEqual([{ question: 'Rotate refresh tokens?', answer: 'Yes, every use' }])
+  })
+
+  it('lets a typed Other answer override the selected option (golden)', async () => {
+    mountPlan()
+    act(() => {
+      radioFor('Only after 24h').click()
+    })
+    typeOther('Rotate only on suspicious activity')
+    expect(radioFor('Only after 24h').checked).toBe(false)
+    const body = (await approve()) as { answers: unknown }
+    expect(body.answers).toEqual([
+      { question: 'Rotate refresh tokens?', answer: 'Rotate only on suspicious activity' },
+    ])
+  })
+
+  it('clears the Other text when an option is picked after typing (edge)', () => {
+    mountPlan()
+    typeOther('half-baked custom answer')
+    act(() => {
+      radioFor('Yes, every use').click()
+    })
+    expect(otherField().value).toBe('')
+    expect(radioFor('Yes, every use').checked).toBe(true)
   })
 })
 

--- a/packages/runtime/tests/queue-review-layer.test.tsx
+++ b/packages/runtime/tests/queue-review-layer.test.tsx
@@ -45,12 +45,28 @@ function fetchedUrls(): string[] {
 
 /** Drive an Approve click through the rendered decision bar. */
 async function clickApprove(): Promise<void> {
-  const approve = Array.from(container.querySelectorAll('button')).find(
-    b => b.textContent?.trim() === 'Approve',
+  await clickDecision('Approve')
+}
+
+/** Drive a decision-bar button click by its label. */
+async function clickDecision(label: string): Promise<void> {
+  const button = Array.from(container.querySelectorAll('button')).find(
+    b => b.textContent?.trim() === label,
   )
-  if (!approve) throw new Error('Approve button not found')
+  if (!button) throw new Error(`${label} button not found`)
   await act(async () => {
-    approve.click()
+    button.click()
+  })
+}
+
+/** Type into the decision bar's note field (Iterate is disabled until some feedback exists). */
+function typeNote(text: string): void {
+  const input = container.querySelector<HTMLInputElement>('.vp-review-bar__note')
+  if (!input) throw new Error('note input not found')
+  const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')?.set
+  act(() => {
+    setter?.call(input, text)
+    input.dispatchEvent(new Event('input', { bubbles: true }))
   })
 }
 
@@ -95,6 +111,46 @@ describe('ReviewLayer queue mode', () => {
     expect(buttonLabels).not.toContain('Approve')
     expect(container.textContent).toContain('Denied')
     expect(container.textContent).not.toContain('close this tab')
+  })
+
+  it('shows the waiting-for-revision notice after a live Iterate in queue mode (golden)', async () => {
+    setReview('plan-7')
+    root = createRoot(container)
+    act(() => root.render(<ReviewLayer />))
+    typeNote('tighten the rollout phase')
+    await clickDecision('Iterate')
+    expect(container.textContent).toContain('Waiting for the revised plan')
+    expect(container.querySelector('.vp-review-done__spin')).not.toBeNull()
+  })
+
+  it('shows the same waiting notice when re-opening a plan decided iterate (golden)', () => {
+    setReview('plan-7')
+    ;(globalThis as ReviewGlobal).__VP_REVIEW_DECIDED__ = 'iterate'
+    root = createRoot(container)
+    act(() => root.render(<ReviewLayer />))
+    expect(container.textContent).toContain('Waiting for the revised plan')
+    expect(container.querySelector('.vp-review-done__spin')).not.toBeNull()
+  })
+
+  it('keeps the plain decided notice for Approve in queue mode (edge)', async () => {
+    setReview('plan-7')
+    root = createRoot(container)
+    act(() => root.render(<ReviewLayer />))
+    await clickApprove()
+    expect(container.textContent).toContain('Approved')
+    expect(container.textContent).not.toContain('Waiting for the revised plan')
+    expect(container.querySelector('.vp-review-done__spin')).toBeNull()
+  })
+
+  it('keeps the standalone notice for Iterate outside queue mode (edge)', async () => {
+    setReview(undefined)
+    root = createRoot(container)
+    act(() => root.render(<ReviewLayer />))
+    typeNote('tighten the rollout phase')
+    await clickDecision('Iterate')
+    expect(container.textContent).toContain('close this tab')
+    expect(container.textContent).not.toContain('Waiting for the revised plan')
+    expect(container.querySelector('.vp-review-done__spin')).toBeNull()
   })
 
   it('still says to close the tab after submit in standalone mode (error)', async () => {

--- a/packages/runtime/tests/queue-shell-logic.test.ts
+++ b/packages/runtime/tests/queue-shell-logic.test.ts
@@ -5,11 +5,14 @@ import {
   hasNewActivity,
   moveSelection,
   nextActiveId,
+  relativeTime,
   reviewedCount,
+  revisingCount,
+  unseenRevs,
 } from '../components/queue/logic.js'
 
-function entry(id: string, status: QueueEntry['status'] = 'pending'): QueueEntry {
-  return { id, title: `Plan ${id}`, dir: 'proj', status }
+function entry(id: string, status: QueueEntry['status'] = 'pending', rev = 1): QueueEntry {
+  return { id, title: `Plan ${id}`, dir: 'proj', status, rev }
 }
 
 describe('firstPendingId', () => {
@@ -17,8 +20,16 @@ describe('firstPendingId', () => {
     expect(firstPendingId([entry('a', 'done'), entry('b'), entry('c')])).toBe('b')
   })
 
+  it('skips an iterating entry, which has nothing new to review yet (golden)', () => {
+    expect(firstPendingId([entry('a', 'iterating'), entry('b'), entry('c')])).toBe('b')
+  })
+
   it('returns null when every entry is done (edge)', () => {
     expect(firstPendingId([entry('a', 'done'), entry('b', 'done')])).toBeNull()
+  })
+
+  it('returns null when the only entries are iterating or done (edge)', () => {
+    expect(firstPendingId([entry('a', 'iterating'), entry('b', 'done')])).toBeNull()
   })
 
   it('returns null for an empty queue (error)', () => {
@@ -26,25 +37,51 @@ describe('firstPendingId', () => {
   })
 })
 
-describe('nextActiveId: auto-advance when the active plan finishes', () => {
+describe('nextActiveId: prev-aware auto-advance', () => {
   it('keeps the active id while it is still pending (golden)', () => {
-    const entries = [entry('a'), entry('b')]
-    expect(nextActiveId(entries, 'a')).toBe('a')
+    const prev = [entry('a'), entry('b')]
+    const next = [entry('a'), entry('b')]
+    expect(nextActiveId(prev, next, 'a')).toBe('a')
   })
 
-  it('advances to the next pending plan once the active one is done (golden)', () => {
-    const entries = [entry('a', 'done'), entry('b'), entry('c')]
-    expect(nextActiveId(entries, 'a')).toBe('b')
+  it('advances to the next pending plan on the frame the active one turns done (golden)', () => {
+    const prev = [entry('a'), entry('b'), entry('c')]
+    const next = [entry('a', 'done'), entry('b'), entry('c')]
+    expect(nextActiveId(prev, next, 'a')).toBe('b')
+  })
+
+  it('stays on the active plan when it flips to iterating (golden)', () => {
+    const prev = [entry('a'), entry('b')]
+    const next = [entry('a', 'iterating'), entry('b')]
+    expect(nextActiveId(prev, next, 'a')).toBe('a')
+  })
+
+  it('stays across an iterating-to-pending rev bump (golden)', () => {
+    const prev = [entry('a', 'iterating', 1), entry('b')]
+    const next = [entry('a', 'pending', 2), entry('b')]
+    expect(nextActiveId(prev, next, 'a')).toBe('a')
+  })
+
+  it('does not yank the user off a manually selected done plan on an unrelated frame (edge)', () => {
+    const prev = [entry('a', 'done'), entry('b')]
+    const next = [entry('a', 'done'), entry('b'), entry('c')]
+    expect(nextActiveId(prev, next, 'a')).toBe('a')
   })
 
   it('returns null when the active plan was the last pending one (edge)', () => {
-    const entries = [entry('a', 'done'), entry('b', 'done')]
-    expect(nextActiveId(entries, 'b')).toBeNull()
+    const prev = [entry('a', 'done'), entry('b')]
+    const next = [entry('a', 'done'), entry('b', 'done')]
+    expect(nextActiveId(prev, next, 'b')).toBeNull()
   })
 
-  it('falls back to the first pending when the active id is unknown (error)', () => {
-    const entries = [entry('a', 'done'), entry('b')]
-    expect(nextActiveId(entries, 'gone')).toBe('b')
+  it('falls back to the first pending when the active id vanished (error)', () => {
+    const prev = [entry('gone'), entry('a', 'done'), entry('b')]
+    const next = [entry('a', 'done'), entry('b')]
+    expect(nextActiveId(prev, next, 'gone')).toBe('b')
+  })
+
+  it('falls back to the first pending when nothing is active (error)', () => {
+    expect(nextActiveId([], [entry('a')], null)).toBe('a')
   })
 })
 
@@ -90,6 +127,75 @@ describe('reviewedCount', () => {
   })
 })
 
+describe('relativeTime', () => {
+  const MIN = 60_000
+  const HOUR = 60 * MIN
+  const DAY = 24 * HOUR
+
+  it('reports under a minute as just now (golden)', () => {
+    expect(relativeTime(100_000, 100_000 - 30_000)).toBe('just now')
+  })
+
+  it('reports whole minutes, hours, and days (golden)', () => {
+    expect(relativeTime(DAY * 10, DAY * 10 - 5 * MIN)).toBe('5m ago')
+    expect(relativeTime(DAY * 10, DAY * 10 - 3 * HOUR)).toBe('3h ago')
+    expect(relativeTime(DAY * 10, DAY * 10 - 2 * DAY)).toBe('2d ago')
+  })
+
+  it('rolls over exactly at each bucket boundary (edge)', () => {
+    expect(relativeTime(DAY * 10, DAY * 10 - MIN)).toBe('1m ago')
+    expect(relativeTime(DAY * 10, DAY * 10 - HOUR)).toBe('1h ago')
+    expect(relativeTime(DAY * 10, DAY * 10 - DAY)).toBe('1d ago')
+  })
+
+  it('treats a future timestamp (clock skew) as just now (error)', () => {
+    expect(relativeTime(100_000, 200_000)).toBe('just now')
+  })
+})
+
+describe('unseenRevs', () => {
+  it('flags an entry whose rev moved past the last-seen rev (golden)', () => {
+    const seen = new Map([['a', 1]])
+    expect(unseenRevs([entry('a', 'pending', 2)], seen, null)).toEqual(new Set(['a']))
+  })
+
+  it('never flags the active entry: the user is looking at it (golden)', () => {
+    const seen = new Map([['a', 1]])
+    expect(unseenRevs([entry('a', 'pending', 2)], seen, 'a')).toEqual(new Set())
+  })
+
+  it('does not flag a never-seen entry at rev 1: it is a brand-new row, not an update (edge)', () => {
+    expect(unseenRevs([entry('a')], new Map(), null)).toEqual(new Set())
+  })
+
+  it('flags a never-seen entry already past rev 1 (edge)', () => {
+    expect(unseenRevs([entry('a', 'pending', 2)], new Map(), null)).toEqual(new Set(['a']))
+  })
+
+  it('does not flag an entry at its last-seen rev (edge)', () => {
+    const seen = new Map([['a', 2]])
+    expect(unseenRevs([entry('a', 'pending', 2)], seen, null)).toEqual(new Set())
+  })
+
+  it('returns an empty set for an empty queue (error)', () => {
+    expect(unseenRevs([], new Map(), null)).toEqual(new Set())
+  })
+})
+
+describe('revisingCount', () => {
+  it('counts iterating entries (golden)', () => {
+    expect(revisingCount([entry('a', 'iterating'), entry('b'), entry('c', 'iterating')])).toBe(2)
+  })
+
+  it('is zero when nothing is iterating (edge)', () => {
+    expect(revisingCount([entry('a'), entry('b', 'done')])).toBe(0)
+  })
+
+  it('is zero for an empty queue (error)', () => {
+    expect(revisingCount([])).toBe(0)
+  })
+})
+
 describe('hasNewActivity', () => {
   const at = (
     id: string,
@@ -113,6 +219,12 @@ describe('hasNewActivity', () => {
 
   it('flags a version bump on a requeued plan (golden)', () => {
     expect(hasNewActivity([at('a', 'pending', 2)], [at('a', 'pending', 3)])).toBe(true)
+  })
+
+  it('flags a rev bump on an in-place revision (golden)', () => {
+    const before = { ...at('a', 'pending'), rev: 1 }
+    const after = { ...at('a', 'pending'), rev: 2 }
+    expect(hasNewActivity([before], [after])).toBe(true)
   })
 
   it('does not flag an unchanged queue (edge)', () => {

--- a/packages/runtime/tests/queue-shell.test.tsx
+++ b/packages/runtime/tests/queue-shell.test.tsx
@@ -101,15 +101,15 @@ describe('QueueShell', () => {
   it('defaults the active iframe to the first pending plan (golden)', () => {
     render()
     act(() => source().emitQueue([entry('a', 'done'), entry('b'), entry('c')]))
-    expect(iframeSrc()).toBe('/plan/b')
+    expect(iframeSrc()).toBe('/plan/b?rev=1')
   })
 
   it('auto-advances the iframe when the active plan is marked done (golden)', () => {
     render()
     act(() => source().emitQueue([entry('a'), entry('b')]))
-    expect(iframeSrc()).toBe('/plan/a')
+    expect(iframeSrc()).toBe('/plan/a?rev=1')
     act(() => source().emitQueue([entry('a', 'done'), entry('b')]))
-    expect(iframeSrc()).toBe('/plan/b')
+    expect(iframeSrc()).toBe('/plan/b?rev=1')
   })
 
   it('shows an all-reviewed empty state when every plan is done (edge)', () => {
@@ -131,7 +131,7 @@ describe('QueueShell', () => {
     expect(container.querySelector('iframe')).toBeNull()
     // Clicking a decided row loads it (the daemon serves it locked into its verdict).
     act(() => container.querySelector<HTMLButtonElement>('.vp-queue__row')?.click())
-    expect(iframeSrc()).toBe('/plan/a')
+    expect(iframeSrc()).toBe('/plan/a?rev=1')
   })
 
   it('shows a progress count of reviewed plans (edge)', () => {
@@ -143,11 +143,11 @@ describe('QueueShell', () => {
   it('moves the active plan with the j key (golden)', () => {
     render()
     act(() => source().emitQueue([entry('a'), entry('b'), entry('c')]))
-    expect(iframeSrc()).toBe('/plan/a')
+    expect(iframeSrc()).toBe('/plan/a?rev=1')
     act(() => {
       window.dispatchEvent(new KeyboardEvent('keydown', { key: 'j' }))
     })
-    expect(iframeSrc()).toBe('/plan/b')
+    expect(iframeSrc()).toBe('/plan/b?rev=1')
   })
 
   it('closes the events stream on unmount (error)', () => {
@@ -158,32 +158,231 @@ describe('QueueShell', () => {
   })
 })
 
-// The queue chrome is for navigating BETWEEN plans, so a lone plan should look like an ordinary
-// single review (no sidebar); the sidebar appears only once a second plan is in the queue.
-describe('QueueShell single-plan vs queue', () => {
-  it('hides the sidebar and shows the plan full-width when only one plan is queued (golden)', () => {
+// In-place revisions reuse the plan id; the iframe is keyed and cache-busted by `rev` so a revised
+// plan remounts with fresh content while an unchanged rev keeps the same mounted frame.
+describe('QueueShell iframe revision keying', () => {
+  it('remounts the iframe with the new rev in its src when a revision arrives (golden)', () => {
     render()
-    act(() => source().emitQueue([entry('a')]))
-    expect(sidebar()).toBeNull()
-    // The single plan still renders; it just has no queue rail beside it.
-    expect(iframeSrc()).toBe('/plan/a')
+    act(() => source().emitQueue([entry('a', 'pending', { rev: 1 })]))
+    expect(iframeSrc()).toBe('/plan/a?rev=1')
+    act(() => source().emitQueue([entry('a', 'pending', { rev: 2 })]))
+    expect(iframeSrc()).toBe('/plan/a?rev=2')
   })
 
-  it('reveals the sidebar when a second plan joins the queue mid-review (golden)', () => {
+  it('keeps the same mounted iframe across frames while the rev is unchanged (edge)', () => {
     render()
-    act(() => source().emitQueue([entry('a')]))
-    expect(sidebar()).toBeNull()
-    act(() => source().emitQueue([entry('a'), entry('b')]))
-    expect(sidebar()).not.toBeNull()
+    act(() => source().emitQueue([entry('a', 'pending', { rev: 1 })]))
+    const frame = container.querySelector('iframe')
+    act(() => source().emitQueue([entry('a', 'pending', { rev: 1 }), entry('b')]))
+    expect(container.querySelector('iframe')).toBe(frame)
   })
 
-  it('hides the sidebar again if the queue drops back to a single plan (edge)', () => {
+  it('stays on an active plan that flips to iterating, iframe still mounted (golden)', () => {
+    render()
+    act(() => source().emitQueue([entry('a', 'pending', { rev: 1 })]))
+    const frame = container.querySelector('iframe')
+    act(() => source().emitQueue([entry('a', 'iterating', { rev: 1 })]))
+    // No auto-advance and no "All plans reviewed" empty state: the reviewer waits in place.
+    expect(container.querySelector('iframe')).toBe(frame)
+    expect(container.textContent ?? '').not.toContain('All plans reviewed')
+  })
+})
+
+// A background entry's in-place revision raises a small accent dot on its row (never a focus
+// steal); viewing the row marks the revision seen and clears the dot.
+describe('QueueShell unseen revision dots', () => {
+  function rowFor(title: string): HTMLButtonElement | null {
+    return (
+      Array.from(container.querySelectorAll<HTMLButtonElement>('.vp-queue__row')).find(r =>
+        (r.getAttribute('aria-label') ?? '').startsWith(title),
+      ) ?? null
+    )
+  }
+
+  it('dots a background entry when its revision arrives (golden)', () => {
+    render()
+    act(() => source().emitQueue([entry('a'), entry('b')]))
+    act(() => source().emitQueue([entry('a'), entry('b', 'pending', { rev: 2 })]))
+    const row = rowFor('Plan b')
+    expect(row?.querySelector('.vp-queue__dot')).not.toBeNull()
+    expect(row?.getAttribute('aria-label')).toContain('updated')
+  })
+
+  it('clears the dot once the updated entry is selected (golden)', () => {
+    render()
+    act(() => source().emitQueue([entry('a'), entry('b')]))
+    act(() => source().emitQueue([entry('a'), entry('b', 'pending', { rev: 2 })]))
+    act(() => rowFor('Plan b')?.click())
+    expect(rowFor('Plan b')?.querySelector('.vp-queue__dot')).toBeNull()
+  })
+
+  it('never dots the active entry on its own revision (edge)', () => {
+    render()
+    act(() => source().emitQueue([entry('a'), entry('b')]))
+    act(() => source().emitQueue([entry('a', 'pending', { rev: 2 }), entry('b')]))
+    expect(rowFor('Plan a')?.querySelector('.vp-queue__dot')).toBeNull()
+  })
+
+  it('does not dot brand-new rows arriving at rev 1 (edge)', () => {
+    render()
+    act(() => source().emitQueue([entry('a'), entry('b')]))
+    expect(container.querySelector('.vp-queue__dot')).toBeNull()
+  })
+})
+
+// The daemon distinguishes a real unload (short deny grace) from a silent socket drop (long grace)
+// by this beacon; it fires unconditionally because a reload's SSE reconnect cancels the short grace.
+describe('QueueShell close beacon', () => {
+  afterEach(() => {
+    Reflect.deleteProperty(window.navigator, 'sendBeacon')
+  })
+
+  it('notifies the daemon via sendBeacon on pagehide (golden)', () => {
+    const beacon = vi.fn(() => true)
+    Object.defineProperty(window.navigator, 'sendBeacon', { value: beacon, configurable: true })
+    render()
+    act(() => {
+      window.dispatchEvent(new Event('pagehide'))
+    })
+    expect(beacon).toHaveBeenCalledWith('/__vp_shell_closed')
+  })
+
+  it('survives pagehide when sendBeacon is unavailable (error)', () => {
+    render()
+    expect(() =>
+      act(() => {
+        window.dispatchEvent(new Event('pagehide'))
+      }),
+    ).not.toThrow()
+  })
+
+  it('stops firing after unmount (edge)', () => {
+    const beacon = vi.fn(() => true)
+    Object.defineProperty(window.navigator, 'sendBeacon', { value: beacon, configurable: true })
+    render()
+    act(() => root.unmount())
+    window.dispatchEvent(new Event('pagehide'))
+    expect(beacon).not.toHaveBeenCalled()
+  })
+})
+
+// Closing the tab with undecided plans denies them, so the user gets a native confirm; decided and
+// iterating plans are already resolved to their callers and must not block a close.
+describe('QueueShell beforeunload guard', () => {
+  function fireBeforeUnload(): Event {
+    const event = new Event('beforeunload', { cancelable: true })
+    act(() => {
+      window.dispatchEvent(event)
+    })
+    return event
+  }
+
+  it('prevents the unload while an undecided plan is pending (golden)', () => {
+    render()
+    act(() => source().emitQueue([entry('a'), entry('b', 'done')]))
+    expect(fireBeforeUnload().defaultPrevented).toBe(true)
+  })
+
+  it('lets the unload proceed when every plan is done or iterating (golden)', () => {
+    render()
+    act(() => source().emitQueue([entry('a', 'done'), entry('b', 'iterating')]))
+    expect(fireBeforeUnload().defaultPrevented).toBe(false)
+  })
+
+  it('lets the unload proceed for an empty queue (edge)', () => {
+    render()
+    expect(fireBeforeUnload().defaultPrevented).toBe(false)
+  })
+})
+
+describe('QueueShell revising count', () => {
+  it('appends the revising count to the sidebar header when plans are iterating (golden)', () => {
+    render()
+    act(() => source().emitQueue([entry('a', 'done'), entry('b', 'iterating'), entry('c')]))
+    expect(container.querySelector('.vp-queue__count')?.textContent).toBe(
+      '1 of 3 reviewed - 1 revising',
+    )
+  })
+
+  it('omits the revising suffix when nothing is iterating (edge)', () => {
+    render()
+    act(() => source().emitQueue([entry('a', 'done'), entry('b')]))
+    expect(container.querySelector('.vp-queue__count')?.textContent).toBe('1 of 2 reviewed')
+  })
+
+  it('announces the revising count in the live region (golden)', () => {
+    render()
+    act(() => source().emitQueue([entry('a', 'done'), entry('b', 'iterating'), entry('c')]))
+    const live = container.querySelector('[aria-live="polite"]')
+    expect(live?.textContent).toBe(
+      '1 of 3 plans reviewed, 1 awaiting revision. Now reviewing Plan c',
+    )
+  })
+})
+
+describe('QueueShell iterating rows', () => {
+  it("labels an iterating row 'awaiting revision' (golden)", () => {
+    render()
+    act(() => source().emitQueue([entry('a', 'iterating'), entry('b')]))
+    const row = container.querySelector('.vp-queue__row')
+    expect(row?.getAttribute('aria-label')).toBe('Plan a, dir-a, awaiting revision')
+  })
+
+  it('marks the iterating row with its status for the spinner styling (golden)', () => {
+    render()
+    act(() => source().emitQueue([entry('a', 'iterating'), entry('b')]))
+    expect(container.querySelector('.vp-queue__row')?.getAttribute('data-status')).toBe('iterating')
+  })
+})
+
+describe('QueueShell relative timestamps', () => {
+  it('shows a muted relative time on a row carrying updatedAt, also in its name (golden)', () => {
+    // Computed before render: the shell's clock starts at mount, so a timestamp taken after it
+    // would land fractionally under the 5m bucket and flake to '4m ago'.
+    const updatedAt = Date.now() - 5 * 60_000
+    render()
+    act(() => source().emitQueue([entry('a', 'pending', { updatedAt })]))
+    const row = container.querySelector('.vp-queue__row')
+    expect(row?.querySelector('.vp-queue__time')?.textContent).toBe('5m ago')
+    expect(row?.getAttribute('aria-label')).toContain('5m ago')
+  })
+
+  it('omits the timestamp when an older daemon sends no updatedAt (edge)', () => {
+    render()
+    act(() => source().emitQueue([entry('a')]))
+    expect(container.querySelector('.vp-queue__time')).toBeNull()
+  })
+
+  it('advances timestamps as time passes without new frames (golden)', () => {
+    vi.useFakeTimers()
+    try {
+      render()
+      act(() => source().emitQueue([entry('a', 'pending', { updatedAt: Date.now() })]))
+      expect(container.querySelector('.vp-queue__time')?.textContent).toBe('just now')
+      act(() => vi.advanceTimersByTime(90_000))
+      expect(container.querySelector('.vp-queue__time')?.textContent).toBe('1m ago')
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+})
+
+// The sidebar is the session's history rail, so it renders even for a lone plan: a solo review
+// still shows its row, status, and progress instead of masquerading as a plain single render.
+describe('QueueShell always-on sidebar', () => {
+  it('renders the sidebar for a single-entry queue (golden)', () => {
+    render()
+    act(() => source().emitQueue([entry('a')]))
+    expect(sidebar()).not.toBeNull()
+    expect(iframeSrc()).toContain('/plan/a')
+  })
+
+  it('keeps the sidebar when the queue drops back to a single plan (edge)', () => {
     render()
     act(() => source().emitQueue([entry('a'), entry('b')]))
     expect(sidebar()).not.toBeNull()
-    // A caller abandoning its plan removes it; back to one plan means back to no chrome.
     act(() => source().emitQueue([entry('a')]))
-    expect(sidebar()).toBeNull()
+    expect(sidebar()).not.toBeNull()
   })
 })
 

--- a/packages/runtime/tests/review-comments.test.tsx
+++ b/packages/runtime/tests/review-comments.test.tsx
@@ -1,0 +1,230 @@
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { ReviewLayer } from '../components/review/ReviewLayer.js'
+
+type ReviewGlobal = {
+  __VP_REVIEW__?: boolean
+  __VP_REVIEW_PLAN_ID__?: string
+}
+
+// The section hover flows through a plain document `pointermove` listener, so its state updates
+// need a real act environment to flush (React events happen to flush without it; these do not).
+;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+
+let main: HTMLDivElement
+let overlayHost: HTMLDivElement
+let root: Root
+let fetchMock: ReturnType<typeof vi.fn>
+
+/** jsdom does no layout, so stub the box an element reports for the section band math. */
+function stubRect(el: Element, top: number, bottom: number): void {
+  el.getBoundingClientRect = () =>
+    ({
+      top,
+      bottom,
+      left: 20,
+      right: 400,
+      width: 380,
+      height: bottom - top,
+      x: 20,
+      y: top,
+    }) as DOMRect
+}
+
+beforeEach(() => {
+  ;(globalThis as ReviewGlobal).__VP_REVIEW__ = true
+  ;(globalThis as ReviewGlobal).__VP_REVIEW_PLAN_ID__ = 'plan-7'
+  // The plan column: `createRoot(...).render` wipes its container, so the review chrome mounts in
+  // its own host beside the plan (all its UI is fixed-position anyway).
+  main = document.createElement('div')
+  main.className = 'vp-main'
+  main.innerHTML = '<h2>Design</h2>'
+  document.body.appendChild(main)
+  stubRect(main, 0, 200)
+  const heading = main.querySelector('h2')
+  if (heading) stubRect(heading, 10, 30)
+  overlayHost = document.createElement('div')
+  document.body.appendChild(overlayHost)
+  fetchMock = vi.fn().mockResolvedValue({ ok: true })
+  vi.stubGlobal('fetch', fetchMock)
+})
+
+afterEach(() => {
+  act(() => root?.unmount())
+  main.remove()
+  overlayHost.remove()
+  ;(globalThis as ReviewGlobal).__VP_REVIEW__ = undefined
+  ;(globalThis as ReviewGlobal).__VP_REVIEW_PLAN_ID__ = undefined
+  vi.restoreAllMocks()
+})
+
+function mount(): void {
+  root = createRoot(overlayHost)
+  act(() => root.render(<ReviewLayer />))
+}
+
+/** Find a rendered button by its visible label or aria-label. */
+function findButton(label: string): HTMLButtonElement {
+  const button = Array.from(document.querySelectorAll('button')).find(
+    b => b.textContent?.trim() === label || b.getAttribute('aria-label') === label,
+  )
+  if (!button) throw new Error(`${label} button not found`)
+  return button as HTMLButtonElement
+}
+
+/** Open the comment composer on the stubbed "Design" section via the hover add button. */
+function openComposer(): void {
+  act(() => {
+    document.dispatchEvent(new MouseEvent('pointermove', { clientY: 50 }))
+  })
+  act(() => {
+    findButton('Comment on "Design"').click()
+  })
+}
+
+/** Type into the composer textarea through React's controlled-input machinery. */
+function typeComment(text: string): void {
+  const textarea = document.querySelector<HTMLTextAreaElement>('.vp-review-composer__input')
+  if (!textarea) throw new Error('composer textarea not found')
+  const setter = Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype, 'value')?.set
+  act(() => {
+    setter?.call(textarea, text)
+    textarea.dispatchEvent(new Event('input', { bubbles: true }))
+  })
+}
+
+/** Add one section comment on "Design" through the composer. */
+function addComment(text: string): void {
+  openComposer()
+  typeComment(text)
+  act(() => {
+    findButton('Add comment').click()
+  })
+}
+
+async function clickDecision(label: string): Promise<void> {
+  await act(async () => {
+    findButton(label).click()
+  })
+}
+
+/** The JSON body of the POST to /__vp_feedback. */
+function feedbackBody(): { comments: Array<Record<string, unknown>> } {
+  const call = fetchMock.mock.calls.find(c => String(c[0]) === '/__vp_feedback')
+  if (!call) throw new Error('no feedback POST was made')
+  return JSON.parse((call[1] as RequestInit).body as string)
+}
+
+describe('read-only comment marks after a decision', () => {
+  it('keeps the section comment badge visible and read-only after approving (golden)', async () => {
+    mount()
+    addComment('tighten this section')
+    expect(document.querySelector('.vp-review-badge')).not.toBeNull()
+    await clickDecision('Approve')
+    // The mark survives the decision so the reviewer can still see what they flagged.
+    const badge = document.querySelector<HTMLButtonElement>('.vp-review-badge')
+    expect(badge).not.toBeNull()
+    // Its popover still opens, but without the delete affordance.
+    act(() => badge?.click())
+    expect(document.querySelector('.vp-review-popover')).not.toBeNull()
+    expect(document.querySelector('.vp-review-popover__delete')).toBeNull()
+    // The live review controls are gone; only the submitted notice remains.
+    expect(document.querySelector('.vp-review-bar')).toBeNull()
+    expect(document.querySelector('.vp-review-composer')).toBeNull()
+    expect(document.body.textContent).toContain('Approved')
+  })
+
+  it('closes an open composer when the decision lands (edge)', async () => {
+    mount()
+    addComment('tighten this section')
+    openComposer()
+    expect(document.querySelector('.vp-review-composer')).not.toBeNull()
+    await clickDecision('Approve')
+    expect(document.querySelector('.vp-review-composer')).toBeNull()
+  })
+
+  it('still shows the delete affordance before any decision (error guard)', () => {
+    mount()
+    addComment('tighten this section')
+    act(() => findButton('1 comment on "Design"').click())
+    expect(document.querySelector('.vp-review-popover__delete')).not.toBeNull()
+  })
+
+  it('keeps a selection quote mark rendered after the decision (golden)', async () => {
+    // jsdom Ranges report no boxes; stub them so the selection button and quote mark can position.
+    const rect = { top: 40, bottom: 55, left: 30, right: 90, width: 60, height: 15, x: 30, y: 40 }
+    Range.prototype.getBoundingClientRect = () => rect as DOMRect
+    Range.prototype.getClientRects = () => [rect] as unknown as DOMRectList
+    mount()
+    const textNode = main.querySelector('h2')?.firstChild
+    if (!textNode) throw new Error('heading text missing')
+    const range = document.createRange()
+    range.setStart(textNode, 0)
+    range.setEnd(textNode, 6)
+    const selection = window.getSelection()
+    selection?.removeAllRanges()
+    selection?.addRange(range)
+    act(() => {
+      document.dispatchEvent(new MouseEvent('mouseup'))
+    })
+    act(() => findButton('Comment').click())
+    typeComment('rename this')
+    act(() => findButton('Add comment').click())
+    expect(document.querySelector('.vp-review-quote-mark')).not.toBeNull()
+    await clickDecision('Approve')
+    expect(document.querySelector('.vp-review-quote-mark')).not.toBeNull()
+  })
+})
+
+describe('comment severity', () => {
+  it('sends severity must-fix when Must fix is selected in the composer (golden)', async () => {
+    mount()
+    openComposer()
+    typeComment('this must change')
+    const mustFix = findButton('Must fix')
+    act(() => mustFix.click())
+    expect(mustFix.getAttribute('aria-pressed')).toBe('true')
+    act(() => findButton('Add comment').click())
+    await clickDecision('Approve')
+    expect(feedbackBody().comments[0]).toEqual({
+      section: 'Design',
+      body: 'this must change',
+      severity: 'must-fix',
+    })
+  })
+
+  it('sends an untagged comment without a severity key (edge)', async () => {
+    mount()
+    addComment('just a thought')
+    await clickDecision('Approve')
+    const comment = feedbackBody().comments[0]
+    expect(comment).toBeDefined()
+    expect(comment && 'severity' in comment).toBe(false)
+  })
+
+  it('deselects back to untagged when the chosen option is clicked again (edge)', async () => {
+    mount()
+    openComposer()
+    typeComment('changed my mind on the tag')
+    const suggestion = findButton('Suggestion')
+    act(() => suggestion.click())
+    act(() => suggestion.click())
+    expect(suggestion.getAttribute('aria-pressed')).toBe('false')
+    act(() => findButton('Add comment').click())
+    await clickDecision('Approve')
+    const comment = feedbackBody().comments[0]
+    expect(comment && 'severity' in comment).toBe(false)
+  })
+
+  it('shows the severity tag in the comment popover listing (golden)', () => {
+    mount()
+    openComposer()
+    typeComment('this must change')
+    act(() => findButton('Must fix').click())
+    act(() => findButton('Add comment').click())
+    act(() => findButton('1 comment on "Design"').click())
+    const tag = document.querySelector('.vp-review-tag')
+    expect(tag?.textContent).toBe('must fix')
+  })
+})

--- a/packages/runtime/theme.css
+++ b/packages/runtime/theme.css
@@ -718,6 +718,46 @@ body {
   box-shadow: 0 0 0 2px var(--vp-question-glow);
 }
 
+/* Multiple-choice options under a question. Outside a live review they read as a plain sub-list;
+   in one, each option is a radio row above the "Other" free-text field. */
+.vp-questions__options {
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+}
+
+/* The static form (a <ul>) keeps a native marker so the choices still read as a sub-list. */
+ul.vp-questions__options {
+  list-style: circle;
+  padding-left: 1.15rem;
+}
+
+.vp-questions__option {
+  font-size: 0.9rem;
+  color: var(--vp-text);
+}
+
+/* The selectable form: one radio row per option, keyed to the question blue like the answer field. */
+label.vp-questions__option {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  cursor: pointer;
+}
+
+.vp-questions__option input[type="radio"] {
+  margin: 0;
+  accent-color: var(--vp-question);
+  cursor: inherit;
+}
+
+.vp-questions__option input[type="radio"]:focus-visible {
+  outline: 2px solid var(--vp-question);
+  outline-offset: 2px;
+}
+
 /* Compare */
 .vp-compare {
   display: grid;

--- a/skills/visual-plan/SKILL.md
+++ b/skills/visual-plan/SKILL.md
@@ -38,15 +38,20 @@ and tables, with prose only connecting the visuals, not carrying the plan itself
 3. **Present the plan with `vplan <file>.mdx`. An interactive review is the default way to deliver a
    plan, not a special mode reserved for sign-off.** It opens the plan with a feedback layer where the
    user comments on whole sections or on selected text, **answers any `<Questions>` directly** (each
-   question becomes an inline answer field, printed back as `Answer to "<question>":`), then clicks
+   question becomes an inline answer field; a question with nested option bullets becomes clickable
+   choices, and the picked option's text (or the typed "Other" text) is the answer, printed back as
+   `Answer to "<question>":`), then clicks
    Approve / Deny / Iterate. It **blocks** until they submit, prints the decision, comments, and
    answers to stdout, and exits: approve 0, deny 1, iterate 2, timeout 3 (`--timeout`, default 15m;
    closing the tab counts as deny). It is a long-running foreground server, so run it in the
    background. (The explicit `--review` flag still works but is redundant now that review is the
-   default.) Then act on the printed feedback:
+   default.) A comment may carry a severity tag: treat a `[must-fix]` comment as blocking (it must
+   be addressed before the plan can be approved) and a `[suggestion]` or untagged comment as
+   non-blocking input. Then act on the printed feedback:
    - **Approve** -> proceed with the plan as written.
-   - **Iterate** -> revise the plan addressing each comment, then review again with `-i N`
-     (`--iteration N`) incremented so the bar shows the round; repeat until Approve or Deny. **Edit
+   - **Iterate** -> revise the plan addressing each comment, then simply re-run `vplan <file>.mdx`;
+     the review tab updates the same plan in place and the round number increments automatically
+     (pass `-i N` only to override it). Repeat until Approve or Deny. **Edit
      the same `.mdx` file in place** and re-render: `vplan` snapshots each plan it presents (keyed by
      the file path), so the next render automatically marks what changed since the last view with a
      subtle git-gutter accent and a "N changed" summary, letting the user re-review only the delta.
@@ -155,10 +160,16 @@ brace errors that break a render.
   Use this instead of burying uncertainties in prose. The title defaults to "Open questions";
   override with `title="..."`. In a `--review` session each question is directly answerable, so
   prefer a `<Questions>` block over prose when you want the reviewer to answer specific questions.
+  Nest bullets under a question to offer **multiple-choice options**: in a review they become
+  clickable choices (plus an "Other" free-text field), and the chosen option's text comes back as
+  the answer. Offer options whenever you can enumerate the likely answers; they get you a crisp,
+  actionable answer instead of prose. A question with no nested bullets stays free-text.
 
   ```mdx
   <Questions>
   - Should the limiter fail open or fail closed if Redis is unreachable?
+    - Fail open, availability first
+    - Fail closed, safety first
   - Is a 15-minute access-token TTL acceptable?
   </Questions>
   ```


### PR DESCRIPTION
## What

Reworks the Review Queue's iterate cycle so a plan no longer vanishes and reappears between rounds: a re-review updates the same queue entry in place, the tab shows an explicit "waiting for the revised plan" state, and the sidebar is now always visible with the session's history. Also hardens tab open/close detection so a suspended tab or laptop sleep no longer denies pending reviews and kills the daemon, and sharpens the agent loop with auto-incremented iterations, must-fix/suggestion comment severity, and multiple-choice Questions.

## How

- Same-key enqueues mutate the existing entry (stable id, `rev` counter, waiter rebind, iteration auto-increment) instead of delete-and-recreate; an iterate settles to a new `iterating` status that holds the idle TTL until the revision arrives.
- Tab liveness is two-tier: SSE heartbeats surface dead sockets, a `pagehide` beacon marks real unloads (5s grace), and a silent drop gets the idle timeout instead of the old 1.5s, since it is likely suspension. A `beforeunload` confirm guards closing with pending plans.
- Shell selection is prev-aware (`nextActiveId(prev, next, activeId)`), so an iterate keeps the plan on screen and background revisions raise unseen dots instead of stealing focus.
- All protocol changes are additive to the frozen daemon contract; the `--no-daemon` one-shot path is untouched. Nested bullets under a `Questions` item become clickable options whose text returns as the answer.

## Verification

- `pnpm test`: 620 passed, 2 pre-existing env-gated skips. `pnpm typecheck`, `pnpm build`, `pnpm lint`, `pnpm format` all clean (8 biome warnings pre-exist on main).
- Live browser walkthrough against the built CLI (playwright + system Chrome), 11/11 assertions: iterate round-trip with `[must-fix]` comment and option answer (exit 2), in-place v2 swap with diff cues and zero empty-state flashes, reload survival, deny-on-close in ~5.5s via the beacon path, SIGTERM lockfile cleanup.
- A second, human-driven session exercised iterate, timeout retry, explicit deny, option answers, and approve through the real queue tab.

- [x] `pnpm lint` passes
- [x] `pnpm format` reports no changes (`biome format .`)
- [x] `pnpm typecheck` passes
- [x] `pnpm build` succeeds
- [x] `pnpm test` passes

## Notes

Descoped by decision: comment-mark restore after an iframe remount while iterating (documented limitation), persisted history across daemon restarts, prior-iteration archives. Suggested follow-up: a skip-gated e2e test driving the full iterate round-trip through a real spawned daemon.